### PR TITLE
fix: #14 disable always-on render-loop debug/error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ GitHub Pages deployment is automated via `.github/workflows/deploy-pages.yml`:
 - Publish directory: `dist`
 - SPA fallback: `dist/404.html` mirrors `dist/index.html` for refresh-safe routing
 
+## Dev Debug Toggles
+
+- Render-only animation loop tracing is disabled by default.
+- To enable it in local development, set `VITE_DEBUG_ANIMATION_LOOP=true` before running `pnpm dev`.
+
 ## Contributing
 
 1. Fork, branch, code

--- a/src/features/ide/composables/useScreenAnimationLoopRenderOnly.ts
+++ b/src/features/ide/composables/useScreenAnimationLoopRenderOnly.ts
@@ -18,8 +18,8 @@ import { logScreen } from '@/shared/logger'
 import type { KonvaScreenLayers } from './useKonvaScreenRenderer'
 import { updateAnimatedSprites } from './useKonvaScreenRenderer'
 
-/** Enable detailed animation loop tracing */
-const DEBUG_ANIMATION_LOOP = true
+/** Dev-only render-loop trace toggle (set VITE_DEBUG_ANIMATION_LOOP=true in local env). */
+const DEBUG_ANIMATION_LOOP = import.meta.env.DEV && import.meta.env.VITE_DEBUG_ANIMATION_LOOP === 'true'
 
 export interface UseScreenAnimationLoopRenderOnlyOptions {
   layers: Ref<KonvaScreenLayers | Record<string, unknown>>
@@ -208,7 +208,7 @@ export function useScreenAnimationLoopRenderOnly(
   // Start the loop immediately
   animationFrameId = requestAnimationFrame(animationLoop)
   if (DEBUG_ANIMATION_LOOP) {
-    logScreen.error('[RENDER-ONLY LOOP] Started continuous animation loop at 60fps')
+    logScreen.debug('[RENDER-ONLY LOOP] Started continuous animation loop at 60fps')
   }
 
   // Return cleanup function


### PR DESCRIPTION
## Summary
- disable render-loop debug tracing by default in normal builds
- make render-loop startup trace dev-only behind `VITE_DEBUG_ANIMATION_LOOP=true`
- downgrade startup trace severity from `error` to `debug`
- document the dev toggle in README

## Validation
- pnpm -s eslint src/features/ide/composables/useScreenAnimationLoopRenderOnly.ts
- pnpm -s test:run -- test/ide/useScreenAnimationLoopRenderOnly.test.ts

Closes #14