### PR TITLE
fix: #8 normalize parser diagnostic coordinates

### DIFF
--- a/src/core/parser/FBasicParser.ts
+++ b/src/core/parser/FBasicParser.ts
@@ -11,6 +11,14 @@ import type { ParserInfo } from '@/core/interfaces'
 
 import { parseWithChevrotain } from './FBasicChevrotainParser'
 
+function normalizeLocationValue(value: number | undefined, fallback = 1): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback
+  }
+  const normalized = Math.floor(value)
+  return normalized >= 1 ? normalized : fallback
+}
+
 /**
  * Parser error interface
  */
@@ -59,21 +67,27 @@ export class FBasicParser {
         const errorMessages = parseResult.errors?.map(e => e.message).join('; ') ?? 'Unknown parse error'
         return {
           success: false,
-          errors: parseResult.errors?.map(err => ({
-            message: `${err.message} (line ${err.line}, col ${err.column})`,
-            location: {
-              start: {
-                offset: 0,
-                line: err.line ?? 1,
-                column: err.column ?? 1,
+          errors: parseResult.errors?.map(err => {
+            const line = normalizeLocationValue(err.line)
+            const column = normalizeLocationValue(err.column)
+            const length = normalizeLocationValue(err.length)
+
+            return {
+              message: `${err.message} (line ${line}, col ${column})`,
+              location: {
+                start: {
+                  offset: 0,
+                  line,
+                  column,
+                },
+                end: {
+                  offset: 0,
+                  line,
+                  column: column + length,
+                },
               },
-              end: {
-                offset: 0,
-                line: err.line ?? 1,
-                column: (err.column ?? 1) + (err.length ?? 1),
-              },
-            },
-          })) ?? [
+            }
+          }) ?? [
             {
               message: errorMessages,
               location: {

--- a/test/parser/ErrorHandling.test.ts
+++ b/test/parser/ErrorHandling.test.ts
@@ -52,5 +52,21 @@ describe('Parser Error Handling', () => {
       expect(result.success).toBe(false)
       expect(result.errors).toBeDefined()
     })
+
+    it('should normalize parser diagnostics when token column is not finite', async () => {
+      const result = await parser.parse('10 PALET B 0, 15, 0, 0')
+      expect(result.success).toBe(false)
+
+      const firstError = result.errors?.[0]
+      expect(firstError).toBeDefined()
+      expect(firstError?.message).not.toContain('NaN')
+
+      const start = firstError?.location?.start
+      const end = firstError?.location?.end
+      expect(Number.isFinite(start?.line)).toBe(true)
+      expect(Number.isFinite(start?.column)).toBe(true)
+      expect(Number.isFinite(end?.line)).toBe(true)
+      expect(Number.isFinite(end?.column)).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- normalize parser diagnostic line/column/length values to finite positive integers before formatting error messages and location ranges
- prevent malformed parser token metadata from surfacing as `col NaN` in interpreter parse failures
- add regression coverage for malformed `PALET` syntax to assert no `NaN` leaks in parser diagnostics

## Validation
- pnpm -s test:run -- test/parser/ErrorHandling.test.ts test/executors/PaletExecutor.test.ts

Closes #8