### PR TITLE
fix: ignore generated automation report artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,8 @@ public/basic-interpreter-worker.js
 build-number.json
 .vite/
 .playwright-mcp/
+
+# Generated automation reports
+docs/automation/**
+!docs/automation/
+!docs/automation/README.md

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -1,0 +1,7 @@
+# Automation Artifacts Policy
+
+This directory is reserved for automation outputs (for example issue-discovery reports).
+
+- Generated run artifacts under `docs/automation/**` are ignored by Git.
+- This README is intentionally tracked to document the policy.
+- Do not commit machine-generated run snapshots unless the policy is revised.


### PR DESCRIPTION
## Summary
- ignore generated run artifacts under docs/automation/**
- keep docs/automation/README.md tracked to document policy
- closes #18

## Verification
- reproduced before fix: creating docs/automation/issue-discovery/latest.json showed ?? docs/automation/
- after fix: git check-ignore -v docs/automation/issue-discovery/latest.json matches .gitignore
- after fix: git check-ignore -v docs/automation/README.md shows explicit unignore rule
