### PR TITLE
fix(#68): reduce large bundle chunks in Vite build

### DIFF
--- a/src/features/ide/components/MonacoCodeEditor.vue
+++ b/src/features/ide/components/MonacoCodeEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import * as monaco from 'monaco-editor'
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
 import { onBeforeUnmount, onDeactivated, onMounted, useTemplateRef, watch } from 'vue'
 
 import { setupLiveErrorChecking, setupMonacoLanguage } from '@/features/ide/integrations/monaco-integration'

--- a/src/features/ide/integrations/monaco-integration.ts
+++ b/src/features/ide/integrations/monaco-integration.ts
@@ -11,7 +11,7 @@
  */
 
 import { useDebounceFn } from '@vueuse/core'
-import * as monaco from 'monaco-editor'
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
 
 import { parseWithChevrotain } from '@/core/parser/FBasicChevrotainParser'
 

--- a/src/features/ide/integrations/monaco-workers.ts
+++ b/src/features/ide/integrations/monaco-workers.ts
@@ -1,8 +1,4 @@
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker.js?worker'
-import CssWorker from 'monaco-editor/esm/vs/language/css/css.worker.js?worker'
-import HtmlWorker from 'monaco-editor/esm/vs/language/html/html.worker.js?worker'
-import JsonWorker from 'monaco-editor/esm/vs/language/json/json.worker.js?worker'
-import TsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker'
 
 let isConfigured = false
 
@@ -14,10 +10,9 @@ export function configureMonacoWorkers(): void {
 
   window.MonacoEnvironment = {
     getWorker(_workerId: string, label: string): Worker {
-      if (label === 'json') return new JsonWorker()
-      if (label === 'css' || label === 'scss' || label === 'less') return new CssWorker()
-      if (label === 'html' || label === 'handlebars' || label === 'razor') return new HtmlWorker()
-      if (label === 'typescript' || label === 'javascript') return new TsWorker()
+      // F-BASIC editor only needs the generic editor worker.
+      // Avoid shipping language-service workers for json/css/html/ts to keep Monaco bundles small.
+      void label
       return new EditorWorker()
     },
   }

--- a/src/types/monaco-editor-esm.d.ts
+++ b/src/types/monaco-editor-esm.d.ts
@@ -1,0 +1,3 @@
+declare module 'monaco-editor/esm/vs/editor/editor.api' {
+  export * from 'monaco-editor'
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,11 +27,55 @@ export default defineConfig({
     include: ['monaco-editor'],
   },
   build: {
-    chunkSizeWarningLimit: 4000,
     rollupOptions: {
       output: {
-        // Ensure Monaco workers are handled correctly
-        manualChunks: undefined,
+        manualChunks(id: string) {
+          const monacoPrefix = '/node_modules/monaco-editor/esm/vs/'
+          const monacoIndex = id.indexOf(monacoPrefix)
+          if (monacoIndex >= 0) {
+            const monacoPath = id.slice(monacoIndex + monacoPrefix.length)
+            const [section, group, subgroup] = monacoPath.split('/')
+            if (!section) return undefined
+
+            if (
+              monacoPath.startsWith('editor/common/model') ||
+              monacoPath.startsWith('editor/common/services') ||
+              monacoPath.startsWith('editor/common/languageFeatureRegistry')
+            ) {
+              return 'monaco-editor-common-model-services'
+            }
+            if (
+              monacoPath.startsWith('editor/browser/editorExtensions') ||
+              monacoPath.startsWith('editor/browser/services')
+            ) {
+              return 'monaco-editor-browser-extensions-services'
+            }
+            if (
+              monacoPath.startsWith('base/browser/ui') ||
+              monacoPath.startsWith('base/browser/markdownRenderer')
+            ) {
+              return 'monaco-base-browser-ui-markdown'
+            }
+            if (
+              monacoPath.startsWith('platform/actions/browser') ||
+              monacoPath.startsWith('platform/contextview/browser')
+            ) {
+              return 'monaco-platform-actions-contextview-browser'
+            }
+
+            if (section === 'editor' || section === 'base' || section === 'platform') {
+              if (group && subgroup && !subgroup.endsWith('.js')) {
+                return `monaco-${section}-${group}-${subgroup}`
+              }
+              if (group) {
+                return `monaco-${section}-${group}`
+              }
+            }
+
+            return `monaco-${section}`
+          }
+          return undefined
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- switch Monaco imports to the API-only ESM entrypoint used by the IDE integrations
- remove unused Monaco language-service workers (json/css/html/typescript) and keep only the generic editor worker used by F-BASIC
- replace the temporary chunk warning limit override with Monaco-focused manual chunking in Vite so production build runs at the default 500 kB warning threshold

## Root cause
The bundle relied on broad Monaco imports plus extra worker entrypoints, and Vite warnings were masked by `chunkSizeWarningLimit: 4000` instead of addressing chunk composition.

## Validation
- pnpm -s vite build
- pnpm -s eslint src/features/ide/components/MonacoCodeEditor.vue src/features/ide/integrations/monaco-integration.ts src/features/ide/integrations/monaco-workers.ts

## Notes
- build no longer emits the Vite chunk-size warning at the default threshold.
- Rollup still prints Monaco circular-chunk warnings from deep manual splitting (non-fatal; build succeeds).

Closes #68
