### PR TITLE
fix: #77 surface COI service worker registration failures in UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
-import { watch } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import ErrorBoundary from './shared/components/ErrorBoundary.vue'
+import GameButton from './shared/components/ui/GameButton.vue'
+import GameIcon from './shared/components/ui/GameIcon.vue'
 import { useSkin } from './shared/composables/useSkin'
+import {
+  COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT,
+  type CoiServiceWorkerRegistrationFailedDetail,
+} from './shared/constants/coiServiceWorker'
+import { reloadPage } from './shared/utils/reloadPage'
 
 /**
  * App component - Root component of the application.
@@ -16,6 +23,18 @@ defineOptions({
 })
 
 const { locale } = useI18n()
+const showCoiWarning = ref(false)
+
+const handleCoiServiceWorkerRegistrationFailed = (event: Event) => {
+  const customEvent = event as CustomEvent<CoiServiceWorkerRegistrationFailedDetail>
+  if (customEvent.detail?.errorMessage) {
+    showCoiWarning.value = true
+  }
+}
+
+const dismissCoiWarning = () => {
+  showCoiWarning.value = false
+}
 
 // Initialize skin system early
 const { currentSkin: _currentSkin } = useSkin()
@@ -30,14 +49,82 @@ watch(
   },
   { immediate: true }
 )
+
+onMounted(() => {
+  window.addEventListener(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, handleCoiServiceWorkerRegistrationFailed)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, handleCoiServiceWorkerRegistrationFailed)
+})
 </script>
 
 <template>
   <ErrorBoundary name="AppRoot">
+    <section v-if="showCoiWarning" class="coi-warning-banner" role="status" aria-live="polite">
+      <div class="coi-warning-content">
+        <GameIcon icon="mdi:alert" size="small" />
+        <p>
+          High-performance mode is unavailable because cross-origin isolation is not enabled.
+          Try reloading, use HTTPS, and confirm COOP/COEP headers are configured.
+        </p>
+      </div>
+      <div class="coi-warning-actions">
+        <GameButton type="warning" size="small" @click="reloadPage">Reload</GameButton>
+        <GameButton size="small" @click="dismissCoiWarning">Dismiss</GameButton>
+      </div>
+    </section>
     <router-view />
   </ErrorBoundary>
 </template>
 
-<style>
-/* Global styles */
+<style scoped>
+.coi-warning-banner {
+  position: sticky;
+  top: 0;
+  z-index: 900;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--semantic-solid-warning);
+  background: linear-gradient(
+    90deg,
+    var(--semantic-alpha-warning-30) 0%,
+    var(--semantic-alpha-warning-10) 100%
+  );
+}
+
+.coi-warning-content {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 280px;
+}
+
+.coi-warning-content p {
+  margin: 0;
+  color: var(--game-text-primary);
+  font-family: var(--game-font-family);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.coi-warning-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+@media (width <= 720px) {
+  .coi-warning-actions {
+    width: 100%;
+  }
+
+  .coi-warning-actions :deep(.game-button) {
+    flex: 1;
+  }
+}
 </style>

--- a/src/coi-serviceworker-client.ts
+++ b/src/coi-serviceworker-client.ts
@@ -1,3 +1,9 @@
+import {
+  COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT,
+  type CoiServiceWorkerRegistrationFailedDetail,
+} from '@/shared/constants/coiServiceWorker'
+import { logApp } from '@/shared/logger'
+
 if (typeof window !== 'undefined') {
   // Register service worker only when cross-origin isolation is still missing.
   if (window.crossOriginIsolated === false && window.isSecureContext && 'serviceWorker' in navigator) {
@@ -14,7 +20,16 @@ if (typeof window !== 'undefined') {
           window.location.reload()
         })
       } catch (error) {
-        console.error('[coi-serviceworker] registration failed:', error)
+        const detail: CoiServiceWorkerRegistrationFailedDetail = {
+          errorMessage: error instanceof Error ? error.message : String(error),
+        }
+        const warningEvent = new CustomEvent<CoiServiceWorkerRegistrationFailedDetail>(
+          COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT,
+          { detail }
+        )
+
+        window.dispatchEvent(warningEvent)
+        logApp.debug('[coi-serviceworker] registration failed:', error)
       }
     })
   }

--- a/src/shared/constants/coiServiceWorker.ts
+++ b/src/shared/constants/coiServiceWorker.ts
@@ -1,0 +1,5 @@
+export const COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT = 'coi-serviceworker:registration-failed'
+
+export interface CoiServiceWorkerRegistrationFailedDetail {
+  errorMessage: string
+}

--- a/src/shared/utils/reloadPage.ts
+++ b/src/shared/utils/reloadPage.ts
@@ -1,0 +1,3 @@
+export const reloadPage = (): void => {
+  window.location.reload()
+}

