### PR TITLE
fix: #11 reset STICK typematic state on lifecycle transitions

### DIFF
--- a/src/core/devices/WebWorkerDeviceAdapter.ts
+++ b/src/core/devices/WebWorkerDeviceAdapter.ts
@@ -112,6 +112,7 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
   /** Stop execution in the web worker */
   stopExecution(): void {
     this.webWorkerManager.stopExecution()
+    this.resetStickTypematicState()
   }
   /** Send a STRIG event to the web worker */
   sendStrigEvent(joystickId: number, state: number): void {
@@ -149,12 +150,16 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
   terminate(): void {
     this.webWorkerManager.terminate()
     this.messageHandler.rejectAllPending('Web worker terminated')
+    this.resetStickTypematicState()
   }
 
   // === DEVICE ADAPTER METHODS ===
   /** Enable or disable the device adapter */
   setEnabled(enabled: boolean): void {
     this.isEnabled = enabled
+    if (!enabled) {
+      this.resetStickTypematicState()
+    }
     logWorker.debug('Device adapter enabled:', enabled)
   }
 
@@ -225,7 +230,13 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
    */
   setSharedJoystickBuffer(buffer: SharedArrayBuffer): void {
     this.sharedJoystickView = createViewsFromJoystickBuffer(buffer)
+    this.resetStickTypematicState()
     logWorker.debug('[WebWorkerDeviceAdapter] Shared joystick buffer set')
+  }
+
+  private resetStickTypematicState(): void {
+    this.lastStickValue.clear()
+    this.lastStickReadTime.clear()
   }
 
   // === KEYBOARD INPUT (INKEY$) ===
@@ -685,6 +696,7 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
    */
   setCurrentExecutionId(executionId: string | null): void {
     this.screenStateManager.setCurrentExecutionId(executionId)
+    this.resetStickTypematicState()
     if (executionId) {
       // Sound state reset is now handled by SoundService in ExecutionContext.reset()
       this.screenStateManager.initializeScreen()

--- a/test/devices/WebWorkerDeviceAdapter.test.ts
+++ b/test/devices/WebWorkerDeviceAdapter.test.ts
@@ -8,6 +8,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createSharedDisplayBuffer } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
+import {
+  createSharedJoystickBuffer,
+  createViewsFromJoystickBuffer,
+  setStickState,
+} from '@/core/devices/sharedJoystickBuffer'
 import { WebWorkerDeviceAdapter } from '@/core/devices/WebWorkerDeviceAdapter'
 import type { AnyServiceWorkerMessage } from '@/core/interfaces'
 
@@ -370,6 +375,46 @@ describe('WebWorkerDeviceAdapter - Cursor Position', () => {
     const screenState = accessor.readScreenState()
 
     expect(screenState.buffer[0]?.[0]?.character).toBe('E')
+  })
+})
+
+describe('WebWorkerDeviceAdapter - STICK typematic lifecycle reset', () => {
+  let adapter: WebWorkerDeviceAdapter
+  let joystickView: ReturnType<typeof createViewsFromJoystickBuffer>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    adapter = new WebWorkerDeviceAdapter()
+    const joystickBuffer = createSharedJoystickBuffer()
+    joystickView = createViewsFromJoystickBuffer(joystickBuffer)
+    adapter.setSharedJoystickBuffer(joystickBuffer)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should return held direction immediately after execution restart', () => {
+    setStickState(joystickView, 0, 8)
+    expect(adapter.getStickState(0)).toBe(8)
+
+    vi.advanceTimersByTime(1)
+    expect(adapter.getStickState(0)).toBe(0)
+
+    adapter.setCurrentExecutionId(null)
+    adapter.setCurrentExecutionId('run-2')
+    expect(adapter.getStickState(0)).toBe(8)
+  })
+
+  it('should reset typematic suppression when execution is stopped', () => {
+    setStickState(joystickView, 0, 4)
+    expect(adapter.getStickState(0)).toBe(4)
+
+    vi.advanceTimersByTime(1)
+    expect(adapter.getStickState(0)).toBe(0)
+
+    adapter.stopExecution()
+    expect(adapter.getStickState(0)).toBe(4)
   })
 })
 


### PR DESCRIPTION
## Summary
- reset STICK typematic tracking when execution lifecycle boundaries change
- clear typematic maps on execution start/stop, adapter disable, worker termination, and shared joystick buffer reset
- add regression tests for hold-stop-restart and hold-stop-first-read behavior

## Testing
- pnpm -s test:run -- test/devices/WebWorkerDeviceAdapter.test.ts
- pnpm -s eslint src/core/devices/WebWorkerDeviceAdapter.ts test/devices/WebWorkerDeviceAdapter.test.ts

Closes #11