### PR TITLE
test: #62 replace toContain matcher usage

### DIFF
--- a/test/bg-editor/bgCompression.test.ts
+++ b/test/bg-editor/bgCompression.test.ts
@@ -45,9 +45,9 @@ describe('bgCompression', () => {
       const compressed = compressBg(grid)
 
       expect(compressed.format).toBe('sparse1')
-      expect(compressed.data).toContain('0,0,65,1')
-      expect(compressed.data).toContain('5,10,66,2')
-      expect(compressed.data).toContain('27,20,67,3')
+      expect(compressed.data).toMatch(/0,0,65,1/)
+      expect(compressed.data).toMatch(/5,10,66,2/)
+      expect(compressed.data).toMatch(/27,20,67,3/)
     })
 
     it('should compress dense grid using RLE format', () => {

--- a/test/devices/MessageHandler.test.ts
+++ b/test/devices/MessageHandler.test.ts
@@ -66,7 +66,7 @@ describe('MessageHandler', () => {
     expect(resolve).not.toHaveBeenCalled()
     expect(reject).toHaveBeenCalledTimes(1)
     expect(reject.mock.calls[0]?.[0]).toBeInstanceOf(Error)
-    expect((reject.mock.calls[0]?.[0] as Error).message).toContain('falling back to main thread')
+    expect((reject.mock.calls[0]?.[0] as Error).message).toMatch(/falling back to main thread/)
     expect(pendingMessages.has(messageId)).toBe(false)
   })
 

--- a/test/evaluation/StickStrigFunctions.test.ts
+++ b/test/evaluation/StickStrigFunctions.test.ts
@@ -192,8 +192,8 @@ describe('STICK and STRIG Functions', () => {
 
       const outputs = deviceAdapter.getAllOutputs()
       // Should see both outputs: first 1 (RIGHT), then 8 (UP)
-      expect(outputs).toContain(' 1\n')
-      expect(outputs).toContain(' 8\n')
+      expect(outputs).toMatch(/ 1\n/)
+      expect(outputs).toMatch(/ 8\n/)
     })
 
     it('should return 0 after release', async () => {

--- a/test/executors/CgenExecutor.test.ts
+++ b/test/executors/CgenExecutor.test.ts
@@ -151,7 +151,7 @@ describe('CgenExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0]?.message).toContain('CGEN: Mode out of range (0-3)')
+    expect(result.errors[0]?.message).toMatch(/CGEN: Mode out of range \(0-3\)/)
     expect(deviceAdapter.cgenModeCalls).toHaveLength(0)
   })
 
@@ -164,7 +164,7 @@ describe('CgenExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0]?.message).toContain('CGEN: Mode out of range (0-3)')
+    expect(result.errors[0]?.message).toMatch(/CGEN: Mode out of range \(0-3\)/)
     expect(deviceAdapter.cgenModeCalls).toHaveLength(0)
   })
 
@@ -177,7 +177,7 @@ describe('CgenExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0]?.message).toContain('CGEN: Mode out of range (0-3)')
+    expect(result.errors[0]?.message).toMatch(/CGEN: Mode out of range \(0-3\)/)
     expect(deviceAdapter.cgenModeCalls).toHaveLength(0)
   })
 
@@ -206,6 +206,6 @@ describe('CgenExecutor', () => {
     expect(result.errors).toHaveLength(0)
     expect(deviceAdapter.cgenModeCalls).toHaveLength(1)
     expect(deviceAdapter.cgenModeCalls[0]).toBe(0)
-    expect(deviceAdapter.printOutputs).toContain('HELLO\n')
+    expect(deviceAdapter.printOutputs).toEqual(expect.arrayContaining(['HELLO\n']))
   })
 })

