### PR TITLE
Fix issue #41: reduce initial app-shell bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Vue 3 + TypeScript + Vite + Chevrotain parser
 | `pnpm test:run` | Run tests |
 | `pnpm lint` | Lint and format |
 | `pnpm type-check` | TypeScript check |
+| `pnpm verify:build-size-budgets` | Enforce initial app-shell JS chunk budget (<= 1.5 MB raw) |
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "visualize-cst": "tsx scripts/dev/visualize-cst.ts",
         "check-syntax": "tsx scripts/validation/check-syntax.ts",
         "verify:script-entrypoints": "tsx scripts/validation/verify-script-entrypoints.ts",
-        "verify:build-no-unresolved-assets": "tsx scripts/validation/check-unresolved-assets.ts"
+        "verify:build-no-unresolved-assets": "tsx scripts/validation/check-unresolved-assets.ts",
+        "verify:build-size-budgets": "node scripts/validation/check-build-size-budgets.mjs"
     },
     "dependencies": {
         "@fontsource/exo-2": "^5.1.0",

--- a/scripts/validation/check-build-size-budgets.mjs
+++ b/scripts/validation/check-build-size-budgets.mjs
@@ -1,0 +1,58 @@
+import { readFileSync, statSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const DIST_DIR = resolve(process.cwd(), 'dist')
+const INDEX_HTML = resolve(DIST_DIR, 'index.html')
+const INITIAL_JS_BUDGET_BYTES = Number(process.env.INITIAL_JS_BUDGET_BYTES ?? 1_500_000)
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KiB`
+}
+
+function getInitialJsAssetPaths(indexHtml) {
+  const paths = new Set()
+  const pattern = /<(script|link)\b[^>]*(src|href)=["']([^"']+\.js)["'][^>]*>/gi
+  let match = pattern.exec(indexHtml)
+  while (match) {
+    const assetPath = match[3]
+    if (assetPath.startsWith('/assets/')) {
+      paths.add(assetPath.slice(1))
+    }
+    match = pattern.exec(indexHtml)
+  }
+  return [...paths]
+}
+
+function main() {
+  const indexHtml = readFileSync(INDEX_HTML, 'utf8')
+  const initialJsAssets = getInitialJsAssetPaths(indexHtml)
+
+  if (initialJsAssets.length === 0) {
+    throw new Error('No initial JS assets found in dist/index.html.')
+  }
+
+  let hasViolation = false
+  for (const assetPath of initialJsAssets) {
+    const fullPath = resolve(DIST_DIR, assetPath.replace(/^assets\//, 'assets/'))
+    const size = statSync(fullPath).size
+    const withinBudget = size <= INITIAL_JS_BUDGET_BYTES
+
+    // Keep output concise for CI logs.
+    console.log(
+      `${withinBudget ? 'PASS' : 'FAIL'} ${assetPath} ${formatBytes(size)} (budget ${formatBytes(INITIAL_JS_BUDGET_BYTES)})`
+    )
+
+    if (!withinBudget) {
+      hasViolation = true
+    }
+  }
+
+  if (hasViolation) {
+    process.exitCode = 1
+    return
+  }
+
+  console.log('Initial app-shell JS chunk budgets satisfied.')
+}
+
+main()

--- a/src/features/ide/components/MonacoCodeEditor.vue
+++ b/src/features/ide/components/MonacoCodeEditor.vue
@@ -3,6 +3,7 @@ import * as monaco from 'monaco-editor'
 import { onBeforeUnmount, onDeactivated, onMounted, useTemplateRef, watch } from 'vue'
 
 import { setupLiveErrorChecking, setupMonacoLanguage } from '@/features/ide/integrations/monaco-integration'
+import { configureMonacoWorkers } from '@/features/ide/integrations/monaco-workers'
 
 /**
  * MonacoCodeEditor component - Monaco Editor integration for F-BASIC code editing.
@@ -54,6 +55,8 @@ function updateTheme(): void {
 
 onMounted(() => {
   if (!editorContainer.value) return
+
+  configureMonacoWorkers()
 
   // Setup Monaco language support (this also sets up themes)
   setupMonacoLanguage()

--- a/src/features/ide/integrations/monaco-workers.ts
+++ b/src/features/ide/integrations/monaco-workers.ts
@@ -1,0 +1,26 @@
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker.js?worker'
+import CssWorker from 'monaco-editor/esm/vs/language/css/css.worker.js?worker'
+import HtmlWorker from 'monaco-editor/esm/vs/language/html/html.worker.js?worker'
+import JsonWorker from 'monaco-editor/esm/vs/language/json/json.worker.js?worker'
+import TsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker'
+
+let isConfigured = false
+
+/**
+ * Configure Monaco worker routing lazily so app shell does not import Monaco workers.
+ */
+export function configureMonacoWorkers(): void {
+  if (isConfigured || typeof window === 'undefined') return
+
+  window.MonacoEnvironment = {
+    getWorker(_workerId: string, label: string): Worker {
+      if (label === 'json') return new JsonWorker()
+      if (label === 'css' || label === 'scss' || label === 'less') return new CssWorker()
+      if (label === 'html' || label === 'handlebars' || label === 'razor') return new HtmlWorker()
+      if (label === 'typescript' || label === 'javascript') return new TsWorker()
+      return new EditorWorker()
+    },
+  }
+
+  isConfigured = true
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,24 +4,6 @@ import './shared/styles/theme.css'
 import './shared/styles/utilities.css'
 import './shared/styles/skins/index.css'
 
-// Register MDI icon set locally so icons load from bundle instead of Iconify API.
-import { icons } from '@iconify-json/mdi'
-
-import type { IconCollectionData } from '@/shared/icons'
-import { registerIconCollection } from '@/shared/icons'
-// @iconify-json/mdi icons type lacks index signature; assert for IconCollectionData
-// eslint-disable-next-line no-restricted-syntax -- IconifyJSON.icons not assignable to Record<string, ...>
-registerIconCollection({ prefix: 'mdi', icons, width: 24, height: 24 } as unknown as IconCollectionData)
-
-// Configure Monaco Editor workers before Monaco is imported.
-// Use Vite's ?worker imports so workers are bundled and load correctly (avoids
-// "Could not create web worker(s)" and uncaught Worker error events when
-// /node_modules/ is not served by the dev server).
-import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker.js?worker'
-import CssWorker from 'monaco-editor/esm/vs/language/css/css.worker.js?worker'
-import HtmlWorker from 'monaco-editor/esm/vs/language/html/html.worker.js?worker'
-import JsonWorker from 'monaco-editor/esm/vs/language/json/json.worker.js?worker'
-import TsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker'
 import { createApp } from 'vue'
 import VueKonva from 'vue-konva'
 
@@ -31,16 +13,6 @@ import i18n from './shared/i18n'
 import { logApp } from './shared/logger'
 
 if (typeof window !== 'undefined') {
-  window.MonacoEnvironment = {
-    getWorker(_workerId: string, label: string): Worker {
-      if (label === 'json') return new JsonWorker()
-      if (label === 'css' || label === 'scss' || label === 'less') return new CssWorker()
-      if (label === 'html' || label === 'handlebars' || label === 'razor') return new HtmlWorker()
-      if (label === 'typescript' || label === 'javascript') return new TsWorker()
-      return new EditorWorker()
-    },
-  }
-
   // Global handler for unhandled promise rejections
   window.addEventListener('unhandledrejection', (event) => {
     logApp.error('Unhandled promise rejection:', event.reason)

--- a/src/shared/components/ui/GameIcon.vue
+++ b/src/shared/components/ui/GameIcon.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
+
+import { ensureLocalIcon } from '@/shared/icons'
 
 /**
  * GameIcon component - An icon component using Iconify with size, color, and animation options.
@@ -69,11 +71,26 @@ const rotateValue = computed((): number | undefined => {
 
 const iconColorValue = computed(() => props.color)
 const iconFontSize = computed(() => `${iconSize.value}px`)
+const resolvedIcon = ref<string | undefined>(props.icon)
+
+watch(
+  () => props.icon,
+  async (newIcon) => {
+    if (!newIcon) {
+      resolvedIcon.value = undefined
+      return
+    }
+
+    await ensureLocalIcon(newIcon)
+    resolvedIcon.value = newIcon
+  },
+  { immediate: true }
+)
 </script>
 
 <template>
-  <span v-if="icon" :class="iconClasses">
-    <Icon :icon="icon" :width="iconSize" :height="iconSize" :color="color" :inline="inline" :rotate="rotateValue" />
+  <span v-if="resolvedIcon" :class="iconClasses">
+    <Icon :icon="resolvedIcon" :width="iconSize" :height="iconSize" :color="color" :inline="inline" :rotate="rotateValue" />
   </span>
   <span v-else class="game-icon-placeholder">
     <slot />

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -1,21 +1,44 @@
-/**
- * Icon registration for offline/bundled icon sets.
- * Registers icon set data with @iconify/vue; addCollection accepts this shape at
- * runtime but types declare IconifyIcons, so we centralize the type bridge here.
- */
-import { addCollection } from '@iconify/vue'
+import { addIcon } from '@iconify/vue'
 
-/** Shape accepted by addCollection at runtime (IconifyJSON); library types differ. */
-export interface IconCollectionData {
-  prefix: string
-  icons: Record<string, { body: string; width?: number; height?: number }>
-  width: number
-  height: number
+type IconModule = {
+  default: {
+    body: string
+    width?: number
+    height?: number
+  }
 }
 
-type AddCollectionArg = Parameters<typeof addCollection>[0]
+const mdiIconModules = import.meta.glob<IconModule>('../../node_modules/@iconify-json/mdi/icons/*.json')
+const loadedIcons = new Set<string>()
+const pendingLoads = new Map<string, Promise<void>>()
 
-export function registerIconCollection(data: IconCollectionData): void {
-  // eslint-disable-next-line no-restricted-syntax -- addCollection runtime API vs IconifyIcons type def
-  addCollection(data as unknown as AddCollectionArg)
+/**
+ * Load an mdi icon from the local icon package only when it is requested.
+ */
+export async function ensureLocalIcon(iconName: string): Promise<void> {
+  if (!iconName.startsWith('mdi:')) return
+  if (loadedIcons.has(iconName)) return
+
+  const existingLoad = pendingLoads.get(iconName)
+  if (existingLoad) {
+    await existingLoad
+    return
+  }
+
+  const iconId = iconName.slice('mdi:'.length)
+  const modulePath = `../../node_modules/@iconify-json/mdi/icons/${iconId}.json`
+  const loader = mdiIconModules[modulePath]
+  if (!loader) return
+
+  const loadPromise = loader()
+    .then((module) => {
+      addIcon(iconName, module.default)
+      loadedIcons.add(iconName)
+    })
+    .finally(() => {
+      pendingLoads.delete(iconName)
+    })
+
+  pendingLoads.set(iconName, loadPromise)
+  await loadPromise
 }


### PR DESCRIPTION
## Summary
- fix the real app-shell size root cause by removing eager `@iconify-json/mdi` full-collection import from app startup
- lazy-load local MDI icon JSON files on demand via `import.meta.glob` in `ensureLocalIcon(...)`
- keep Monaco worker setup scoped to IDE editor usage via `configureMonacoWorkers()`
- add `verify:build-size-budgets` script to enforce initial app-shell JS budget (`<= 1.5 MB`)
- document the budget check command in README

## Issue
- Closes #41

## Validation
- `pnpm -s vite build`
  - `dist/assets/index-*.js`: **401.01 kB** (was ~3,378 kB)
  - `dist/assets/MonacoCodeEditor-*.js`: 3,733.68 kB (still lazy-loaded, non-shell chunk)
- `pnpm -s verify:build-size-budgets`
  - PASS `assets/index-*.js` under 1.5 MB budget
- `pnpm -s test:run -- test/ide/useProgramStore.test.ts`
  - PASS (7 tests)

## Notes
- `pnpm build` remains blocked by pre-existing unrelated type-check issues in:
  - `test/ide/usePerformanceDiagnosticsMetrics.test.ts`
  - `test/validation/ScriptEntrypointIntegrity.test.ts`