### PR TITLE
Fix diagnostics message-rate counting and remove output mutation

### DIFF
--- a/src/features/ide/composables/usePerformanceDiagnosticsMetrics.ts
+++ b/src/features/ide/composables/usePerformanceDiagnosticsMetrics.ts
@@ -195,9 +195,10 @@ export function usePerformanceDiagnosticsMetrics({
   watch(
     () => output.value.length,
     (newLength, oldLength) => {
-      if (measurementActive && newLength > oldLength) {
+      const increment = Math.max(0, newLength - (oldLength ?? 0))
+      if (measurementActive && increment > 0) {
         performance.mark(`message-start-${messageSequence}`)
-        messageCount++
+        messageCount += increment
         setTimeout(() => {
           performance.mark(`message-end-${messageSequence}`)
           try {
@@ -225,11 +226,6 @@ export function usePerformanceDiagnosticsMetrics({
         totalTime.value = Math.round(performance.now() - startTime)
       }
     }, 100)
-    const originalPush = output.value.push.bind(output.value)
-    output.value.push = function (...items: string[]) {
-      messageCount += items.length
-      return originalPush(...items)
-    }
   })
 
   onBeforeUnmount(() => {

--- a/test/ide/usePerformanceDiagnosticsMetrics.test.ts
+++ b/test/ide/usePerformanceDiagnosticsMetrics.test.ts
@@ -1,0 +1,89 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, nextTick, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePerformanceDiagnosticsMetrics } from '@/features/ide/composables/usePerformanceDiagnosticsMetrics'
+
+describe('usePerformanceDiagnosticsMetrics', () => {
+  let now = 0
+
+  beforeEach(() => {
+    now = 0
+    vi.useFakeTimers()
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  function mountHarness() {
+    const code = ref('')
+    const isRunning = ref(false)
+    const output = ref<string[]>([])
+    const screenBuffer = ref({})
+    const runCode = vi.fn(async () => {})
+
+    let api: ReturnType<typeof usePerformanceDiagnosticsMetrics> | null = null
+
+    const Harness = defineComponent({
+      setup() {
+        api = usePerformanceDiagnosticsMetrics({
+          code,
+          runCode,
+          isRunning,
+          output,
+          screenBuffer,
+        })
+        return () => null
+      },
+    })
+
+    const wrapper = mount(Harness)
+    if (!api) {
+      throw new Error('failed to initialize diagnostics metrics harness')
+    }
+
+    return {
+      wrapper,
+      api,
+      isRunning,
+      output,
+    }
+  }
+
+  it('counts single-line output writes once', async () => {
+    const { wrapper, api, isRunning, output } = mountHarness()
+
+    isRunning.value = true
+    await nextTick()
+
+    output.value.push('one')
+    await nextTick()
+
+    now = 1000
+    vi.advanceTimersByTime(100)
+
+    expect(api.messagesPerSecond.value).toBe(1)
+    wrapper.unmount()
+  })
+
+  it('counts batched output writes by batch size', async () => {
+    const { wrapper, api, isRunning, output } = mountHarness()
+
+    isRunning.value = true
+    await nextTick()
+
+    output.value.push('one', 'two')
+    await nextTick()
+
+    now = 1000
+    vi.advanceTimersByTime(100)
+
+    expect(api.messagesPerSecond.value).toBe(2)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- remove runtime monkeypatching of output.value.push in performance diagnostics metrics
- count messages using output length deltas from a single watcher path so batched pushes are counted accurately
- add regression tests for single-line and batched output writes

## Testing
- pnpm vitest run test/ide/usePerformanceDiagnosticsMetrics.test.ts

Closes #48