### PR TITLE
refactor: #5 extract ScreenUpdateBatcher from WebWorkerDeviceAdapter

### DIFF
--- a/src/core/devices/ScreenUpdateBatcher.ts
+++ b/src/core/devices/ScreenUpdateBatcher.ts
@@ -1,0 +1,67 @@
+type ScreenUpdateBatcherOptions = {
+  targetFps?: number
+  maxBatchDelayMs?: number
+}
+
+const DEFAULT_TARGET_FPS = 60
+const DEFAULT_MAX_BATCH_DELAY_MS = 33
+
+/**
+ * Batches screen flush requests to align updates with a target frame rate.
+ */
+export class ScreenUpdateBatcher {
+  private pendingScreenUpdate = false
+  private screenUpdateTimeout: number | null = null
+  private lastScreenUpdateTime = 0
+  private readonly frameIntervalMs: number
+  private readonly maxBatchDelayMs: number
+
+  constructor(
+    private readonly flushCallback: () => void,
+    options: ScreenUpdateBatcherOptions = {}
+  ) {
+    const targetFps = options.targetFps ?? DEFAULT_TARGET_FPS
+    this.frameIntervalMs = 1000 / targetFps
+    this.maxBatchDelayMs = options.maxBatchDelayMs ?? DEFAULT_MAX_BATCH_DELAY_MS
+  }
+
+  schedule(): void {
+    this.pendingScreenUpdate = true
+
+    if (this.screenUpdateTimeout !== null) {
+      return
+    }
+
+    const now = performance.now()
+    const timeSinceLastUpdate = now - this.lastScreenUpdateTime
+
+    if (timeSinceLastUpdate >= this.frameIntervalMs) {
+      this.flush()
+      return
+    }
+
+    const delayUntilNextFrame = this.frameIntervalMs - timeSinceLastUpdate
+    const delay = Math.min(delayUntilNextFrame, this.maxBatchDelayMs)
+    this.screenUpdateTimeout = self.setTimeout(() => {
+      this.flush()
+    }, delay)
+  }
+
+  cancel(): void {
+    if (this.screenUpdateTimeout !== null) {
+      self.clearTimeout(this.screenUpdateTimeout)
+      this.screenUpdateTimeout = null
+    }
+    this.pendingScreenUpdate = false
+  }
+
+  flush(): void {
+    this.screenUpdateTimeout = null
+    if (!this.pendingScreenUpdate) {
+      return
+    }
+    this.pendingScreenUpdate = false
+    this.lastScreenUpdateTime = performance.now()
+    this.flushCallback()
+  }
+}

--- a/src/core/devices/WebWorkerDeviceAdapter.ts
+++ b/src/core/devices/WebWorkerDeviceAdapter.ts
@@ -24,6 +24,7 @@ import { logWorker } from '@/shared/logger'
 
 import { MessageHandler } from './MessageHandler'
 import { ScreenStateManager } from './ScreenStateManager'
+import { ScreenUpdateBatcher } from './ScreenUpdateBatcher'
 import {
   createViewsFromJoystickBuffer,
   getStickState as getRawStickState,
@@ -69,17 +70,16 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
     { resolve: (values: string[]) => void; reject: (err: Error) => void }
   > = new Map()
   // === SCREEN UPDATE BATCHING (FPS-based: aligns updates with target frame rate) ===
-  private pendingScreenUpdate: boolean = false
-  private screenUpdateTimeout: number | null = null
-  private lastScreenUpdateTime: number = 0
-  private readonly TARGET_FPS = 60
-  private readonly FRAME_INTERVAL_MS = 1000 / 60
-  private readonly MAX_BATCH_DELAY_MS = 33
+  private readonly screenUpdateBatcher: ScreenUpdateBatcher
   constructor() {
     logWorker.debug('WebWorkerDeviceAdapter created')
     this.webWorkerManager = new WebWorkerManager()
     this.screenStateManager = new ScreenStateManager()
     this.messageHandler = new MessageHandler(this.webWorkerManager.getPendingMessages())
+    this.screenUpdateBatcher = new ScreenUpdateBatcher(() => {
+      this.syncScreenStateToShared()
+      this.postScreenChanged()
+    })
     this.setupMessageListener()
   }
 
@@ -501,7 +501,7 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
     }
 
     // Batch screen updates to reduce Vue reactivity overhead
