### PR TITLE
fix: align PAUSE timing units to intended quarter-frame model

### DIFF
--- a/src/core/execution/executors/PauseExecutor.ts
+++ b/src/core/execution/executors/PauseExecutor.ts
@@ -2,21 +2,8 @@
  * Pause Statement Executor
  *
  * Handles execution of PAUSE statements to delay program execution.
- *
- * ## Why our PAUSE was ~2× real F-BASIC (analysis)
- *
- * 1. **Two time bases**: We use TIMING.FRAME_RATE = 30 (33.33ms per frame). DEF MOVE
- *    uses 60/C dots per second (manual), so movement is tied to a 60Hz-like base.
- *
- * 2. **Original formula**: We used (frames × FRAME_DURATION_MS) / 2 ≈ 16.67ms per
- *    PAUSE unit (60Hz). That assumed real PAUSE used the same 60Hz tick.
- *
- * 3. **Empirical result**: Our pause was ~2× longer than real hardware, so real
- *    PAUSE uses a shorter unit: ~8.33ms (120Hz-equivalent). Real F-BASIC likely
- *    drives PAUSE from a ~120Hz time base (e.g. CPU/scanline-derived), not 60Hz.
- *
- * 4. **Fix**: Use divisor 4 so 1 PAUSE unit ≈ 8.33ms (quarter of our 30 FPS frame),
- *    matching observed real F-BASIC timing.
+ * F-BASIC PAUSE timing maps to roughly 8.33ms per PAUSE unit in this runtime,
+ * i.e. one quarter of the nominal 30fps frame duration.
  */
 
 import type { CstNode } from 'chevrotain'
@@ -33,9 +20,8 @@ export class PauseExecutor {
   ) {}
 
   /**
-   * Execute a PAUSE statement from CST
-   * Pauses execution for the specified number of frames.
-   * Real F-BASIC PAUSE is ~quarter of our nominal frame duration (~8.33ms per frame).
+   * Execute a PAUSE statement from CST.
+   * Pauses execution for the specified number of PAUSE units.
    */
   async execute(pauseStmtCst: CstNode): Promise<void> {
     const expressionCst = getFirstCstNode(pauseStmtCst.children.expression)
@@ -49,24 +35,22 @@ export class PauseExecutor {
       return
     }
 
-    // Evaluate the pause duration (in frames)
+    // Evaluate the pause duration (in PAUSE units)
     const durationValue = this.evaluator.evaluateExpression(expressionCst)
-    // Convert to number (handles both numeric and string values)
-    const frames =
+    const pauseUnits =
       typeof durationValue === 'number'
         ? Math.max(0, Math.floor(durationValue))
         : Math.max(0, Math.floor(parseFloat(String(durationValue)) || 0))
 
-    // Convert frames to milliseconds; 1 PAUSE frame = 1 nominal frame (33.33ms at 30 FPS)
-    const durationMs = frames * TIMING.FRAME_DURATION_MS
+    // 1 PAUSE unit ~= quarter frame (~8.33ms when FRAME_DURATION_MS is 33.33ms)
+    const durationMs = (pauseUnits * TIMING.FRAME_DURATION_MS) / 4
 
     if (durationMs > 0) {
       await new Promise(resolve => setTimeout(resolve, durationMs))
     }
 
-    // Add debug output
     if (this.context.config.enableDebugMode) {
-      this.context.addDebugOutput(`PAUSE: ${frames} frames (${Math.round(durationMs)}ms)`)
+      this.context.addDebugOutput(`PAUSE: ${pauseUnits} units (${Math.round(durationMs)}ms)`)
     }
   }
 }

--- a/src/core/parser/FBasicChevrotainParser.ts
+++ b/src/core/parser/FBasicChevrotainParser.ts
@@ -576,7 +576,7 @@ class FBasicChevrotainParser extends CstParser {
     })
 
     // PAUSE Expression
