### PR TITLE
fix: #34 throttle inspector MOVE tab updates in render-only loop

### DIFF
--- a/src/features/ide/composables/useScreenAnimationLoopRenderOnly.ts
+++ b/src/features/ide/composables/useScreenAnimationLoopRenderOnly.ts
@@ -20,6 +20,7 @@ import { updateAnimatedSprites } from './useKonvaScreenRenderer'
 
 /** Dev-only render-loop trace toggle (set VITE_DEBUG_ANIMATION_LOOP=true in local env). */
 const DEBUG_ANIMATION_LOOP = import.meta.env.DEV && import.meta.env.VITE_DEBUG_ANIMATION_LOOP === 'true'
+const INSPECTOR_UPDATE_INTERVAL_MS = 1000 / 15
 
 export interface UseScreenAnimationLoopRenderOnlyOptions {
   layers: Ref<KonvaScreenLayers | Record<string, unknown>>
@@ -71,6 +72,7 @@ export function useScreenAnimationLoopRenderOnly(
   // Track last positions to detect changes (dirty tracking)
   const lastPositions = new Map<number, { x: number; y: number }>()
   let needsRedraw = false
+  let lastInspectorUpdateAt = Number.NEGATIVE_INFINITY
 
   /**
    * Animation loop - runs continuously at 60fps
@@ -79,7 +81,7 @@ export function useScreenAnimationLoopRenderOnly(
    * Detects orphaned nodes (nodes that exist but shouldn't be visible) and removes them
    * Uses dirty tracking to only redraw when positions actually change
    */
-  async function animationLoop(): Promise<void> {
+  async function animationLoop(timestamp = 0): Promise<void> {
     if (!sharedDisplayBufferAccessor) {
       animationFrameId = requestAnimationFrame(animationLoop)
       return
@@ -192,8 +194,13 @@ export function useScreenAnimationLoopRenderOnly(
 
     // Update inspector MOVE tab data with all sprite state (position, direction, speed, etc.)
     // Throttle to ~15fps instead of 60fps to reduce Vue reactivity overhead
-    if (updateInspectorMoveSlots && needsRedraw) {
+    if (
+      updateInspectorMoveSlots
+      && needsRedraw
+      && timestamp - lastInspectorUpdateAt >= INSPECTOR_UPDATE_INTERVAL_MS
+    ) {
       updateInspectorMoveSlots()
+      lastInspectorUpdateAt = timestamp
     }
 
     // Run pending static render at end of frame (animation first, then render)

--- a/test/ide/useScreenAnimationLoopRenderOnly.test.ts
+++ b/test/ide/useScreenAnimationLoopRenderOnly.test.ts
@@ -58,7 +58,7 @@ describe('useScreenAnimationLoopRenderOnly', () => {
     vi.unstubAllGlobals()
   })
 
-  async function runNextFrame(): Promise<void> {
+  async function runNextFrame(atMs = performance.now()): Promise<void> {
     const next = rafCallbacks.entries().next()
     if (next.done) {
       throw new Error('No queued requestAnimationFrame callback')
@@ -66,7 +66,7 @@ describe('useScreenAnimationLoopRenderOnly', () => {
 
     const [id, callback] = next.value
     rafCallbacks.delete(id)
-    await Promise.resolve(callback(performance.now()))
+    await Promise.resolve(callback(atMs))
   }
 
   it('skips animation updates on idle frames', async () => {
@@ -112,6 +112,46 @@ describe('useScreenAnimationLoopRenderOnly', () => {
 
     expect(onRenderNeeded).toHaveBeenCalledTimes(1)
     expect(updateAnimatedSpritesMock).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('throttles inspector MOVE updates to around 15fps under continuous movement', async () => {
+    let x = 0
+    const updateInspectorMoveSlots = vi.fn()
+    const spriteNode = {
+      x: vi.fn(),
+      y: vi.fn(),
+      destroy: vi.fn(),
+    }
+    const accessor: AccessorStub = {
+      readSpriteCharacterType: (actionNumber: number) => (actionNumber === 0 ? 2 : -1),
+      readSpriteIsVisible: (actionNumber: number) => actionNumber === 0,
+      readSpritePriority: () => 0,
+      readSpritePosition: (actionNumber: number) => {
+        if (actionNumber !== 0) return null
+        x += 1
+        return { x, y: 7 }
+      },
+    }
+
+    const stop = useScreenAnimationLoopRenderOnly({
+      layers: ref({
+        spriteFrontLayer: null,
+        spriteBackLayer: null,
+      }),
+      frontSpriteNodes: ref(new Map([[0, spriteNode]])),
+      backSpriteNodes: ref(new Map()),
+      spritePalette: ref(1),
+      sharedDisplayBufferAccessor: accessor as never,
+      getPendingStaticRender: () => false,
+      updateInspectorMoveSlots,
+    })
+
+    for (let frame = 0; frame < 8; frame += 1) {
+      await runNextFrame(frame * 16)
+    }
+
+    expect(updateInspectorMoveSlots).toHaveBeenCalledTimes(2)
     stop()
   })
 })


### PR DESCRIPTION
## Summary
- throttle `updateInspectorMoveSlots()` in `useScreenAnimationLoopRenderOnly` to ~15fps using the RAF timestamp
- keep sprite render updates on the normal 60fps loop
- add regression test that simulates continuous movement and verifies inspector updates are rate-limited

## Root cause
- inspector MOVE tab updates were called on every dirty animation frame despite a comment saying they should be throttled

## Validation
- `pnpm -s test:run -- test/ide/useScreenAnimationLoopRenderOnly.test.ts`
- `pnpm -s eslint src/features/ide/composables/useScreenAnimationLoopRenderOnly.ts test/ide/useScreenAnimationLoopRenderOnly.test.ts`

Closes #34