--- a/test/App.test.ts
+++ b/test/App.test.ts
@@ -1,0 +1,86 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import App from '@/App.vue'
+import { COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT } from '@/shared/constants/coiServiceWorker'
+import { reloadPage } from '@/shared/utils/reloadPage'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    locale: ref('en'),
+  }),
+}))
+
+vi.mock('@/shared/composables/useSkin', () => ({
+  useSkin: () => ({
+    currentSkin: ref('default'),
+  }),
+}))
+
+vi.mock('@/shared/utils/reloadPage', () => ({
+  reloadPage: vi.fn(),
+}))
+
+describe('App', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows warning banner when coi registration failure event is received', async () => {
+    const wrapper = mount(App)
+
+    window.dispatchEvent(
+      new CustomEvent(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, {
+        detail: { errorMessage: 'registration blocked' },
+      })
+    )
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.coi-warning-banner').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('dismisses warning banner when dismiss button is clicked', async () => {
+    const wrapper = mount(App)
+
+    window.dispatchEvent(
+      new CustomEvent(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, {
+        detail: { errorMessage: 'registration blocked' },
+      })
+    )
+    await wrapper.vm.$nextTick()
+
+    const dismissButton = wrapper
+      .findAll('button')
+      .find(button => button.text().trim() === 'Dismiss')
+    expect(dismissButton).toBeTruthy()
+
+    await dismissButton!.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.coi-warning-banner').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('reloads page when reload button is clicked', async () => {
+    const wrapper = mount(App)
+
+    window.dispatchEvent(
+      new CustomEvent(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, {
+        detail: { errorMessage: 'registration blocked' },
+      })
+    )
+    await wrapper.vm.$nextTick()
+
+    const reloadButton = wrapper
+      .findAll('button')
+      .find(button => button.text().trim() === 'Reload')
+    expect(reloadButton).toBeTruthy()
+
+    await reloadButton!.trigger('click')
+
+    expect(reloadPage).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+})

--- a/test/core/coiServiceWorkerClient.test.ts
+++ b/test/core/coiServiceWorkerClient.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT } from '@/shared/constants/coiServiceWorker'
+
+describe('coi-serviceworker-client', () => {
+  const register = vi.fn()
+  const addServiceWorkerListener = vi.fn()
+  let loadHandler: (() => void | Promise<void>) | undefined
+
+  beforeEach(() => {
+    vi.resetModules()
+    register.mockReset()
+    addServiceWorkerListener.mockReset()
+    loadHandler = undefined
+
+    Object.defineProperty(window, 'crossOriginIsolated', {
+      configurable: true,
+      value: false,
+    })
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    })
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        register,
+        controller: null,
+        addEventListener: addServiceWorkerListener,
+      } satisfies Pick<ServiceWorkerContainer, 'register' | 'controller' | 'addEventListener'>,
+    })
+
+    const originalAddEventListener = window.addEventListener.bind(window)
+    vi.spyOn(window, 'addEventListener').mockImplementation((type, listener, options) => {
+      if (type === 'load') {
+        loadHandler = listener as () => void | Promise<void>
+        return
+      }
+      originalAddEventListener(type, listener as EventListener, options)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Object.defineProperty(window, 'crossOriginIsolated', {
+      configurable: true,
+      value: undefined,
+    })
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: undefined,
+    })
+  })
+
+  it('dispatches a UI warning event when registration fails', async () => {
+    register.mockRejectedValueOnce(new Error('registration blocked'))
+    const listener = vi.fn()
+    window.addEventListener(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, listener)
+
+    await import('@/coi-serviceworker-client')
+    expect(loadHandler).toBeTypeOf('function')
+    await loadHandler?.()
+
+    expect(register).toHaveBeenCalledWith('/coi-serviceworker.js')
+    expect(listener).toHaveBeenCalledTimes(1)
+    const customEvent = listener.mock.calls[0]?.[0] as CustomEvent<{ errorMessage: string }>
+    expect(customEvent.detail.errorMessage).toBe('registration blocked')
+
+    window.removeEventListener(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, listener)
+  })
+
+  it('does not dispatch warning event when registration succeeds', async () => {
+    register.mockResolvedValueOnce({ active: false })
+    const listener = vi.fn()
+    window.addEventListener(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, listener)
+
+    await import('@/coi-serviceworker-client')
+    expect(loadHandler).toBeTypeOf('function')
+    await loadHandler?.()
+
+    expect(register).toHaveBeenCalledWith('/coi-serviceworker.js')
+    expect(listener).not.toHaveBeenCalled()
+    expect(addServiceWorkerListener).toHaveBeenCalledWith('controllerchange', expect.any(Function))
+
+    window.removeEventListener(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, listener)
+  })
+
+  it('skips registration when cross origin isolation is already enabled', async () => {
+    Object.defineProperty(window, 'crossOriginIsolated', {
+      configurable: true,
+      value: true,
+    })
+
+    await import('@/coi-serviceworker-client')
+    expect(loadHandler).toBeUndefined()
+
+    expect(register).not.toHaveBeenCalled()
+    expect(addServiceWorkerListener).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- dispatch a browser event when COI service worker registration fails so UI can react
- show a dismissible app-level warning banner with actionable guidance and a Reload action
- keep failure logging at debug level and add focused regression coverage for event emission

## Validation
- pnpm -s test:run -- test/core/coiServiceWorkerClient.test.ts
- pnpm -s eslint src/coi-serviceworker-client.ts src/App.vue src/shared/constants/coiServiceWorker.ts test/core/coiServiceWorkerClient.test.ts

Closes #77