### PR TITLE
fix: resolve FZRuiZhengHei build-time asset warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "test-service-worker": "tsx scripts/dev/test-service-worker.ts",
         "visualize-cst": "tsx scripts/dev/visualize-cst.ts",
         "check-syntax": "tsx scripts/validation/check-syntax.ts",
-        "verify:script-entrypoints": "tsx scripts/validation/verify-script-entrypoints.ts"
+        "verify:script-entrypoints": "tsx scripts/validation/verify-script-entrypoints.ts",
+        "verify:build-no-unresolved-assets": "tsx scripts/validation/check-unresolved-assets.ts"
     },
     "dependencies": {
         "@fontsource/exo-2": "^5.1.0",

--- a/scripts/validation/check-unresolved-assets.ts
+++ b/scripts/validation/check-unresolved-assets.ts
@@ -1,0 +1,54 @@
+import { spawn } from 'node:child_process'
+
+const unresolvedAssetPattern = /didn't resolve at build time/i
+
+async function runBuildAndCapture(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child =
+      process.platform === 'win32'
+        ? spawn('cmd.exe', ['/d', '/s', '/c', 'pnpm -s vite build'], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+          })
+        : spawn('pnpm', ['-s', 'vite', 'build'], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+          })
+
+    let combinedOutput = ''
+
+    child.stdout.on('data', (chunk) => {
+      const text = String(chunk)
+      combinedOutput += text
+      process.stdout.write(text)
+    })
+
+    child.stderr.on('data', (chunk) => {
+      const text = String(chunk)
+      combinedOutput += text
+      process.stderr.write(text)
+    })
+
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`vite build failed with exit code ${code ?? 'unknown'}`))
+        return
+      }
+      resolve(combinedOutput)
+    })
+  })
+}
+
+async function main(): Promise<void> {
+  const buildOutput = await runBuildAndCapture()
+  if (unresolvedAssetPattern.test(buildOutput)) {
+    console.error('[check-unresolved-assets] Found unresolved build asset warnings.')
+    process.exit(1)
+  }
+
+  console.log('[check-unresolved-assets] No unresolved build asset warnings found.')
+}
+
+main().catch((error) => {
+  console.error('[check-unresolved-assets] Unexpected error:', error)
+  process.exit(1)
+})

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -164,13 +164,14 @@
 
 /* Multi-language Font Support */
 
-/* FZRuiZhengHei (方正锐正黑) Font Face Declaration */
-
-/* Note: Font files should be placed in public/fonts/ directory */
-
+/*
+  Prefer local-only FZRuiZhengHei sources.
+  This avoids unresolved /fonts/* build warnings when proprietary font files
+  are not bundled in the repository.
+*/
 @font-face {
     font-family: 'FZRuiZhengHei';
-    src: url('/fonts/FZRuiZhengHei.woff2') format('woff2'), url('/fonts/FZRuiZhengHei.woff') format('woff'), url('/fonts/FZRuiZhengHei.ttf') format('truetype');
+    src: local('FZRuiZhengHei'), local('FZ Rui Zheng Hei');
     font-weight: normal;
     font-style: normal;
     font-display: swap;
@@ -178,12 +179,11 @@
 
 @font-face {
     font-family: 'FZRuiZhengHei';
-    src: url('/fonts/FZRuiZhengHei-Bold.woff2') format('woff2'), url('/fonts/FZRuiZhengHei-Bold.woff') format('woff'), url('/fonts/FZRuiZhengHei-Bold.ttf') format('truetype');
+    src: local('FZRuiZhengHei Bold'), local('FZ Rui Zheng Hei Bold');
     font-weight: bold;
     font-style: normal;
     font-display: swap;
 }
-
 
 /* Japanese */
 
@@ -193,7 +193,7 @@
 }
 
 
-/* Simplified Chinese - Using FZRuiZhengHei (方正锐正黑) */
+/* Simplified Chinese - prefer local FZRuiZhengHei, then Noto Sans SC */
 
 :lang(zh-CN) {
     --game-font-family: 'FZRuiZhengHei', 'Noto Sans SC', 'Rajdhani', 'Orbitron', system-ui, sans-serif;
@@ -201,7 +201,7 @@
 }
 
 
-/* Traditional Chinese - Using FZRuiZhengHei (方正锐正黑) */
+/* Traditional Chinese - prefer local FZRuiZhengHei, then Noto Sans TC */
 
 :lang(zh-TW) {
     --game-font-family: 'FZRuiZhengHei', 'Noto Sans TC', 'Rajdhani', 'Orbitron', system-ui, sans-serif;


### PR DESCRIPTION
## Summary
- replace URL-based FZRuiZhengHei @font-face sources with local-only sources to prevent unresolved /fonts/* build warnings when proprietary font files are not present
- keep Chinese locale font stacks intact with FZRuiZhengHei preferred and Noto Sans fallbacks
- add erify:build-no-unresolved-assets script (scripts/validation/check-unresolved-assets.ts) to fail CI/local validation when Vite reports unresolved build-time assets

## Reproduction
Before fix:
- pnpm -s run build
- Vite emitted didn't resolve at build time warnings for /fonts/FZRuiZhengHei*.woff2|woff|ttf

After fix:
- pnpm -s run build completes without unresolved font-asset warnings

## Validation
- pnpm -s run build
- pnpm -s verify:build-no-unresolved-assets
- pnpm -s type-check
- pnpm -s verify:script-entrypoints

Closes #42