### PR TITLE
Implement STOP/CONT runtime semantics

### DIFF
--- a/src/core/BasicInterpreter.ts
+++ b/src/core/BasicInterpreter.ts
@@ -20,7 +20,7 @@ import { ExecutionContext, ExecutionEngine } from './execution'
 import { SoundService } from './execution/sound/SoundService'
 import { expandStatements } from './execution/statement-expander'
 import type { BasicVariable, ExecutionResult, InterpreterConfig } from './interfaces'
-import { getSourceTextFromCst } from './parser/cst-helpers'
+import { getCstNodes, getFirstCstNode, getSourceTextFromCst } from './parser/cst-helpers'
 import { FBasicParser } from './parser/FBasicParser'
 import { SpriteStateManager } from './sprite/SpriteStateManager'
 
@@ -85,6 +85,29 @@ export class BasicInterpreter {
           variables: new Map(),
           executionTime: 0,
         }
+      }
+
+      if (parseResult.cst && this.isContinueOnlyCommand(parseResult.cst)) {
+        if (!this.context || !this.executionEngine || !this.context.isStopPaused) {
+          return {
+            success: false,
+            errors: [
+              {
+                line: 0,
+                message: 'CONT: no paused program to continue',
+                type: ERROR_TYPES.RUNTIME,
+              },
+            ],
+            variables: this.context?.variables ?? new Map(),
+            arrays: this.context?.arrays ?? new Map(),
+            executionTime: 0,
+            spriteStates: this.context?.spriteStateManager?.getAllSpriteStates(),
+            spriteEnabled: this.context?.spriteStateManager?.isSpriteEnabled(),
+          }
+        }
+
+        this.context.isStopPaused = false
+        return await this.executionEngine.continueExecution()
       }
 
       // Create execution context (or reuse existing one if it has device adapter)
@@ -163,6 +186,24 @@ export class BasicInterpreter {
         executionTime: 0,
       }
     }