-    // Pauses program execution for the specified number of frames (1 frame = ~1/30 second)
+    // Pauses program execution for the specified number of PAUSE units (~8.33ms per unit)
     this.pauseStatement = this.RULE('pauseStatement', () => {
       this.CONSUME(Pause)
       this.SUBRULE(this.expression)

--- a/test/executors/PauseExecutor.test.ts
+++ b/test/executors/PauseExecutor.test.ts
@@ -1,0 +1,38 @@
+import type { CstNode } from 'chevrotain'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { TIMING } from '@/core/constants'
+import { PauseExecutor } from '@/core/execution/executors/PauseExecutor'
+
+describe('PauseExecutor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('converts PAUSE units to quarter-frame milliseconds', async () => {
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((handler: TimerHandler, _timeout?: number): ReturnType<typeof setTimeout> => {
+        if (typeof handler === 'function') {
+          handler()
+        }
+        return 0 as ReturnType<typeof setTimeout>
+      })
+
+    const mockContext = {
+      addError: vi.fn(),
+      addDebugOutput: vi.fn(),
+      config: { enableDebugMode: false },
+    }
+    const mockEvaluator = {
+      evaluateExpression: vi.fn().mockReturnValue(4),
+    }
+
+    const executor = new PauseExecutor(mockContext as never, mockEvaluator as never)
+    await executor.execute({ children: { expression: [{ children: {} } as CstNode] } } as CstNode)
+
+    const expectedMs = (4 * TIMING.FRAME_DURATION_MS) / 4
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1)
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expectedMs)
+  })
+})

