### PR TITLE
Fix script entrypoint drift for service-worker/syntax tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
         "test:display-snapshots": "vitest run test/integration/SampleDisplaySnapshot.test.ts",
         "test:animation-integration": "vitest run test/integration/AnimationWorkerRuntimeIntegration.test.ts test/integration/AnimationSyncProtocol.test.ts test/integration/ClearAllMovements.test.ts test/integration/sprite-movement-lifecycle.test.ts test/integration/sprite-position-sync.test.ts",
         "test:coverage": "vitest run --coverage",
-        "build-web-worker": "tsx scripts/build-service-worker.ts",
+        "build-web-worker": "tsx scripts/dev/build-service-worker.ts",
         "build-service-worker": "pnpm build-web-worker",
-        "test-service-worker": "tsx scripts/test-service-worker.ts",
-        "visualize-cst": "tsx scripts/visualize-cst.ts",
-        "check-syntax": "tsx scripts/check-syntax.ts"
+        "test-service-worker": "tsx scripts/dev/test-service-worker.ts",
+        "visualize-cst": "tsx scripts/dev/visualize-cst.ts",
+        "check-syntax": "tsx scripts/validation/check-syntax.ts",
+        "verify:script-entrypoints": "tsx scripts/validation/verify-script-entrypoints.ts"
     },
     "dependencies": {
         "@fontsource/exo-2": "^5.1.0",

--- a/scripts/dev/build-service-worker.ts
+++ b/scripts/dev/build-service-worker.ts
@@ -1,0 +1,21 @@
+import { access } from 'node:fs/promises'
+import path from 'node:path'
+
+async function main(): Promise<void> {
+  const workerEntry = path.resolve(process.cwd(), 'src/core/workers/WebWorkerInterpreter.ts')
+
+  try {
+    await access(workerEntry)
+  } catch {
+    console.error(`[build-service-worker] Worker entrypoint not found: ${workerEntry}`)
+    process.exit(1)
+  }
+
+  console.log(`[build-service-worker] Worker entrypoint found: ${workerEntry}`)
+  console.log('[build-service-worker] Standalone worker build is not required; Vite bundles ?worker imports during app build.')
+}
+
+main().catch((error) => {
+  console.error('[build-service-worker] Unexpected error:', error)
+  process.exit(1)
+})

--- a/scripts/dev/test-service-worker.ts
+++ b/scripts/dev/test-service-worker.ts
@@ -1,0 +1,30 @@
+import { access, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+async function main(): Promise<void> {
+  const workerEntry = path.resolve(process.cwd(), 'src/core/workers/WebWorkerInterpreter.ts')
+  const managerFile = path.resolve(process.cwd(), 'src/core/devices/WebWorkerManager.ts')
+
+  try {
+    await access(workerEntry)
+    await access(managerFile)
+  } catch (error) {
+    console.error('[test-service-worker] Required files are missing:', error)
+    process.exit(1)
+  }
+
+  const managerSource = await readFile(managerFile, 'utf8')
+  const hasWorkerImport = managerSource.includes('WebWorkerInterpreter.ts?worker')
+
+  if (!hasWorkerImport) {
+    console.error('[test-service-worker] WebWorkerManager does not reference WebWorkerInterpreter.ts?worker as expected.')
+    process.exit(1)
+  }
+
+  console.log('[test-service-worker] Worker wiring looks valid.')
+}
+
+main().catch((error) => {
+  console.error('[test-service-worker] Unexpected error:', error)
+  process.exit(1)
+})

--- a/scripts/validation/check-syntax.ts
+++ b/scripts/validation/check-syntax.ts
@@ -1,0 +1,26 @@
+import { FBasicParser } from '../../src/core/parser/FBasicParser'
+
+async function main(): Promise<void> {
+  const parser = new FBasicParser()
+  const smokeProgram = ['10 A=1', '20 IF A=1 THEN PRINT "OK"', '30 END'].join('\n')
+  const result = await parser.parse(smokeProgram)
+
+  if (!result.success) {
+    console.error('[check-syntax] Parser smoke check failed.')
+    if (result.errors?.length) {
+      for (const error of result.errors) {
+        const line = error.location?.start?.line ?? '?'
+        const column = error.location?.start?.column ?? '?'
+        console.error(`- line ${line}, col ${column}: ${error.message}`)
+      }
+    }
+    process.exit(1)
+  }
+
+  console.log('[check-syntax] Parser smoke check passed.')
+}
+
+main().catch((error) => {
+  console.error('[check-syntax] Unexpected error:', error)
+  process.exit(1)
+})

--- a/scripts/validation/verify-script-entrypoints.ts
+++ b/scripts/validation/verify-script-entrypoints.ts
@@ -1,0 +1,53 @@
+import { access, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+interface PackageJson {
+  scripts?: Record<string, string>
+}
+
+const scriptsToValidate = [
+  'build-web-worker',
+  'build-service-worker',
+  'test-service-worker',
+  'check-syntax',
+  'visualize-cst',
+] as const
+
+function resolveTsxEntrypoint(command: string): string | null {
+  const match = command.match(/(?:^|\s)tsx\s+([^\s]+)/)
+  return match?.[1] ?? null
+}
+
+async function main(): Promise<void> {
+  const packageJsonPath = path.resolve(process.cwd(), 'package.json')
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as PackageJson
+  const scripts = packageJson.scripts ?? {}
+
+  for (const scriptName of scriptsToValidate) {
+    const scriptCommand = scripts[scriptName]
+    if (!scriptCommand) {
+      console.error(`[verify-script-entrypoints] Missing script: ${scriptName}`)
+      process.exit(1)
+    }
+
+    const entrypoint = resolveTsxEntrypoint(scriptCommand)
+    if (!entrypoint) {
+      continue
+    }
+
+    const resolvedEntrypoint = path.resolve(process.cwd(), entrypoint)
+    try {
+      await access(resolvedEntrypoint)
+    } catch {
+      console.error(`[verify-script-entrypoints] Entrypoint not found for "${scriptName}": ${entrypoint}`)
+      process.exit(1)
+    }
+  }
+
+  console.log('[verify-script-entrypoints] Script entrypoints verified.')
+}
+
+main().catch((error) => {
+  console.error('[verify-script-entrypoints] Unexpected error:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- fix broken `package.json` script paths to existing TS entrypoints
- add minimal `build-service-worker` and `test-service-worker` scripts under `scripts/dev/`
- add `scripts/validation/check-syntax.ts` smoke check entrypoint
- add `verify:script-entrypoints` automation guard for script path drift

## Repro
Before this change, these all failed with `ERR_MODULE_NOT_FOUND` due to missing `scripts/*.ts` files:
- `pnpm -s build-service-worker`
- `pnpm -s test-service-worker`
- `pnpm -s check-syntax`
- `pnpm -s visualize-cst`

## Verification
- `pnpm -s build-service-worker`
- `pnpm -s test-service-worker`
- `pnpm -s check-syntax`
- `pnpm -s visualize-cst "10 PRINT X"`
- `pnpm -s verify:script-entrypoints`

Closes #30