-    this.scheduleScreenUpdate()
+    this.screenUpdateBatcher.schedule()
   }
 
   debugOutput(output: string): void {
@@ -704,7 +704,7 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
       this.postScreenChanged()
       this.cancelPendingScreenUpdate()
     } else {
-      this.flushScreenUpdate()
+      this.screenUpdateBatcher.flush()
     }
   }
 
@@ -812,60 +812,8 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
     // Output is now handled by the device adapter in the web worker
   }
 
-  /**
-   * Schedule a batched screen update with FPS-based timing
-   * This batches multiple screen updates together to align with target frame rate
-   * and reduce message volume and Vue reactivity overhead on the receiving side
-   * 
-   * Strategy:
-   * - Calculate time since last update
-   * - If enough time has passed (>= frame interval), send immediately
-   * - Otherwise, schedule for the next frame boundary
-   * - This ensures updates are sent at consistent FPS intervals
-   */
-  private scheduleScreenUpdate(): void {
-    // Mark that we have a pending update
-    this.pendingScreenUpdate = true
-
-    // If there's already a scheduled update, don't schedule another one
-    // The existing scheduled update will pick up this pending change
-    if (this.screenUpdateTimeout !== null) {
-      return
-    }
-
-    const now = performance.now()
-    const timeSinceLastUpdate = now - this.lastScreenUpdateTime
-
-    // If enough time has passed since last update, send immediately
-    if (timeSinceLastUpdate >= this.FRAME_INTERVAL_MS) {
-      this.flushScreenUpdate()
-      return
-    }
-
-    // Calculate delay to next frame boundary (capped to prevent excessive lag)
-    const delayUntilNextFrame = this.FRAME_INTERVAL_MS - timeSinceLastUpdate
-    const delay = Math.min(delayUntilNextFrame, this.MAX_BATCH_DELAY_MS)
-    // Schedule the update to be sent at the next frame boundary
-    this.screenUpdateTimeout = self.setTimeout(() => {
-      this.flushScreenUpdate()
-    }, delay)
-  }
-
   /** Cancel any pending screen update (used by flush paths and tests to avoid timeouts after teardown) */
   cancelPendingScreenUpdate(): void {
-    if (this.screenUpdateTimeout !== null) {
-      self.clearTimeout(this.screenUpdateTimeout)
-      this.screenUpdateTimeout = null
-    }
-    this.pendingScreenUpdate = false
-  }
-  /** Flush pending screen update: write to shared buffer and send SCREEN_CHANGED */
-  private flushScreenUpdate(): void {
-    this.screenUpdateTimeout = null
-    if (!this.pendingScreenUpdate) return
-    this.pendingScreenUpdate = false
-    this.lastScreenUpdateTime = performance.now()
-    this.syncScreenStateToShared()
-    this.postScreenChanged()
+    this.screenUpdateBatcher.cancel()
   }
 }


### PR DESCRIPTION
## Summary
- extract FPS-based screen update batching state/timing into new `ScreenUpdateBatcher`
- keep WebWorkerDeviceAdapter behavior and public `cancelPendingScreenUpdate()` API unchanged
- wire existing print/flush paths to use the helper directly

## Root Cause
`src/core/devices/WebWorkerDeviceAdapter.ts` bundled screen update batching state machine with broader adapter responsibilities, which contributed to file growth and a permanent `max-lines` suppression.

## Validation
- `pnpm -s test:run -- test/devices/WebWorkerDeviceAdapter.test.ts`
- `pnpm -s exec eslint src/core/devices/WebWorkerDeviceAdapter.ts src/core/devices/ScreenUpdateBatcher.ts --no-warn-ignored`

Closes #5