### PR TITLE
Bundle COI client and silence chunk warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 
 <body>
     <div id="app"></div>
+    <script type="module" src="/src/coi-serviceworker-client.ts"></script>
     <script type="module" src="/src/main.ts"></script>
 </body>
 

--- a/src/coi-serviceworker-client.ts
+++ b/src/coi-serviceworker-client.ts
@@ -1,0 +1,21 @@
+if (typeof window !== 'undefined') {
+  // Register service worker only when cross-origin isolation is still missing.
+  if (window.crossOriginIsolated === false && window.isSecureContext && 'serviceWorker' in navigator) {
+    window.addEventListener('load', async () => {
+      try {
+        const registration = await navigator.serviceWorker.register('/coi-serviceworker.js')
+
+        if (registration.active && !navigator.serviceWorker.controller) {
+          window.location.reload()
+          return
+        }
+
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          window.location.reload()
+        })
+      } catch (error) {
+        console.error('[coi-serviceworker] registration failed:', error)
+      }
+    })
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     include: ['monaco-editor'],
   },
   build: {
+    chunkSizeWarningLimit: 4000,
     rollupOptions: {
       output: {
         // Ensure Monaco workers are handled correctly


### PR DESCRIPTION
## Summary\n- Move COI service worker registration into a Vite module entry\n- Keep coi-serviceworker.js in public/ and register it from bundled client code\n- Raise Vite chunk size warning limit to 4000 kB (see issue #68)\n\n## Testing\n- pnpm build\n\n## Notes\nThis keeps the chunk-limit bump for now; follow-up tracked in #68 to reduce bundle size properly.