### PR TITLE
fix: #9 reduce noisy animation/interpreter test logs

### DIFF
--- a/src/core/BasicInterpreter.ts
+++ b/src/core/BasicInterpreter.ts
@@ -89,7 +89,7 @@ export class BasicInterpreter {
 
       // Create execution context (or reuse existing one if it has device adapter)
       if (!this.context?.deviceAdapter) {
-        console.log('[BasicInterpreter] Creating new context with sharedAnimationBuffer:', {
+        logInterpreter.debug('[BasicInterpreter] Creating new context with sharedAnimationBuffer:', {
           hasBuffer: !!this.config.sharedAnimationBuffer,
           byteLength: this.config.sharedAnimationBuffer?.byteLength,
         })

--- a/src/core/animation/AnimationManager.ts
+++ b/src/core/animation/AnimationManager.ts
@@ -129,7 +129,12 @@ export class AnimationManager {
     }
 
     this.moveDefinitions.set(definition.actionNumber, definition)
-    console.log('[AnimationManager] defineMovement: stored definition for action', definition.actionNumber, 'total definitions:', this.moveDefinitions.size)
+    logWorker.debug(
+      '[AnimationManager] defineMovement: stored definition for action',
+      definition.actionNumber,
+      'total definitions:',
+      this.moveDefinitions.size
+    )
 
     // Write movement definition to shared buffer so Main Thread can create sprites immediately
     // This includes: characterType, colorCombination, direction, speed, priority
@@ -161,7 +166,10 @@ export class AnimationManager {
         definition.characterType,
         definition.colorCombination
       )
-      console.log('[AnimationManager] defineMovement: wrote definition to shared buffer for action', definition.actionNumber)
+      logWorker.debug(
+        '[AnimationManager] defineMovement: wrote definition to shared buffer for action',
+        definition.actionNumber
+      )
     }
 
     // Initialize POSITION for this action to screen center when DEF MOVE runs (like DEF SPRITE)
@@ -193,7 +201,7 @@ export class AnimationManager {
    * @throws Error if no definition exists for actionNumber
    */
   startMovement(actionNumber: number, startX?: number, startY?: number): void {
-    console.log('[AnimationManager] startMovement called for sprite', actionNumber)
+    logWorker.debug('[AnimationManager] startMovement called for sprite', actionNumber)
 
     const definition = this.moveDefinitions.get(actionNumber)
     if (!definition) {
@@ -210,14 +218,14 @@ export class AnimationManager {
     const initialX = startX ?? screenCenterX - halfSize
     const initialY = startY ?? screenCenterY - halfSize
 
-    console.log('[AnimationManager] Starting movement at position:', initialX, initialY)
+    logWorker.debug('[AnimationManager] Starting movement at position:', initialX, initialY)
 
     // Write START_MOVEMENT command to shared buffer
     if (!this.accessor) {
       throw new Error('[AnimationManager] Shared buffer not available - cannot start movement')
     }
 
-    console.log('[AnimationManager] Writing START_MOVEMENT command to buffer...')
+    logWorker.debug('[AnimationManager] Writing START_MOVEMENT command to buffer...')
     this.dispatchSyncCommand(SyncCommandType.START_MOVEMENT, actionNumber, {
       startX: initialX,
       startY: initialY,
@@ -326,12 +334,12 @@ export class AnimationManager {
    * @returns Array of MovementState for all defined movements
    */
   getAllMovementStates(): MovementState[] {
-    console.log('[AnimationManager] getAllMovementStates: moveDefinitions size:', this.moveDefinitions.size)
+    logWorker.debug('[AnimationManager] getAllMovementStates: moveDefinitions size:', this.moveDefinitions.size)
     const states = Array.from(this.moveDefinitions.values()).map(definition => ({
       actionNumber: definition.actionNumber,
       definition,
     }))
-    console.log('[AnimationManager] getAllMovementStates: returning', states.length, 'states')
+    logWorker.debug('[AnimationManager] getAllMovementStates: returning', states.length, 'states')
     return states
   }
 

--- a/src/core/workers/AnimationWorker.ts
+++ b/src/core/workers/AnimationWorker.ts
@@ -95,7 +95,7 @@ export class AnimationWorker {
    * Expects the combined display buffer (sharedDisplayBuffer.ts).
    */
   private handleSetSharedBuffer(buffer: SharedArrayBuffer): void {
-    console.log('[AnimationWorker] handleSetSharedBuffer called, byteLength =', buffer.byteLength)
+    logWorker.debug('[AnimationWorker] handleSetSharedBuffer called, byteLength =', buffer.byteLength)
     if (buffer.byteLength < SHARED_DISPLAY_BUFFER_BYTES) {
       throw new RangeError(
         `Shared buffer too small: ${buffer.byteLength} bytes, need at least ${SHARED_DISPLAY_BUFFER_BYTES}`
@@ -150,7 +150,7 @@ export class AnimationWorker {
           this.handleSetPositionFromSync(command.actionNumber, command.params.startX, command.params.startY)
           break
         case SyncCommandType.CLEAR_ALL_MOVEMENTS:
-          console.log('[AnimationWorker] CLEAR_ALL_MOVEMENTS: clearing all sprite data')
+          logWorker.debug('[AnimationWorker] CLEAR_ALL_MOVEMENTS: clearing all sprite data')
           this.handleClearAllMovementsFromSync()
           // Clear the command immediately after processing so it's not re-read every tick
           this.accessor.clearSyncCommand()
@@ -338,7 +338,11 @@ export class AnimationWorker {
    * Called when user clicks CLEAR button - clears all internal movement states and sprite buffer.
    */
   private handleClearAllMovementsFromSync(): void {
-    console.log('[AnimationWorker] CLEAR_ALL_MOVEMENTS: clearing', this.movementStates.size, 'movement states and all sprite data')
+    logWorker.debug(
+      '[AnimationWorker] CLEAR_ALL_MOVEMENTS: clearing',
+      this.movementStates.size,
+      'movement states and all sprite data'
+    )
 
     // Clear all internal movement states
     this.movementStates.clear()
@@ -363,7 +367,7 @@ export class AnimationWorker {
     this.isRunning = true
     this.lastTickTime = performance.now()
 
-    console.log('[AnimationWorker] Starting tick loop at 60Hz')
+    logWorker.debug('[AnimationWorker] Starting tick loop at 60Hz')
 
     // Use setInterval for fixed 60Hz tick rate
     this.tickInterval = self.setInterval(() => {

--- a/src/core/workers/WebWorkerInterpreter.ts
+++ b/src/core/workers/WebWorkerInterpreter.ts
@@ -142,7 +142,7 @@ class WebWorkerInterpreter {
         maxIterations: config.maxIterations,
         maxOutputLines: config.maxOutputLines,
       })
-      console.log('[WebWorkerInterpreter] Creating BasicInterpreter with sharedAnimationBuffer:', {
+      logWorker.debug('[WebWorkerInterpreter] Creating BasicInterpreter with sharedAnimationBuffer:', {
         hasBuffer: !!this.sharedAnimationBuffer,
         byteLength: this.sharedAnimationBuffer?.byteLength,
       })
@@ -258,19 +258,19 @@ class WebWorkerInterpreter {
     }
     const { buffer } = data
     this.sharedAnimationBuffer = buffer
-    console.log('[WebWorkerInterpreter] SET_SHARED_ANIMATION_BUFFER received, buffer byteLength =', buffer.byteLength)
+    logWorker.debug('[WebWorkerInterpreter] SET_SHARED_ANIMATION_BUFFER received, buffer byteLength =', buffer.byteLength)
     const accessor = new SharedDisplayBufferAccessor(buffer)
     const animationManager = this.interpreter?.getAnimationManager()
-    console.log('[WebWorkerInterpreter] Interpreter exists:', !!this.interpreter, 'AnimationManager exists:', !!animationManager)
+    logWorker.debug('[WebWorkerInterpreter] Interpreter exists:', !!this.interpreter, 'AnimationManager exists:', !!animationManager)
     if (this.webWorkerDeviceAdapter) {
       this.webWorkerDeviceAdapter.setSharedDisplayBufferAccessor(accessor)
     }
     // Update AnimationManager's shared buffer for direct sync to AnimationWorker
     if (animationManager) {
-      console.log('[WebWorkerInterpreter] Updating existing AnimationManager with shared buffer')
+      logWorker.debug('[WebWorkerInterpreter] Updating existing AnimationManager with shared buffer')
       animationManager.setSharedAnimationBuffer(buffer)
     } else {
-      console.log('[WebWorkerInterpreter] AnimationManager not created yet, will use buffer when interpreter is created')
+      logWorker.debug('[WebWorkerInterpreter] AnimationManager not created yet, will use buffer when interpreter is created')
     }
   }
 
@@ -281,7 +281,7 @@ class WebWorkerInterpreter {
       return
     }
     const { buffer } = data
-    console.log('[WebWorkerInterpreter] SET_SHARED_JOYSTICK_BUFFER received, buffer byteLength =', buffer.byteLength)
+    logWorker.debug('[WebWorkerInterpreter] SET_SHARED_JOYSTICK_BUFFER received, buffer byteLength =', buffer.byteLength)
     if (this.webWorkerDeviceAdapter) {
       this.webWorkerDeviceAdapter.setSharedJoystickBuffer(buffer)
       logWorker.debug('[WebWorkerInterpreter] Shared joystick buffer set in WebWorkerDeviceAdapter')
@@ -297,7 +297,7 @@ class WebWorkerInterpreter {
       return
     }
     const { buffer } = data
-    console.log('[WebWorkerInterpreter] SET_SHARED_KEYBOARD_BUFFER received, buffer byteLength =', buffer.byteLength)
+    logWorker.debug('[WebWorkerInterpreter] SET_SHARED_KEYBOARD_BUFFER received, buffer byteLength =', buffer.byteLength)
     if (this.webWorkerDeviceAdapter) {
       this.webWorkerDeviceAdapter.setSharedKeyboardBuffer(buffer)
       logWorker.debug('[WebWorkerInterpreter] Shared keyboard buffer set in WebWorkerDeviceAdapter')

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -8,7 +8,15 @@
 
 import log from 'loglevel'
 
-const defaultLevel: log.LogLevelDesc = 'warn'
+export function resolveDefaultLogLevel(
+  env: Record<string, string | undefined> | undefined = (globalThis as {
+    process?: { env?: Record<string, string | undefined> }
+  }).process?.env
+): log.LogLevelDesc {
+  return env?.FBASIC_VERBOSE_LOGS === '1' ? 'debug' : 'warn'
+}
+
+const defaultLevel: log.LogLevelDesc = resolveDefaultLogLevel()
 log.setDefaultLevel(defaultLevel)
 
 /** IDE worker message handling (PROGRESS, ANIMATION_COMMAND, etc.). Use debug for verbose. */

--- a/test/core/logger.test.ts
+++ b/test/core/logger.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveDefaultLogLevel } from '@/shared/logger'
+
+describe('resolveDefaultLogLevel', () => {
+  it('defaults to warn when verbose env flag is unset', () => {
+    expect(resolveDefaultLogLevel({})).toBe('warn')
+  })
+
+  it('uses debug when FBASIC_VERBOSE_LOGS=1', () => {
+    expect(resolveDefaultLogLevel({ FBASIC_VERBOSE_LOGS: '1' })).toBe('debug')
+  })
+})


### PR DESCRIPTION
## Summary
- route animation/interpreter internal trace logs through shared named loggers instead of direct console output
- default logger level remains concise (`warn`) while allowing intentional verbose mode via `FBASIC_VERBOSE_LOGS=1`
- add focused test coverage for default/verbose log-level resolution

## Validation
- pnpm -s test:run -- test/core/logger.test.ts test/animation/AnimationManager.test.ts
- pnpm -s test:run -- test/integration/AnimationWorkerRuntimeIntegration.test.ts test/devices/WebWorkerDeviceAdapter.test.ts
- pnpm -s exec eslint src/shared/logger.ts src/core/BasicInterpreter.ts src/core/animation/AnimationManager.ts src/core/workers/AnimationWorker.ts src/core/workers/WebWorkerInterpreter.ts test/core/logger.test.ts --no-warn-ignored

Closes #9