### PR TITLE
fix: guard ON expressions against NaN/Infinity

### DIFF
--- a/src/core/execution/executors/OnExecutor.ts
+++ b/src/core/execution/executors/OnExecutor.ts
@@ -56,6 +56,16 @@ export class OnExecutor {
     // Convert to integer (Family BASIC uses integer values)
     // If it's a string, try to convert it
     const numericValue = typeof expressionValue === 'string' ? parseFloat(expressionValue) : Number(expressionValue)
+
+    if (!Number.isFinite(numericValue)) {
+      this.context.addError({
+        line: lineNumber,
+        message: 'ON: expression must evaluate to a number',
+        type: ERROR_TYPES.RUNTIME,
+      })
+      return
+    }
+
     const index = Math.floor(numericValue)
 
     // If index is 0 or negative, or exceeds the number of line numbers, proceed to next line

--- a/test/executors/OnExecutor.test.ts
+++ b/test/executors/OnExecutor.test.ts
@@ -370,6 +370,50 @@ describe('OnExecutor', () => {
   })
 
   describe('Error Handling', () => {
+    it('should return a clear runtime error for non-numeric string expression', async () => {
+      const source = `
+10 LET X$ = "ABC"
+20 ON X$ GOTO 100, 200
+30 PRINT "This should not print"
+40 END
+100 PRINT "First"
+110 END
+200 PRINT "Second"
+210 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+      const errorMessages = result.errors.map(e => e.message).join(' ')
+      expect(errorMessages).toEqual('ON: expression must evaluate to a number')
+
+      const outputs = deviceAdapter.getAllOutputs()
+      expect(outputs).toEqual('RUNTIME: ON: expression must evaluate to a number')
+    })
+
+    it('should return a clear runtime error for Infinity expression values', async () => {
+      const source = `
+10 LET X$ = "Infinity"
+20 ON X$ GOTO 100, 200
+30 PRINT "This should not print"
+40 END
+100 PRINT "First"
+110 END
+200 PRINT "Second"
+210 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+      const errorMessages = result.errors.map(e => e.message).join(' ')
+      expect(errorMessages).toEqual('ON: expression must evaluate to a number')
+
+      const outputs = deviceAdapter.getAllOutputs()
+      expect(outputs).toEqual('RUNTIME: ON: expression must evaluate to a number')
+    })
+
     it('should error on ON to non-existent line number', async () => {
       const source = `
 10 LET X = 1


### PR DESCRIPTION
## Summary
- validate ON expression numeric conversion with `Number.isFinite` before indexing
- return stable runtime error `ON: expression must evaluate to a number` for NaN/Infinity cases
- add regression tests for string (`"ABC"`) and Infinity (`"Infinity"`) ON expressions

## Testing
- pnpm vitest run test/executors/OnExecutor.test.ts
- pnpm vitest run test/parser/OnStatement.test.ts

Closes #38
