### PR TITLE
fix(#35): skip render-only animation work on idle frames

### DIFF
--- a/src/features/ide/composables/useScreenAnimationLoopRenderOnly.ts
+++ b/src/features/ide/composables/useScreenAnimationLoopRenderOnly.ts
@@ -116,6 +116,7 @@ export function useScreenAnimationLoopRenderOnly(
 
     // Check for visible movements that need sprite nodes
     const visibleMovements: number[] = []
+    let hasMissingSpriteNode = false
     for (let actionNumber = 0; actionNumber < MAX_SPRITES; actionNumber++) {
       const characterType = sharedDisplayBufferAccessor.readSpriteCharacterType(actionNumber)
       if (characterType < 0) continue // No DEF MOVE
@@ -129,6 +130,7 @@ export function useScreenAnimationLoopRenderOnly(
       const priority = sharedDisplayBufferAccessor.readSpritePriority(actionNumber)
       const nodeMap = priority === 0 ? frontNodes : backNodes
       if (!nodeMap.has(actionNumber)) {
+        hasMissingSpriteNode = true
         // Sprite node missing - trigger render to create it
         if (onRenderNeeded) {
           if (DEBUG_ANIMATION_LOOP) {
@@ -138,6 +140,13 @@ export function useScreenAnimationLoopRenderOnly(
           break // Only trigger once per frame
         }
       }
+    }
+
+    const hasPendingStaticRender = getPendingStaticRender?.() ?? false
+    const isIdleFrame = visibleMovements.length === 0 && !hasPendingStaticRender && !hasMissingSpriteNode
+    if (isIdleFrame) {
+      animationFrameId = requestAnimationFrame(animationLoop)
+      return
     }
 
     // Read all sprite positions from shared buffer and update Konva nodes
@@ -188,10 +197,7 @@ export function useScreenAnimationLoopRenderOnly(
     }
 
     // Run pending static render at end of frame (animation first, then render)
-    if (
-      getPendingStaticRender?.() &&
-      onRunPendingStaticRender
-    ) {
+    if (hasPendingStaticRender && onRunPendingStaticRender) {
       await onRunPendingStaticRender()
     }
 

--- a/test/ide/useScreenAnimationLoopRenderOnly.test.ts
+++ b/test/ide/useScreenAnimationLoopRenderOnly.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useScreenAnimationLoopRenderOnly } from '@/features/ide/composables/useScreenAnimationLoopRenderOnly'
+
+const { updateAnimatedSpritesMock } = vi.hoisted(() => ({
+  updateAnimatedSpritesMock: vi.fn(async () => {}),
+}))
+
+vi.mock('@/features/ide/composables/useKonvaScreenRenderer', () => ({
+  updateAnimatedSprites: updateAnimatedSpritesMock,
+}))
+
+type AccessorStub = {
+  readSpriteCharacterType: (actionNumber: number) => number
+  readSpriteIsVisible: (actionNumber: number) => boolean
+  readSpritePriority: (actionNumber: number) => number
+  readSpritePosition: (actionNumber: number) => { x: number; y: number } | null
+}
+
+function createIdleAccessor(): AccessorStub {
+  return {
+    readSpriteCharacterType: () => -1,
+    readSpriteIsVisible: () => false,
+    readSpritePriority: () => 0,
+    readSpritePosition: () => null,
+  }
+}
+
+function createMovementAccessor(isVisibleRef: { value: boolean }): AccessorStub {
+  return {
+    readSpriteCharacterType: (actionNumber: number) => (actionNumber === 0 ? 2 : -1),
+    readSpriteIsVisible: (actionNumber: number) => actionNumber === 0 && isVisibleRef.value,
+    readSpritePriority: () => 0,
+    readSpritePosition: (actionNumber: number) => (actionNumber === 0 ? { x: 4, y: 7 } : null),
+  }
+}
+
+describe('useScreenAnimationLoopRenderOnly', () => {
+  const rafCallbacks = new Map<number, FrameRequestCallback>()
+  let nextRafId = 1
+
+  beforeEach(() => {
+    rafCallbacks.clear()
+    nextRafId = 1
+    updateAnimatedSpritesMock.mockClear()
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      const id = nextRafId++
+      rafCallbacks.set(id, callback)
+      return id
+    }))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => {
+      rafCallbacks.delete(id)
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  async function runNextFrame(): Promise<void> {
+    const next = rafCallbacks.entries().next()
+    if (next.done) {
+      throw new Error('No queued requestAnimationFrame callback')
+    }
+
+    const [id, callback] = next.value
+    rafCallbacks.delete(id)
+    await Promise.resolve(callback(performance.now()))
+  }
+
+  it('skips animation updates on idle frames', async () => {
+    const stop = useScreenAnimationLoopRenderOnly({
+      layers: ref({
+        spriteFrontLayer: null,
+        spriteBackLayer: null,
+      }),
+      frontSpriteNodes: ref(new Map()),
+      backSpriteNodes: ref(new Map()),
+      spritePalette: ref(1),
+      sharedDisplayBufferAccessor: createIdleAccessor() as never,
+      getPendingStaticRender: () => false,
+    })
+
+    await runNextFrame()
+
+    expect(updateAnimatedSpritesMock).not.toHaveBeenCalled()
+    stop()
+  })
+
+  it('resumes animation updates when movement becomes visible', async () => {
+    const isVisible = { value: false }
+    const onRenderNeeded = vi.fn()
+    const stop = useScreenAnimationLoopRenderOnly({
+      layers: ref({
+        spriteFrontLayer: null,
+        spriteBackLayer: null,
+      }),
+      frontSpriteNodes: ref(new Map()),
+      backSpriteNodes: ref(new Map()),
+      spritePalette: ref(1),
+      sharedDisplayBufferAccessor: createMovementAccessor(isVisible) as never,
+      getPendingStaticRender: () => false,
+      onRenderNeeded,
+    })
+
+    await runNextFrame()
+    expect(updateAnimatedSpritesMock).not.toHaveBeenCalled()
+
+    isVisible.value = true
+    await runNextFrame()
+
+    expect(onRenderNeeded).toHaveBeenCalledTimes(1)
+    expect(updateAnimatedSpritesMock).toHaveBeenCalledTimes(1)
+    stop()
+  })
+})


### PR DESCRIPTION
## Summary
- skip expensive render-only animation updates when the frame is truly idle (no visible movements, no pending static render, and no missing sprite nodes)
- keep the RAF loop alive so movement visibility changes are picked up on the next frame
- add targeted regression tests for idle skip and idle-to-active resume behavior

## Root cause
The render-only loop built isibleMovements but never used it to short-circuit work, so updateAnimatedSprites and per-frame buffer scans still ran on idle frames.

## Validation
- pnpm -s test:run -- test/ide/useScreenAnimationLoopRenderOnly.test.ts
- pnpm -s eslint src/features/ide/composables/useScreenAnimationLoopRenderOnly.ts test/ide/useScreenAnimationLoopRenderOnly.test.ts

Closes #35