### PR TITLE
test: add PALET runtime integration coverage

### DIFF
--- a/test/ide/useBasicIdeMessageHandlers.test.ts
+++ b/test/ide/useBasicIdeMessageHandlers.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import {
+  handleScreenUpdateMessage,
+  type MessageHandlerContext,
+} from '@/features/ide/composables/useBasicIdeMessageHandlers'
+import { BACKGROUND_PALETTES, SPRITE_PALETTES } from '@/shared/data/palette'
+
+type PaletteSnapshot = number[][][]
+type RuntimePalettes = number[][][]
+
+function clonePalettes(source: number[][][]): PaletteSnapshot {
+  return source.map((palette) => palette.map((combination) => [...combination]))
+}
+
+function restorePalettes(target: RuntimePalettes, snapshot: PaletteSnapshot): void {
+  snapshot.forEach((palette, paletteIndex) => {
+    palette.forEach((combination, combinationIndex) => {
+      target[paletteIndex]![combinationIndex] = [...combination]
+    })
+  })
+}
+
+function createContext(scheduleRender: () => void): MessageHandlerContext {
+  return {
+    output: ref([]),
+    errors: ref([]),
+    debugOutput: ref(''),
+    screenBuffer: ref([]),
+    cursorX: ref(0),
+    cursorY: ref(0),
+    bgPalette: ref(1),
+    webWorkerManager: {
+      pendingMessages: new Map(),
+    } as MessageHandlerContext['webWorkerManager'],
+    scheduleRender,
+  }
+}
+
+describe('useBasicIdeMessageHandlers palette combination updates', () => {
+  let bgSnapshot: PaletteSnapshot
+  let spriteSnapshot: PaletteSnapshot
+
+  beforeEach(() => {
+    bgSnapshot = clonePalettes(BACKGROUND_PALETTES)
+    spriteSnapshot = clonePalettes(SPRITE_PALETTES)
+  })
+
+  afterEach(() => {
+    restorePalettes(BACKGROUND_PALETTES, bgSnapshot)
+    restorePalettes(SPRITE_PALETTES, spriteSnapshot)
+  })
+
+  it('applies background palette-combination update and schedules render', () => {
+    const scheduleRender = vi.fn()
+    const context = createContext(scheduleRender)
+
+    handleScreenUpdateMessage(
+      {
+        type: 'SCREEN_UPDATE',
+        id: 'test-bg-palette',
+        timestamp: Date.now(),
+        data: {
+          executionId: 'exec-1',
+          updateType: 'palette-combination',
+          paletteTarget: 'B',
+          paletteIndex: 1,
+          paletteCombination: 2,
+          paletteColors: [60, 10, 20, 30],
+          timestamp: Date.now(),
+        },
+      } as never,
+      context
+    )
+
+    expect(BACKGROUND_PALETTES[1][2]).toEqual([60, 10, 20, 30])
+    expect(scheduleRender).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies sprite palette-combination update and schedules render', () => {
+    const scheduleRender = vi.fn()
+    const context = createContext(scheduleRender)
+
+    handleScreenUpdateMessage(
+      {
+        type: 'SCREEN_UPDATE',
+        id: 'test-sprite-palette',
+        timestamp: Date.now(),
+        data: {
+          executionId: 'exec-2',
+          updateType: 'palette-combination',
+          paletteTarget: 'S',
+          paletteIndex: 2,
+          paletteCombination: 3,
+          paletteColors: [1, 2, 3, 4],
+          timestamp: Date.now(),
+        },
+      } as never,
+      context
+    )
+
+    expect(SPRITE_PALETTES[2][3]).toEqual([1, 2, 3, 4])
+    expect(scheduleRender).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/ide/usePerformanceDiagnosticsMetrics.test.ts
+++ b/test/ide/usePerformanceDiagnosticsMetrics.test.ts
@@ -22,19 +22,14 @@ describe('usePerformanceDiagnosticsMetrics', () => {
     vi.unstubAllGlobals()
   })
 
-  function mountHarness(): {
-    wrapper: ReturnType<typeof mount>
-    api: DiagnosticsApi
-    isRunning: { value: boolean }
-    output: { value: string[] }
-  } {
+  function mountHarness() {
     const code = ref('')
     const isRunning = ref(false)
     const output = ref<string[]>([])
     const screenBuffer = ref({})
     const runCode = vi.fn(async () => {})
 
-    let api: DiagnosticsApi | null = null
+    let api!: DiagnosticsApi
 
     const harnessComponent = defineComponent({
       setup() {


### PR DESCRIPTION
## Summary\n- add focused IDE message-handler tests for SCREEN_UPDATE palette-combination updates\n- verify both background (PALET B) and sprite (PALET S) runtime palette mutations\n- assert palette-combination updates schedule a render to make visual changes observable\n\n## Validation\n- pnpm -s test:run -- test/ide/useBasicIdeMessageHandlers.test.ts\n- pnpm -s test:run -- test/executors/PaletExecutor.test.ts\n\nCloses #45