### PR TITLE
fix: preserve REPL-only diagnostic line numbers

### DIFF
--- a/src/core/parser/FBasicChevrotainParser.ts
+++ b/src/core/parser/FBasicChevrotainParser.ts
@@ -1505,13 +1505,24 @@ function checkReplOnlyCommands(cst: CstNode): Array<{ message: string; line?: nu
       return
     }
 
+    let currentLineNumber = lineNumber
+    if (cstNode.name === 'statement') {
+      const lineToken = cstNode.children.NumberLiteral?.[0]
+      if (lineToken && typeof lineToken === 'object' && 'image' in lineToken) {
+        const parsedLine = Number.parseInt(String(lineToken.image), 10)
+        if (Number.isFinite(parsedLine)) {
+          currentLineNumber = parsedLine
+        }
+      }
+    }
+
     // Check if this node is a REPL-only statement
     const errorMsg = REPL_ONLY_COMMANDS[cstNode.name]
     if (errorMsg && !seenErrors.has(errorMsg)) {
       seenErrors.add(errorMsg)
       errors.push({
         message: errorMsg,
-        line: lineNumber,
+        line: currentLineNumber,
         column: 1,
       })
     }
@@ -1529,7 +1540,7 @@ function checkReplOnlyCommands(cst: CstNode): Array<{ message: string; line?: nu
                 seenErrors.add(funcError)
                 errors.push({
                   message: funcError,
-                  line: lineNumber,
+                  line: currentLineNumber,
                   column: 1,
                 })
               }
@@ -1547,7 +1558,7 @@ function checkReplOnlyCommands(cst: CstNode): Array<{ message: string; line?: nu
           if (child && typeof child === 'object') {
             if ('name' in child) {
               // It's a CST node - recurse
-              traverse(child as CstNode, lineNumber)
+              traverse(child as CstNode, currentLineNumber)
             }
             // Token objects don't need recursion
           }

--- a/test/parser/ReplOnlyCommands.test.ts
+++ b/test/parser/ReplOnlyCommands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect,test } from 'vitest'
 
 import { parseWithChevrotain } from '@/core/parser/FBasicChevrotainParser'
+import { FBasicParser } from '@/core/parser/FBasicParser'
 
 describe('REPL-only Commands Parser', () => {
   // REPL-only commands that should parse but produce errors
@@ -88,6 +89,33 @@ describe('REPL-only Commands Parser', () => {
     expect(result.success).toBe(true)
     expect(result.cst).toBeDefined()
     expect(result.errors).toBeUndefined()
+  })
+
+  test('includes concrete line number for LIST diagnostic', () => {
+    const result = parseWithChevrotain('10 LIST')
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0]?.message).toBe('LIST: Not applicable for IDE version')
+    expect(result.errors?.[0]?.line).toBe(10)
+    expect(result.errors?.[0]?.column).toBe(1)
+  })
+
+  test('includes concrete line number for PEEK diagnostic', () => {
+    const result = parseWithChevrotain('120 A=PEEK(&H7000)')
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0]?.message).toBe('PEEK: Not applicable for IDE version')
+    expect(result.errors?.[0]?.line).toBe(120)
+    expect(result.errors?.[0]?.column).toBe(1)
+  })
+
+  test('parser error message never reports line undefined', async () => {
+    const parser = new FBasicParser()
+    const result = await parser.parse('10 LIST')
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0]?.message).toContain('(line 10, col 1)')
+    expect(result.errors?.[0]?.message).not.toContain('line undefined')
   })
 
   // INKEY$ is now a fully implemented function (GitHub issue #4)


### PR DESCRIPTION
## Summary
- preserve BASIC statement line numbers while traversing CST for REPL-only command/function diagnostics
- ensure parser-formatted errors never render as \line undefined\
- add regression tests for LIST and PEEK line-numbered diagnostics

## Testing
- pnpm -s test:run -- test/parser/ReplOnlyCommands.test.ts
- pnpm -s test:run -- test/parser/PauseStatement.test.ts

Closes #23