--- a/test/parser/PauseStatement.test.ts
+++ b/test/parser/PauseStatement.test.ts
@@ -51,52 +51,52 @@ describe('PAUSE Statement', () => {
   describe('Execution Tests', () => {
     it('should pause for specified duration', async () => {
       const startTime = Date.now()
-      const code = '10 PAUSE 3' // 3 frames = ~100ms
+      const code = '10 PAUSE 3' // 3 units = ~25ms
       const result = await interpreter.execute(code)
       const endTime = Date.now()
 
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      // Should have paused for approximately 3 frames = ~100ms (allow some tolerance)
-      expect(endTime - startTime).toBeGreaterThanOrEqual(90)
-      expect(endTime - startTime).toBeLessThan(200)
+      // Should have paused for approximately 3 units = ~25ms (allow tolerance)
+      expect(endTime - startTime).toBeGreaterThanOrEqual(15)
+      expect(endTime - startTime).toBeLessThan(120)
     })
 
     it('should pause with numeric literal', async () => {
       const startTime = Date.now()
-      const code = '10 PAUSE 2' // 2 frames = ~67ms
+      const code = '10 PAUSE 2' // 2 units = ~17ms
       const result = await interpreter.execute(code)
       const endTime = Date.now()
 
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      // 2 frames = ~67ms, allow some tolerance
-      expect(endTime - startTime).toBeGreaterThanOrEqual(50)
+      // 2 units = ~17ms, allow some tolerance
+      expect(endTime - startTime).toBeGreaterThanOrEqual(10)
     })
 
     it('should pause with expression', async () => {
       const startTime = Date.now()
-      const code = '10 PAUSE 1 + 1' // 2 frames = ~67ms
+      const code = '10 PAUSE 1 + 1' // 2 units = ~17ms
       const result = await interpreter.execute(code)
       const endTime = Date.now()
 
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      // 2 frames = ~67ms, allow some tolerance
-      expect(endTime - startTime).toBeGreaterThanOrEqual(50)
+      // 2 units = ~17ms, allow some tolerance
+      expect(endTime - startTime).toBeGreaterThanOrEqual(10)
     })
 
     it('should pause with variable', async () => {
       const startTime = Date.now()
       const code = `10 LET DURATION = 3
-20 PAUSE DURATION` // 3 frames = ~100ms
+20 PAUSE DURATION` // 3 units = ~25ms
       const result = await interpreter.execute(code)
       const endTime = Date.now()
 
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      // 3 frames = ~100ms, allow some tolerance
-      expect(endTime - startTime).toBeGreaterThanOrEqual(90)
+      // 3 units = ~25ms, allow some tolerance
+      expect(endTime - startTime).toBeGreaterThanOrEqual(15)
     })
 
     it('should handle PAUSE 0 (no delay)', async () => {
@@ -127,53 +127,53 @@ describe('PAUSE Statement', () => {
       const startTime = Date.now()
       const code = `10 PAUSE 1
 20 PAUSE 1
-30 PAUSE 1` // 3 frames total = ~100ms
+30 PAUSE 1` // 3 units total = ~25ms
       const result = await interpreter.execute(code)
       const endTime = Date.now()
 
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      // Should pause for approximately 3 frames = ~100ms total
-      expect(endTime - startTime).toBeGreaterThanOrEqual(90)
+      // Should pause for approximately 3 units = ~25ms total
+      expect(endTime - startTime).toBeGreaterThanOrEqual(15)
     })
 
     it('should work with PAUSE in loops', async () => {
       const startTime = Date.now()
       const code = `10 FOR I = 1 TO 3
 20   PAUSE 1
-30 NEXT` // 3 iterations * 1 frame = 3 frames = ~100ms
+30 NEXT` // 3 iterations * 1 unit = 3 units = ~25ms
       const result = await interpreter.execute(code)
       const endTime = Date.now()
 
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      // Should pause 3 times for 1 frame each = 3 frames = ~100ms
-      expect(endTime - startTime).toBeGreaterThanOrEqual(90)
+      // Should pause 3 times for 1 unit each = 3 units = ~25ms
+      expect(endTime - startTime).toBeGreaterThanOrEqual(15)
     })
 
     it('should work with PAUSE on same line as other statements', async () => {
       const startTime = Date.now()
-      const code = `10 PRINT "Before": PAUSE 2: PRINT "After"` // 2 frames = ~67ms
+      const code = `10 PRINT "Before": PAUSE 2: PRINT "After"` // 2 units = ~17ms
       const result = await interpreter.execute(code)
       const endTime = Date.now()
 
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      // 2 frames = ~67ms, allow some tolerance
-      expect(endTime - startTime).toBeGreaterThanOrEqual(50)
+      // 2 units = ~17ms, allow some tolerance
+      expect(endTime - startTime).toBeGreaterThanOrEqual(10)
     })
 
     it('should handle PAUSE with string expression (converts to number)', async () => {
       const startTime = Date.now()
       const code = `10 LET DURATION$ = "3"
-20 PAUSE DURATION$` // 3 frames = ~100ms
+20 PAUSE DURATION$` // 3 units = ~25ms
       const result = await interpreter.execute(code)
       const endTime = Date.now()
 
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      // String "3" should be converted to number 3 frames = ~100ms
-      expect(endTime - startTime).toBeGreaterThanOrEqual(90)
+      // String "3" should be converted to number 3 units = ~25ms
+      expect(endTime - startTime).toBeGreaterThanOrEqual(15)
     })
 
     it('should reject floating point literals', async () => {


### PR DESCRIPTION
## Summary
- fix PauseExecutor to convert PAUSE units using quarter-frame timing (FRAME_DURATION_MS / 4)
- update parser PAUSE comment to match runtime behavior (~8.33ms per unit)
- add executor-level regression test that asserts the scheduled timeout value
- update PAUSE timing assertions in parser execution tests to reflect corrected units

## Reproduction
- Added 	est/executors/PauseExecutor.test.ts to verify PAUSE 4 schedules 33.33ms (not 133.33ms)
- This test fails on previous implementation and passes with this patch.

## Validation
- pnpm test:run -- test/executors/PauseExecutor.test.ts test/parser/PauseStatement.test.ts

Closes #25