+  }
+
+  private isContinueOnlyCommand(programCst: CstNode): boolean {
+    const statements = getCstNodes(programCst.children.statement)
+    if (statements.length !== 1) return false
+
+    const statement = statements[0]
+    if (!statement) return false
+
+    const commandList = getFirstCstNode(statement.children.commandList)
+    if (!commandList) return false
+
+    const commands = getCstNodes(commandList.children.command)
+    if (commands.length !== 1) return false
+
+    const command = commands[0]
+    const singleCommand = getFirstCstNode(command?.children.singleCommand)
+    return !!singleCommand?.children.contStatement
   }
 
   /**

--- a/src/core/execution/ExecutionEngine.ts
+++ b/src/core/execution/ExecutionEngine.ts
@@ -60,14 +60,27 @@ export class ExecutionEngine {
    * Execute the BASIC program
    */
   async execute(): Promise<ExecutionResult> {
+    return this.runExecutionLoop(true)
+  }
+
+  /**
+   * Continue execution after STOP pause without resetting statements/data.
+   */
+  async continueExecution(): Promise<ExecutionResult> {
+    return this.runExecutionLoop(false)
+  }
+
+  private async runExecutionLoop(preprocess: boolean): Promise<ExecutionResult> {
     const startTime = Date.now()
 
     try {
-      // Preprocess DATA statements
-      this.dataService.preprocessDataStatements()
+      if (preprocess) {
+        // Preprocess DATA statements
+        this.dataService.preprocessDataStatements()
 
-      // Preprocess statements
-      this.preprocessStatements()
+        // Preprocess statements
+        this.preprocessStatements()
+      }
 
       // Start execution
       this.context.isRunning = true
@@ -122,6 +135,19 @@ export class ExecutionEngine {
 
       // Execution completed
       this.context.isRunning = false
+
+      // STOP pauses execution and preserves state for CONT.
+      if (this.context.isStopPaused) {
+        return {
+          success: this.context.getErrors().length === 0,
+          errors: this.context.getErrors(),
+          variables: this.context.variables,
+          arrays: this.context.arrays,
+          executionTime: Date.now() - startTime,
+          spriteStates: this.context.spriteStateManager?.getAllSpriteStates(),
+          spriteEnabled: this.context.spriteStateManager?.isSpriteEnabled(),
+        }
+      }
 
       // Check for unclosed FOR loops
       if (this.context.loopStack.length > 0) {

--- a/src/core/execution/StatementRouter.ts
+++ b/src/core/execution/StatementRouter.ts
@@ -17,6 +17,7 @@ import { CgsetExecutor } from './executors/CgsetExecutor'
 import { ClearExecutor } from './executors/ClearExecutor'
 import { ClsExecutor } from './executors/ClsExecutor'
 import { ColorExecutor } from './executors/ColorExecutor'
+import { ContExecutor } from './executors/ContExecutor'
 import { CutExecutor } from './executors/CutExecutor'
 import { DataExecutor } from './executors/DataExecutor'
 import { DefMoveExecutor } from './executors/DefMoveExecutor'
@@ -45,6 +46,7 @@ import { RestoreExecutor } from './executors/RestoreExecutor'
 import { ReturnExecutor } from './executors/ReturnExecutor'
 import { SpriteExecutor } from './executors/SpriteExecutor'
 import { SpriteOnOffExecutor } from './executors/SpriteOnOffExecutor'
+import { StopExecutor } from './executors/StopExecutor'
 import { SwapExecutor } from './executors/SwapExecutor'
 import { ViewExecutor } from './executors/ViewExecutor'
 import type { ExpandedStatement } from './statement-expander'
@@ -72,12 +74,14 @@ export class StatementRouter {
   private clearExecutor: ClearExecutor
   private locateExecutor: LocateExecutor
   private colorExecutor: ColorExecutor
+  private contExecutor: ContExecutor
   private cgsetExecutor: CgsetExecutor
   private cgenExecutor: CgenExecutor
   private paletExecutor: PaletExecutor
   private defSpriteExecutor: DefSpriteExecutor
   private spriteExecutor: SpriteExecutor
   private spriteOnOffExecutor: SpriteOnOffExecutor
+  private stopExecutor: StopExecutor
   private defMoveExecutor: DefMoveExecutor
   private moveExecutor: MoveExecutor
   private cutExecutor: CutExecutor
@@ -115,12 +119,14 @@ export class StatementRouter {
     this.clearExecutor = new ClearExecutor(variableService)
     this.locateExecutor = new LocateExecutor(context, evaluator)
     this.colorExecutor = new ColorExecutor(context, evaluator)
+    this.contExecutor = new ContExecutor(context)
     this.cgsetExecutor = new CgsetExecutor(context, evaluator)
     this.cgenExecutor = new CgenExecutor(context, evaluator)
     this.paletExecutor = new PaletExecutor(context, evaluator)
     this.defSpriteExecutor = new DefSpriteExecutor(context, evaluator)
     this.spriteExecutor = new SpriteExecutor(context, evaluator)
     this.spriteOnOffExecutor = new SpriteOnOffExecutor(context)
+    this.stopExecutor = new StopExecutor(context)
     this.defMoveExecutor = new DefMoveExecutor(context, evaluator)
     this.moveExecutor = new MoveExecutor(context, evaluator)
     this.cutExecutor = new CutExecutor(context, evaluator)
@@ -266,6 +272,11 @@ export class StatementRouter {
         this.returnExecutor.execute(returnStmtCst, expandedStatement.lineNumber)
         return
       }
+    } else if (singleCommandCst.children.contStatement) {
+      const contStmtCst = getFirstCstNode(singleCommandCst.children.contStatement)
+      if (contStmtCst) {
+        this.contExecutor.execute(contStmtCst, expandedStatement.lineNumber)
+      }
     } else if (singleCommandCst.children.printStatement) {
       const printStmtCst = getFirstCstNode(singleCommandCst.children.printStatement)
       if (printStmtCst) {
@@ -311,6 +322,12 @@ export class StatementRouter {
         // END stops execution immediately
         this.endExecutor.execute(endStmtCst)
         return // Don't continue executing
+      }
+    } else if (singleCommandCst.children.stopStatement) {
+      const stopStmtCst = getFirstCstNode(singleCommandCst.children.stopStatement)
+      if (stopStmtCst) {
+        this.stopExecutor.execute(stopStmtCst)
+        return // STOP pauses immediately
       }
     } else if (singleCommandCst.children.pauseStatement) {
       const pauseStmtCst = getFirstCstNode(singleCommandCst.children.pauseStatement)

--- a/src/core/execution/executors/ContExecutor.ts
+++ b/src/core/execution/executors/ContExecutor.ts
@@ -1,0 +1,28 @@
+import type { CstNode } from 'chevrotain'
+
+import { ERROR_TYPES } from '@/core/constants'
+import type { ExecutionContext } from '@/core/state/ExecutionContext'
+
+export class ContExecutor {
+  constructor(private context: ExecutionContext) {}
+
+  /**
+   * CONT can only run when execution is paused by STOP.
+   */
+  execute(_contStmtCst: CstNode, lineNumber: number): void {
+    if (!this.context.isStopPaused) {
+      this.context.addError({
+        line: lineNumber,
+        message: 'CONT: no paused program to continue',
+        type: ERROR_TYPES.RUNTIME,
+      })
+      return
+    }
+
+    this.context.isStopPaused = false
+
+    if (this.context.config.enableDebugMode) {
+      this.context.addDebugOutput('CONT: resuming execution')
+    }
+  }
+}

--- a/src/core/execution/executors/StopExecutor.ts
+++ b/src/core/execution/executors/StopExecutor.ts
@@ -1,0 +1,22 @@
+import type { CstNode } from 'chevrotain'
+
+import type { ExecutionContext } from '@/core/state/ExecutionContext'
+
+export class StopExecutor {
+  constructor(private context: ExecutionContext) {}
+
+  /**
+   * Pause execution and preserve state for later CONT.
+   */
+  execute(_stopStmtCst: CstNode): void {
+    // Continue should resume from the next statement after STOP.
+    this.context.nextStatement()
+    this.context.isStopPaused = true
+    this.context.shouldStop = true
+    this.context.isRunning = false
+
+    if (this.context.config.enableDebugMode) {
+      this.context.addDebugOutput('STOP: execution paused')
+    }
+  }
+}

--- a/src/core/parser/FBasicChevrotainParser.ts
+++ b/src/core/parser/FBasicChevrotainParser.ts
@@ -1473,10 +1473,8 @@ const REPL_ONLY_COMMANDS: Record<string, string> = {
   loadStatement: 'LOAD: Not applicable for IDE version - use Import instead',
   keyStatement: 'KEY: Not applicable for IDE version',
   keylistStatement: 'KEYLIST: Not applicable for IDE version',
-  contStatement: 'CONT: Not applicable for IDE version',
   systemStatement: 'SYSTEM: Not applicable for IDE version',
   pokeStatement: 'POKE: Not applicable for IDE version',
-  stopStatement: 'STOP: Not applicable for IDE version',
 }
 
 /**

--- a/src/core/state/ExecutionContext.ts
+++ b/src/core/state/ExecutionContext.ts
@@ -28,6 +28,7 @@ export class ExecutionContext {
   public variables: Map<string, BasicVariable> = new Map()
   public isRunning = false
   public shouldStop = false
+  public isStopPaused = false
   public currentStatementIndex = 0
   public statements: ExpandedStatement[] = [] // Expanded statements (flat list)
   public labelMap: Map<number, number[]> = new Map() // Line number -> statement indices
@@ -65,6 +66,7 @@ export class ExecutionContext {
     this.variables.clear()
     this.isRunning = false
     this.shouldStop = false
+    this.isStopPaused = false
     this.currentStatementIndex = 0
     this.statements = []
     this.labelMap.clear()

--- a/test/integration/StopContIntegration.test.ts
+++ b/test/integration/StopContIntegration.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { BasicInterpreter } from '@/core/BasicInterpreter'
+import { EXECUTION_LIMITS } from '@/core/constants'
+import { TestDeviceAdapter } from '@/core/devices/TestDeviceAdapter'
+
+describe('STOP/CONT Integration', () => {
+  let interpreter: BasicInterpreter
+  let deviceAdapter: TestDeviceAdapter
+
+  beforeEach(() => {
+    deviceAdapter = new TestDeviceAdapter()
+    interpreter = new BasicInterpreter({
+      maxIterations: EXECUTION_LIMITS.MAX_ITERATIONS_PRODUCTION,
+      maxOutputLines: EXECUTION_LIMITS.MAX_OUTPUT_LINES_PRODUCTION,
+      enableDebugMode: false,
+      strictMode: false,
+      suppressOkPrompt: true,
+      deviceAdapter,
+    })
+  })
+
+  it('pauses at STOP and resumes from next statement with CONT', async () => {
+    const source = `
+10 A=1
+20 PRINT "BEFORE"
+30 STOP
+40 A=A+1
+50 PRINT "AFTER ";A
+60 END
+`
+
+    const pauseResult = await interpreter.execute(source)
+    expect(pauseResult.success).toBe(true)
+    expect(pauseResult.errors).toHaveLength(0)
+    expect(deviceAdapter.getAllOutputs()).toContain('BEFORE\n')
+    expect(deviceAdapter.getAllOutputs()).not.toContain('AFTER')
+    expect(interpreter.getVariables().get('A')?.value).toBe(1)
+
+    const resumeResult = await interpreter.execute('10 CONT')
+    expect(resumeResult.success).toBe(true)
+    expect(resumeResult.errors).toHaveLength(0)
+    expect(interpreter.getVariables().get('A')?.value).toBe(2)
+    expect(deviceAdapter.getAllOutputs()).toContain('AFTER  2\n')
+  })
+
+  it('returns an error for CONT without a paused STOP state', async () => {
+    const result = await interpreter.execute('10 CONT')
+
+    expect(result.success).toBe(false)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.message).toBe('CONT: no paused program to continue')
+  })
+})

--- a/test/parser/ReplOnlyCommands.test.ts
+++ b/test/parser/ReplOnlyCommands.test.ts
@@ -13,7 +13,6 @@ describe('REPL-only Commands Parser', () => {
     { command: 'LOAD?', error: 'LOAD: Not applicable for IDE version - use Import instead' },
     { command: 'KEY', error: 'KEY: Not applicable for IDE version' },
     { command: 'KEYLIST', error: 'KEYLIST: Not applicable for IDE version' },
-    { command: 'CONT', error: 'CONT: Not applicable for IDE version' },
     { command: 'SYSTEM', error: 'SYSTEM: Not applicable for IDE version' },
   ]
 
@@ -22,7 +21,6 @@ describe('REPL-only Commands Parser', () => {
     { command: 'POKE &H7000, 255', error: 'POKE: Not applicable for IDE version' },
     { command: 'A = PEEK(&H7000)', error: 'PEEK: Not applicable for IDE version' },
     { command: 'A = FRE(0)', error: 'FRE: Not applicable for IDE version' },
-    { command: 'STOP', error: 'STOP: Not applicable for IDE version' },
   ]
 
   describe.each(replOnlyCommands)('$command', ({ command, error }) => {
@@ -84,6 +82,22 @@ describe('REPL-only Commands Parser', () => {
 
   test('valid commands still parse successfully', () => {
     const result = parseWithChevrotain('10 PRINT "HELLO"')
+
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    expect(result.errors).toBeUndefined()
+  })
+
+  test('CONT should parse successfully as executable command', () => {
+    const result = parseWithChevrotain('10 CONT')
+
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    expect(result.errors).toBeUndefined()
+  })
+
+  test('STOP should parse successfully as executable command', () => {
+    const result = parseWithChevrotain('10 STOP')
 
     expect(result.success).toBe(true)
     expect(result.cst).toBeDefined()


### PR DESCRIPTION
## Summary
- implement STOP runtime pause state and CONT resume flow without resetting program state
- remove STOP/CONT from parser REPL-only rejection list and add statement routing/executors
- add integration coverage for STOP pause + CONT resume and CONT-without-pause error

## Testing
- pnpm test:run -- test/parser/ReplOnlyCommands.test.ts test/integration/StopContIntegration.test.ts
- pnpm test:run -- test/integration/AsyncExecution.test.ts test/parser/PauseStatement.test.ts

Closes #27