--- a/test/executors/CgsetExecutor.test.ts
+++ b/test/executors/CgsetExecutor.test.ts
@@ -162,7 +162,7 @@ describe('CgsetExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Background palette code out of range (0-1)')
+    expect(result.errors[0]?.message).toMatch(/Background palette code out of range \(0-1\)/)
   })
 
   it('should report error when background palette is out of range (too large)', async () => {
@@ -174,7 +174,7 @@ describe('CgsetExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Background palette code out of range (0-1)')
+    expect(result.errors[0]?.message).toMatch(/Background palette code out of range \(0-1\)/)
   })
 
   it('should report error when sprite palette is out of range (negative)', async () => {
@@ -186,7 +186,7 @@ describe('CgsetExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Sprite palette code out of range (0-2)')
+    expect(result.errors[0]?.message).toMatch(/Sprite palette code out of range \(0-2\)/)
   })
 
   it('should report error when sprite palette is out of range (too large)', async () => {
@@ -198,7 +198,7 @@ describe('CgsetExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Sprite palette code out of range (0-2)')
+    expect(result.errors[0]?.message).toMatch(/Sprite palette code out of range \(0-2\)/)
   })
 
   it('should handle CGSET with all valid background palette values', async () => {

--- a/test/executors/ColorExecutor.test.ts
+++ b/test/executors/ColorExecutor.test.ts
@@ -134,7 +134,7 @@ describe('ColorExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('X coordinate out of range (0-27)')
+    expect(result.errors[0]?.message).toMatch(/X coordinate out of range \(0-27\)/)
   })
 
   it('should report error when X coordinate is out of range (too large)', async () => {
@@ -146,7 +146,7 @@ describe('ColorExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('X coordinate out of range (0-27)')
+    expect(result.errors[0]?.message).toMatch(/X coordinate out of range \(0-27\)/)
   })
 
   it('should report error when Y coordinate is out of range (negative)', async () => {
@@ -158,7 +158,7 @@ describe('ColorExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Y coordinate out of range (0-23)')
+    expect(result.errors[0]?.message).toMatch(/Y coordinate out of range \(0-23\)/)
   })
 
   it('should report error when Y coordinate is out of range (too large)', async () => {
@@ -170,7 +170,7 @@ describe('ColorExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Y coordinate out of range (0-23)')
+    expect(result.errors[0]?.message).toMatch(/Y coordinate out of range \(0-23\)/)
   })
 
   it('should report error when color pattern is out of range (negative)', async () => {
@@ -182,7 +182,7 @@ describe('ColorExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Color pattern number out of range (0-3)')
+    expect(result.errors[0]?.message).toMatch(/Color pattern number out of range \(0-3\)/)
   })
 
   it('should report error when color pattern is out of range (too large)', async () => {
@@ -194,7 +194,7 @@ describe('ColorExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Color pattern number out of range (0-3)')
+    expect(result.errors[0]?.message).toMatch(/Color pattern number out of range \(0-3\)/)
   })
 
   it('should handle COLOR with expressions that evaluate to non-integers (floor conversion)', async () => {

--- a/test/executors/InputExecutor.test.ts
+++ b/test/executors/InputExecutor.test.ts
@@ -116,6 +116,6 @@ describe('InputExecutor', () => {
     const result = await interp.execute(source)
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('not supported')
+    expect(result.errors[0]?.message).toMatch(/not supported/)
   })
 })

--- a/test/executors/LinputExecutor.test.ts
+++ b/test/executors/LinputExecutor.test.ts
@@ -69,7 +69,7 @@ describe('LinputExecutor', () => {
     const result = await interpreter.execute(source)
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('string variable')
+    expect(result.errors[0]?.message).toMatch(/string variable/)
   })
 
   it('should add error when device has no requestInput', async () => {
@@ -89,6 +89,6 @@ describe('LinputExecutor', () => {
 `
     const result = await interp.execute(source)
     expect(result.success).toBe(false)
-    expect(result.errors[0]?.message).toContain('not supported')
+    expect(result.errors[0]?.message).toMatch(/not supported/)
   })
 })

--- a/test/executors/LocateExecutor.test.ts
+++ b/test/executors/LocateExecutor.test.ts
@@ -108,7 +108,7 @@ describe('LocateExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('X coordinate out of range')
+    expect(result.errors[0]?.message).toMatch(/X coordinate out of range/)
   })
 
   it('should error when X coordinate is out of range (too large)', async () => {
@@ -120,7 +120,7 @@ describe('LocateExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('X coordinate out of range')
+    expect(result.errors[0]?.message).toMatch(/X coordinate out of range/)
   })
 
   it('should error when Y coordinate is out of range (negative)', async () => {
@@ -132,7 +132,7 @@ describe('LocateExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Y coordinate out of range')
+    expect(result.errors[0]?.message).toMatch(/Y coordinate out of range/)
   })
 
   it('should error when Y coordinate is out of range (too large)', async () => {
@@ -144,7 +144,7 @@ describe('LocateExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Y coordinate out of range')
+    expect(result.errors[0]?.message).toMatch(/Y coordinate out of range/)
   })
 
   it('should handle LOCATE on same line as other commands', async () => {

--- a/test/executors/PaletExecutor.test.ts
+++ b/test/executors/PaletExecutor.test.ts
@@ -176,7 +176,7 @@ describe('PaletExecutor', () => {
 
       expect(result.success).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
-      expect(result.errors[0]?.message).toContain('PALET')
+      expect(result.errors[0]?.message).toMatch(/PALET/)
     })
 
     it('should report error for missing arguments', async () => {
@@ -201,7 +201,7 @@ describe('PaletExecutor', () => {
 
       expect(result.success).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
-      expect(result.errors[0]?.message).toContain('Color combination number out of range')
+      expect(result.errors[0]?.message).toMatch(/Color combination number out of range/)
     })
 
     it('should report error for color code out of range', async () => {
@@ -213,7 +213,7 @@ describe('PaletExecutor', () => {
 
       expect(result.success).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
-      expect(result.errors[0]?.message).toContain('Color code out of range')
+      expect(result.errors[0]?.message).toMatch(/Color code out of range/)
     })
 
     it('should report error for negative color code', async () => {
@@ -225,7 +225,7 @@ describe('PaletExecutor', () => {
 
       expect(result.success).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
-      expect(result.errors[0]?.message).toContain('Color code out of range')
+      expect(result.errors[0]?.message).toMatch(/Color code out of range/)
     })
   })
 

--- a/test/executors/PlayExecutor.test.ts
+++ b/test/executors/PlayExecutor.test.ts
@@ -152,7 +152,7 @@ describe('PlayExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Expected string')
+    expect(result.errors[0]?.message).toMatch(/Expected string/)
   })
 
   it('should handle PLAY with string concatenation', async () => {

--- a/test/executors/SwapExecutor.test.ts
+++ b/test/executors/SwapExecutor.test.ts
@@ -116,7 +116,7 @@ describe('SwapExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message ?? '').toContain('type mismatch')
+    expect(result.errors[0]?.message ?? '').toMatch(/type mismatch/)
   })
 
   it('should handle SWAP on same line as other commands', async () => {

--- a/test/executors/ViewExecutor.test.ts
+++ b/test/executors/ViewExecutor.test.ts
@@ -61,8 +61,8 @@ describe('ViewExecutor', () => {
     expect(result.errors).toHaveLength(0)
     expect(deviceAdapter.copyBgGraphicToBackgroundCalls).toBe(1)
     const outputs = deviceAdapter.getAllOutputs()
-    expect(outputs).toContain('Before')
-    expect(outputs).toContain('After')
+    expect(outputs).toMatch(/Before/)
+    expect(outputs).toMatch(/After/)
   })
 
   it('should handle VIEW in a loop', async () => {
@@ -92,7 +92,7 @@ describe('ViewExecutor', () => {
     expect(result.errors).toHaveLength(0)
     expect(deviceAdapter.copyBgGraphicToBackgroundCalls).toBe(1)
     const outputs = deviceAdapter.getAllOutputs()
-    expect(outputs).toContain('Done')
+    expect(outputs).toMatch(/Done/)
   })
 
   it('should handle VIEW after CLS', async () => {

--- a/test/integration/AsyncExecution.test.ts
+++ b/test/integration/AsyncExecution.test.ts
@@ -42,8 +42,8 @@ describe('Async Execution - Production Mode', () => {
 
     // Verify all iterations executed
     const outputs = deviceAdapter.getAllOutputs()
-    expect(outputs).toContain('Loop  1')
-    expect(outputs).toContain('Loop  500')
+    expect(outputs).toMatch(/Loop {2}1/)
+    expect(outputs).toMatch(/Loop {2}500/)
   }, 10000) // 10 second timeout
 
   it('should yield during GOTO loop with many iterations', async () => {
@@ -107,7 +107,7 @@ describe('Async Execution - Production Mode', () => {
     expect(result.success).toBe(true)
     const outputs = deviceAdapter.getAllOutputs()
     // Should not print "Done" since we stopped execution
-    expect(outputs).not.toContain('Done')
+    expect(outputs).not.toMatch(/Done/)
   }, 10000)
 })
 

--- a/test/integration/PlayIntegration.test.ts
+++ b/test/integration/PlayIntegration.test.ts
@@ -204,7 +204,7 @@ describe('PLAY Integration', () => {
 
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
-    expect(result.errors[0]?.message).toContain('Expected string')
+    expect(result.errors[0]?.message).toMatch(/Expected string/)
     expect(deviceAdapter.playSoundCalls).toEqual([])
   })
 

--- a/test/integration/SampleDisplaySnapshot.test.ts
+++ b/test/integration/SampleDisplaySnapshot.test.ts
@@ -99,7 +99,7 @@ describe('Sample Display Snapshot Integration', () => {
       checkpoint: 'stopped',
     })
 
-    expect(rowTextFromSnapshot(snapshot, 0)).toContain('JOYSTICK TEST')
+    expect(rowTextFromSnapshot(snapshot, 0)).toMatch(/JOYSTICK TEST/)
     expect(snapshot.sequence).toBeGreaterThan(0)
   })
 })

--- a/test/parser/SampleCodesVerification.test.ts
+++ b/test/parser/SampleCodesVerification.test.ts
@@ -43,7 +43,7 @@ describe('New screen function sample codes', () => {
   test('all new sample code keys exist', () => {
     const allKeys = getSampleCodeKeys()
     for (const key of newSampleKeys) {
-      expect(allKeys).toContain(key)
+      expect(allKeys).toEqual(expect.arrayContaining([key]))
     }
   })
 


### PR DESCRIPTION
## Summary
- replace remaining .toContain() assertions across test files with explicit matchers (	oMatch for string fragments and rrayContaining for membership)
- keep assertion intent unchanged while aligning with the matcher convention tracked in issue #62
- preserve targeted test behavior and lint compliance for updated assertions

## Validation
- pnpm -s test:run -- test/bg-editor/bgCompression.test.ts test/devices/MessageHandler.test.ts test/evaluation/StickStrigFunctions.test.ts test/executors/CgenExecutor.test.ts test/executors/CgsetExecutor.test.ts test/executors/ColorExecutor.test.ts test/executors/InputExecutor.test.ts test/executors/LinputExecutor.test.ts test/executors/LocateExecutor.test.ts test/executors/PaletExecutor.test.ts test/executors/PlayExecutor.test.ts test/executors/SwapExecutor.test.ts test/executors/ViewExecutor.test.ts test/integration/AsyncExecution.test.ts test/integration/PlayIntegration.test.ts test/integration/SampleDisplaySnapshot.test.ts test/parser/SampleCodesVerification.test.ts
- pnpm -s eslint test/bg-editor/bgCompression.test.ts test/devices/MessageHandler.test.ts test/evaluation/StickStrigFunctions.test.ts test/executors/CgenExecutor.test.ts test/executors/CgsetExecutor.test.ts test/executors/ColorExecutor.test.ts test/executors/InputExecutor.test.ts test/executors/LinputExecutor.test.ts test/executors/LocateExecutor.test.ts test/executors/PaletExecutor.test.ts test/executors/PlayExecutor.test.ts test/executors/SwapExecutor.test.ts test/executors/ViewExecutor.test.ts test/integration/AsyncExecution.test.ts test/integration/PlayIntegration.test.ts test/integration/SampleDisplaySnapshot.test.ts test/parser/SampleCodesVerification.test.ts

Closes #62