### PR TITLE
chore: #79 add .gitattributes line-ending policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+* text=auto
+
+# Source and config files use LF across platforms.
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
+*.vue text eol=lf
+*.css text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+.gitattributes text eol=lf
+
+# Native Windows scripts keep CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf


### PR DESCRIPTION
## Summary
- add a root .gitattributes file to standardize line endings
- enforce LF for source/config/docs file types used by the repo
- preserve CRLF for Windows-native .bat/.cmd/.ps1 scripts
- include explicit LF policy for .gitattributes itself

## Local targeted checks
- git check-attr eol -- src/core/parser/FBasicParser.ts README.md package.json scripts/scheduled-agent/run-turn.bat scripts/scheduled-agent/setup-task.ps1

Closes #79