### PR TITLE
Fix PALET runtime palette-combination no-op behavior

### DIFF
--- a/src/core/devices/ScreenStateManager.ts
+++ b/src/core/devices/ScreenStateManager.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ScreenCell, ScreenUpdateMessage } from '@/core/interfaces'
+import { BACKGROUND_PALETTES, SPRITE_PALETTES } from '@/shared/data/palette'
 import { logDevice } from '@/shared/logger'
 
 export class ScreenStateManager {
@@ -13,6 +14,16 @@ export class ScreenStateManager {
   private cursorY = 0
   private bgPalette = 1 // Default background palette (0-1)
   private spritePalette = 1 // Default sprite palette (0-2)
+  private readonly backgroundPalettes = BACKGROUND_PALETTES.map(palette =>
+    palette.map(combination => [...combination] as [number, number, number, number])
+  ) as [[number, number, number, number][], [number, number, number, number][]]
+  private readonly spritePalettes = SPRITE_PALETTES.map(palette =>
+    palette.map(combination => [...combination] as [number, number, number, number])
+  ) as [
+    [number, number, number, number][],
+    [number, number, number, number][],
+    [number, number, number, number][],
+  ]
   private backdropColor = 0 // Default backdrop color code (0-60, 0 = black)
   private cgenMode = 2 // Default character generator mode (0-3): B on BG, A on sprite
   private currentExecutionId: string | null = null
@@ -263,6 +274,39 @@ export class ScreenStateManager {
    */
   getPalette(): { bgPalette: number; spritePalette: number } {
     return { bgPalette: this.bgPalette, spritePalette: this.spritePalette }
+  }
+
+  /**
+   * Set a PALET color combination for the currently selected CGSET palette.
+   */
+  setPaletteCombination(
+    target: 'B' | 'S',
+    combination: number,
+    colors: [number, number, number, number]
+  ): { paletteIndex: number; colors: [number, number, number, number] } {
+    const clampedCombination = Math.max(0, Math.min(3, combination))
+    const clampedColors: [number, number, number, number] = [
+      Math.max(0, Math.min(60, colors[0] ?? 0)),
+      Math.max(0, Math.min(60, colors[1] ?? 0)),
+      Math.max(0, Math.min(60, colors[2] ?? 0)),
+      Math.max(0, Math.min(60, colors[3] ?? 0)),
+    ]
+
+    if (target === 'B') {
+      const paletteIndex = Math.max(0, Math.min(1, this.bgPalette))
+      const palette = this.backgroundPalettes[paletteIndex]
+      if (palette) {
+        palette[clampedCombination] = clampedColors
+      }
+      return { paletteIndex, colors: clampedColors }
+    }
+
+    const paletteIndex = Math.max(0, Math.min(2, this.spritePalette))
+    const palette = this.spritePalettes[paletteIndex]
+    if (palette) {
+      palette[clampedCombination] = clampedColors
+    }
+    return { paletteIndex, colors: clampedColors }
   }
 
   /**

--- a/src/core/devices/TestDeviceAdapter.ts
+++ b/src/core/devices/TestDeviceAdapter.ts
@@ -26,10 +26,50 @@ export class TestDeviceAdapter implements BasicDeviceAdapter {
     bgPalette: number
     spritePalette: number
   }> = []
+  public paletteCombinationCalls: Array<{
+    target: 'B' | 'S'
+    paletteIndex: number
+    combination: number
+    colors: [number, number, number, number]
+  }> = []
   public currentColorPalette: { bgPalette: number; spritePalette: number } = {
     bgPalette: 1,
     spritePalette: 1,
   }
+  public runtimeBackgroundPalettes = [
+    [
+      [0x00, 0x2c, 0x15, 0x07] as [number, number, number, number],
+      [0x00, 0x27, 0x21, 0x12] as [number, number, number, number],
+      [0x00, 0x29, 0x36, 0x17] as [number, number, number, number],
+      [0x00, 0x30, 0x26, 0x07] as [number, number, number, number],
+    ],
+    [
+      [0x00, 0x30, 0x21, 0x02] as [number, number, number, number],
+      [0x00, 0x30, 0x27, 0x18] as [number, number, number, number],
+      [0x00, 0x30, 0x27, 0x16] as [number, number, number, number],
+      [0x00, 0x29, 0x36, 0x17] as [number, number, number, number],
+    ],
+  ]
+  public runtimeSpritePalettes = [
+    [
+      [0x00, 0x36, 0x16, 0x02] as [number, number, number, number],
+      [0x00, 0x27, 0x30, 0x19] as [number, number, number, number],
+      [0x00, 0x35, 0x25, 0x17] as [number, number, number, number],
+      [0x00, 0x30, 0x27, 0x16] as [number, number, number, number],
+    ],
+    [
+      [0x00, 0x30, 0x16, 0x01] as [number, number, number, number],
+      [0x00, 0x10, 0x00, 0x01] as [number, number, number, number],
+      [0x00, 0x30, 0x29, 0x09] as [number, number, number, number],
+      [0x00, 0x30, 0x16, 0x07] as [number, number, number, number],
+    ],
+    [
+      [0x00, 0x30, 0x26, 0x12] as [number, number, number, number],
+      [0x00, 0x30, 0x15, 0x12] as [number, number, number, number],
+      [0x00, 0x30, 0x12, 0x16] as [number, number, number, number],
+      [0x00, 0x30, 0x26, 0x19] as [number, number, number, number],
+    ],
+  ]
   public backdropColorCalls: number[] = []
   public currentBackdropColor: number = 0 // Default backdrop color (0 = black)
   public cgenModeCalls: number[] = []
@@ -265,6 +305,20 @@ export class TestDeviceAdapter implements BasicDeviceAdapter {
       bgPalette,
       spritePalette,
     })
+  }
+
+  setPaletteCombination(target: 'B' | 'S', combination: number, c1: number, c2: number, c3: number, c4: number): void {
+    const colors: [number, number, number, number] = [c1, c2, c3, c4]
+    if (target === 'B') {
+      const paletteIndex = Math.max(0, Math.min(1, this.currentColorPalette.bgPalette))
+      this.runtimeBackgroundPalettes[paletteIndex]![combination] = colors
+      this.paletteCombinationCalls.push({ target, paletteIndex, combination, colors })
+      return
+    }
+
+    const paletteIndex = Math.max(0, Math.min(2, this.currentColorPalette.spritePalette))
+    this.runtimeSpritePalettes[paletteIndex]![combination] = colors
+    this.paletteCombinationCalls.push({ target, paletteIndex, combination, colors })
   }
 
   setBackdropColor(colorCode: number): void {

--- a/src/core/devices/WebWorkerDeviceAdapter.ts
+++ b/src/core/devices/WebWorkerDeviceAdapter.ts
@@ -565,6 +565,25 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
     this.postScreenChanged()
   }
 
+  setPaletteCombination(target: 'B' | 'S', combination: number, c1: number, c2: number, c3: number, c4: number): void {
+    const { paletteIndex, colors } = this.screenStateManager.setPaletteCombination(target, combination, [c1, c2, c3, c4])
+
+    self.postMessage({
+      type: 'SCREEN_UPDATE',
+      id: `screen-palette-combination-${Date.now()}`,
+      timestamp: Date.now(),
+      data: {
+        executionId: this.screenStateManager.getCurrentExecutionId() ?? 'unknown',
+        updateType: 'palette-combination',
+        paletteTarget: target,
+        paletteIndex,
+        paletteCombination: combination,
+        paletteColors: colors,
+        timestamp: Date.now(),
+      },
+    })
+  }
+
   setBackdropColor(colorCode: number): void {
     logWorker.debug('Set backdrop color:', colorCode)
     this.screenStateManager.setBackdropColor(colorCode)

--- a/src/core/execution/executors/PaletExecutor.ts
+++ b/src/core/execution/executors/PaletExecutor.ts
@@ -179,25 +179,18 @@ export class PaletExecutor {
       return
     }
 
-    // Handle PALET B with n=0: set backdrop color
-    if (target === 'B' && n === 0) {
-      // C1 is the backdrop color when n=0
-      if (this.context.deviceAdapter) {
-        this.context.deviceAdapter.setBackdropColor(c1)
-      }
+    // Persist PALET color combination for active CGSET palette selection.
+    this.context.deviceAdapter?.setPaletteCombination?.(target, n, c1, c2, c3, c4)
 
-      if (this.context.config.enableDebugMode) {
-        this.context.addDebugOutput(`PALET B: Set backdrop color to ${c1} (color combination 0)`)
-      }
-    } else {
-      // For other cases (PALET S, or PALET B with n != 0), we would store palette colors
-      // This is a placeholder for future implementation
-      // For now, we'll just log it in debug mode
-      if (this.context.config.enableDebugMode) {
-        this.context.addDebugOutput(
-          `PALET ${target}: Set color combination ${n} to C1=${c1}, C2=${c2}, C3=${c3}, C4=${c4} (not yet fully implemented)`
-        )
-      }
+    // PALET B with n=0 also sets backdrop color to C1.
+    if (target === 'B' && n === 0) {
+      this.context.deviceAdapter?.setBackdropColor(c1)
+    }
+
+    if (this.context.config.enableDebugMode) {
+      this.context.addDebugOutput(
+        `PALET ${target}: Set color combination ${n} to C1=${c1}, C2=${c2}, C3=${c3}, C4=${c4}${target === 'B' && n === 0 ? ' (backdrop updated)' : ''}`
+      )
     }
   }
 }

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -125,6 +125,14 @@ export interface BasicDeviceAdapter {
   getScreenCell(x: number, y: number, colorSwitch?: number): string | number
   setColorPattern(x: number, y: number, pattern: number): void
   setColorPalette(bgPalette: number, spritePalette: number): void
+  setPaletteCombination?(
+    target: 'B' | 'S',
+    combination: number,
+    c1: number,
+    c2: number,
+    c3: number,
+    c4: number
+  ): void
   setBackdropColor(colorCode: number): void
   setCharacterGeneratorMode(mode: number): void
   getCharacterGeneratorMode(): number
@@ -365,7 +373,16 @@ export interface ScreenUpdateMessage extends ServiceWorkerMessage {
   type: 'SCREEN_UPDATE'
   data: {
     executionId: string
-    updateType: 'character' | 'cursor' | 'clear' | 'full' | 'color' | 'palette' | 'cgen' | 'backdrop'
+    updateType:
+      | 'character'
+      | 'cursor'
+      | 'clear'
+      | 'full'
+      | 'color'
+      | 'palette'
+      | 'cgen'
+      | 'backdrop'
+      | 'palette-combination'
     x?: number
     y?: number
     character?: string
@@ -375,6 +392,10 @@ export interface ScreenUpdateMessage extends ServiceWorkerMessage {
     colorUpdates?: Array<{ x: number; y: number; pattern: number }>
     bgPalette?: number
     spritePalette?: number
+    paletteTarget?: 'B' | 'S'
+    paletteIndex?: number
+    paletteCombination?: number
+    paletteColors?: [number, number, number, number]
     backdropColor?: number
     cgenMode?: number
     timestamp: number

--- a/src/features/ide/composables/useBasicIdeMessageHandlers.ts
+++ b/src/features/ide/composables/useBasicIdeMessageHandlers.ts
@@ -19,6 +19,9 @@ import type {
 import type { Note, Rest } from '@/core/sound/types'
 import type { SpriteState } from '@/core/sprite/types'
 import { ExecutionError } from '@/features/ide/errors/ExecutionError'
+import { clearBackgroundTileCache } from '@/features/ide/composables/useCanvasBackgroundRenderer'
+import { clearSpriteImageCache } from '@/features/ide/composables/useKonvaSpriteRenderer'
+import { setRuntimePaletteCombination } from '@/shared/data/palette'
 import { logComposable, logIdeMessages } from '@/shared/logger'
 
 import { extendExecutionTimeout, type WebWorkerManager } from './useBasicIdeWebWorkerUtils'
@@ -376,6 +379,30 @@ export function handleScreenUpdateMessage(message: AnyServiceWorkerMessage, cont
           context.cgenMode.value = update.cgenMode
         }
         logComposable.debug('Updated character generator mode:', update.cgenMode)
+      }
+      break
+    case 'palette-combination':
+      if (
+        update.paletteTarget &&
+        update.paletteIndex !== undefined &&
+        update.paletteCombination !== undefined &&
+        update.paletteColors
+      ) {
+        setRuntimePaletteCombination(
+          update.paletteTarget,
+          update.paletteIndex,
+          update.paletteCombination,
+          update.paletteColors
+        )
+        clearBackgroundTileCache()
+        clearSpriteImageCache()
+        context.scheduleRender?.()
+        logComposable.debug('Updated runtime palette combination:', {
+          target: update.paletteTarget,
+          paletteIndex: update.paletteIndex,
+          combination: update.paletteCombination,
+          colors: update.paletteColors,
+        })
       }
       break
   }

--- a/src/shared/data/palette.ts
+++ b/src/shared/data/palette.ts
@@ -71,7 +71,8 @@ export const COLORS = [
 
 type Palette = [ColorCombination, ColorCombination, ColorCombination, ColorCombination]
 
-type ColorCombination = [number, number, number, number]
+export type ColorCombination = [number, number, number, number]
+export type PaletteTarget = 'B' | 'S'
 
 export const SPRITE_PALETTES: [Palette, Palette, Palette] = [
   [
@@ -108,3 +109,33 @@ export const BACKGROUND_PALETTES: [Palette, Palette] = [
     [0x00, 0x29, 0x36, 0x17],
   ],
 ]
+
+export function setRuntimePaletteCombination(
+  target: PaletteTarget,
+  paletteIndex: number,
+  combination: number,
+  colors: ColorCombination
+): void {
+  const clampedCombination = Math.max(0, Math.min(3, combination))
+  const clampedColors: ColorCombination = [
+    Math.max(0, Math.min(60, colors[0] ?? 0)),
+    Math.max(0, Math.min(60, colors[1] ?? 0)),
+    Math.max(0, Math.min(60, colors[2] ?? 0)),
+    Math.max(0, Math.min(60, colors[3] ?? 0)),
+  ]
+
+  if (target === 'B') {
+    const idx = Math.max(0, Math.min(1, paletteIndex))
+    const palette = BACKGROUND_PALETTES[idx]
+    if (palette) {
+      palette[clampedCombination] = clampedColors
+    }
+    return
+  }
+
+  const idx = Math.max(0, Math.min(2, paletteIndex))
+  const palette = SPRITE_PALETTES[idx]
+  if (palette) {
+    palette[clampedCombination] = clampedColors
+  }
+}

--- a/test/executors/PaletExecutor.test.ts
+++ b/test/executors/PaletExecutor.test.ts
@@ -104,6 +104,13 @@ describe('PaletExecutor', () => {
       expect(result.errors).toHaveLength(0)
       // When n != 0, backdrop color should not be set (only palette colors would be set)
       expect(deviceAdapter.backdropColorCalls).toHaveLength(0)
+      expect(deviceAdapter.paletteCombinationCalls).toHaveLength(1)
+      expect(deviceAdapter.paletteCombinationCalls[0]).toMatchObject({
+        target: 'B',
+        paletteIndex: 1,
+        combination: 1,
+        colors: [15, 0, 0, 0],
+      })
     })
 
     it('should handle multiple PALET B commands', async () => {
@@ -137,6 +144,13 @@ describe('PaletExecutor', () => {
       expect(result.errors).toHaveLength(0)
       // PALET S doesn't set backdrop color, so no backdrop color calls
       expect(deviceAdapter.backdropColorCalls).toHaveLength(0)
+      expect(deviceAdapter.paletteCombinationCalls).toHaveLength(1)
+      expect(deviceAdapter.paletteCombinationCalls[0]).toMatchObject({
+        target: 'S',
+        paletteIndex: 1,
+        combination: 0,
+        colors: [15, 20, 25, 30],
+      })
     })
 
     it('should parse PALETS statement (no space) without errors', async () => {
@@ -245,6 +259,26 @@ describe('PaletExecutor', () => {
       expect(result.errors).toHaveLength(0)
       expect(deviceAdapter.backdropColorCalls).toHaveLength(1)
       expect(deviceAdapter.backdropColorCalls[0]).toBe(20)
+    })
+
+    it('should apply palette combination to currently selected sprite palette from CGSET', async () => {
+      const source = `
+10 CGSET 1, 2
+20 PALET S 2, 9, 10, 11, 12
+30 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+      expect(result.errors).toHaveLength(0)
+      expect(deviceAdapter.paletteCombinationCalls).toHaveLength(1)
+      expect(deviceAdapter.paletteCombinationCalls[0]).toMatchObject({
+        target: 'S',
+        paletteIndex: 2,
+        combination: 2,
+        colors: [9, 10, 11, 12],
+      })
+      expect(deviceAdapter.runtimeSpritePalettes[2]?.[2]).toEqual([9, 10, 11, 12])
     })
   })
 })


### PR DESCRIPTION
## Summary\n- implement runtime persistence for PALET color combinations via device adapter hook (setPaletteCombination)\n- make PALET updates apply to the currently active CGSET palette index and keep PALET B 0 backdrop behavior\n- propagate worker palette-combination updates to the IDE renderer, mutate runtime palettes, clear caches, and trigger redraw\n- add regression coverage for PALET B/PALET S combination persistence and CGSET-selected sprite palette application\n\n## Root cause\nPaletExecutor only performed real runtime work for PALET B 0 (backdrop) and treated every other valid PALET combination as debug-only no-ops.\n\n## Testing\n- pnpm -s test:run -- test/executors/PaletExecutor.test.ts\n- pnpm -s test:run -- test/executors/CgsetExecutor.test.ts\n- pnpm -s test:run -- test/devices/WebWorkerDeviceAdapter.test.ts\n- pnpm -s test:run -- test/integration/CgsetIntegration.test.ts\n\nCloses #45