### PR TITLE
Add script entrypoint integrity guard and fix broken tooling scripts

### DIFF
--- a/scripts/validation/script-entrypoint-integrity.ts
+++ b/scripts/validation/script-entrypoint-integrity.ts
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+export interface ScriptEntrypointReference {
+  scriptName: string
+  command: string
+  entrypoint: string
+}
+
+export interface MissingScriptEntrypoint {
+  scriptName: string
+  command: string
+  entrypoint: string
+  resolvedPath: string
+}
+
+const ENTRYPOINT_PATTERN = /(?:^|[;&|]\s*|\s)(?:pnpm\s+exec\s+)?(?:tsx|node)\s+((?:"[^"]+"|'[^']+'|[^\s;&|]+))/g
+const SCRIPT_FILE_PATTERN = /\.(?:[cm]?[jt]s)$/i
+
+function stripQuotes(value: string): string {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+export function collectScriptEntrypoints(
+  scripts: Record<string, string>
+): ScriptEntrypointReference[] {
+  const entrypoints: ScriptEntrypointReference[] = []
+  const seen = new Set<string>()
+
+  for (const [scriptName, command] of Object.entries(scripts)) {
+    for (const match of command.matchAll(ENTRYPOINT_PATTERN)) {
+      const candidate = stripQuotes(match[1] ?? '')
+      if (!SCRIPT_FILE_PATTERN.test(candidate)) {
+        continue
+      }
+
+      const key = `${scriptName}|${candidate}`
+      if (seen.has(key)) {
+        continue
+      }
+      seen.add(key)
+
+      entrypoints.push({
+        scriptName,
+        command,
+        entrypoint: candidate,
+      })
+    }
+  }
+
+  return entrypoints
+}
+
+export function findMissingScriptEntrypoints(
+  scripts: Record<string, string>,
+  rootDir: string
+): MissingScriptEntrypoint[] {
+  return collectScriptEntrypoints(scripts)
+    .map((reference) => ({
+      ...reference,
+      resolvedPath: resolve(rootDir, reference.entrypoint),
+    }))
+    .filter((reference) => !existsSync(reference.resolvedPath))
+}
+
+export function readPackageScripts(packageJsonPath: string): Record<string, string> {
+  const packageRaw = readFileSync(packageJsonPath, 'utf8')
+  const parsed = JSON.parse(packageRaw) as { scripts?: Record<string, string> }
+  return parsed.scripts ?? {}
+}

--- a/scripts/validation/verify-script-entrypoints.ts
+++ b/scripts/validation/verify-script-entrypoints.ts
@@ -1,53 +1,28 @@
-import { access, readFile } from 'node:fs/promises'
-import path from 'node:path'
+import { resolve } from 'node:path'
+import {
+  collectScriptEntrypoints,
+  findMissingScriptEntrypoints,
+  readPackageScripts,
+} from './script-entrypoint-integrity'
 
-interface PackageJson {
-  scripts?: Record<string, string>
+const repoRoot = process.cwd()
+const packageJsonPath = resolve(repoRoot, 'package.json')
+const scripts = readPackageScripts(packageJsonPath)
+const referencedEntrypoints = collectScriptEntrypoints(scripts)
+const missingEntrypoints = findMissingScriptEntrypoints(scripts, repoRoot)
+
+console.log(`Found ${referencedEntrypoints.length} script entrypoint reference(s).`)
+
+if (missingEntrypoints.length === 0) {
+  console.log('All referenced script entrypoints exist.')
+  process.exit(0)
 }
 
-const scriptsToValidate = [
-  'build-web-worker',
-  'build-service-worker',
-  'test-service-worker',
-  'check-syntax',
-  'visualize-cst',
-] as const
-
-function resolveTsxEntrypoint(command: string): string | null {
-  const match = command.match(/(?:^|\s)tsx\s+([^\s]+)/)
-  return match?.[1] ?? null
+console.error(`Missing ${missingEntrypoints.length} script entrypoint(s):`)
+for (const missing of missingEntrypoints) {
+  console.error(`- ${missing.scriptName}: ${missing.entrypoint}`)
+  console.error(`  command: ${missing.command}`)
+  console.error(`  resolved: ${missing.resolvedPath}`)
 }
 
-async function main(): Promise<void> {
-  const packageJsonPath = path.resolve(process.cwd(), 'package.json')
-  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as PackageJson
-  const scripts = packageJson.scripts ?? {}
-
-  for (const scriptName of scriptsToValidate) {
-    const scriptCommand = scripts[scriptName]
-    if (!scriptCommand) {
-      console.error(`[verify-script-entrypoints] Missing script: ${scriptName}`)
-      process.exit(1)
-    }
-
-    const entrypoint = resolveTsxEntrypoint(scriptCommand)
-    if (!entrypoint) {
-      continue
-    }
-
-    const resolvedEntrypoint = path.resolve(process.cwd(), entrypoint)
-    try {
-      await access(resolvedEntrypoint)
-    } catch {
-      console.error(`[verify-script-entrypoints] Entrypoint not found for "${scriptName}": ${entrypoint}`)
-      process.exit(1)
-    }
-  }
-
-  console.log('[verify-script-entrypoints] Script entrypoints verified.')
-}
-
-main().catch((error) => {
-  console.error('[verify-script-entrypoints] Unexpected error:', error)
-  process.exit(1)
-})
+process.exit(1)

--- a/test/validation/ScriptEntrypointIntegrity.test.ts
+++ b/test/validation/ScriptEntrypointIntegrity.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import {
+  collectScriptEntrypoints,
+  findMissingScriptEntrypoints,
+} from '../../scripts/validation/script-entrypoint-integrity'
+
+describe('script entrypoint integrity', () => {
+  it('collects ts/js entrypoints from package scripts', () => {
+    const scripts = {
+      validA: 'tsx scripts/dev/visualize-cst.ts',
+      validB: 'node scripts/tools/check.js --strict',
+      noFile: 'vite build',
+    }
+
+    const entrypoints = collectScriptEntrypoints(scripts)
+
+    expect(entrypoints.map((entry) => entry.entrypoint)).toEqual([
+      'scripts/dev/visualize-cst.ts',
+      'scripts/tools/check.js',
+    ])
+  })
+
+  it('reports missing script targets', () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'script-entrypoint-'))
+    try {
+      const existingDir = join(rootDir, 'scripts', 'dev')
+      mkdirSync(existingDir, { recursive: true })
+      writeFileSync(join(existingDir, 'exists.ts'), 'export {}')
+
+      const scripts = {
+        ok: 'tsx scripts/dev/exists.ts',
+        broken: 'tsx scripts/dev/missing.ts',
+      }
+
+      const missing = findMissingScriptEntrypoints(scripts, rootDir)
+      expect(missing).toHaveLength(1)
+      expect(missing[0]?.scriptName).toBe('broken')
+      expect(missing[0]?.entrypoint).toBe('scripts/dev/missing.ts')
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- fix broken package.json script paths to existing TS entrypoints under scripts/dev and scripts/validation
- add minimal build-service-worker, test-service-worker, and check-syntax entrypoint scripts
- add verify:script-entrypoints guard to fail when script targets are missing
- add regression test covering a broken-path scenario

## Repro (before fix)
These failed with ERR_MODULE_NOT_FOUND on master:
- pnpm -s build-service-worker
- pnpm -s test-service-worker
- pnpm -s check-syntax
- pnpm -s visualize-cst "10 PRINT X"

## Verification
- pnpm -s build-service-worker
- pnpm -s test-service-worker
- pnpm -s check-syntax
- pnpm -s visualize-cst "10 PRINT X"
- pnpm -s verify:script-entrypoints
- pnpm test:run -- test/validation/ScriptEntrypointIntegrity.test.ts

## Blocker
This automation token cannot push .github/workflows/* changes (workflow scope missing), so CI wiring for the new guardrail is not included in this PR.

Closes #31
