### PR TITLE
fix: localize sample selector category labels (#13)

### DIFF
--- a/src/features/ide/components/SampleSelector.vue
+++ b/src/features/ide/components/SampleSelector.vue
@@ -52,16 +52,10 @@ const selectedCategory = ref<string>('basics')
 
 const samplesInCategory = computed(() => categories.value.get(selectedCategory.value) ?? [])
 
-// Category display names
-const categoryNames: Record<string, string> = {
-  basics: 'Basics',
-  control: 'Control Flow',
-  data: 'Data & Arrays',
-  screen: 'Screen',
-  sprites: 'Sprites',
-  interactive: 'Interactive',
-  comprehensive: 'Full Demo',
-  music: 'Music',
+const getCategoryName = (category: string): string => {
+  const key = `ide.samples.categories.${category}`
+  const translated = t(key)
+  return translated === key ? category : translated
 }
 
 // Category colors for visual distinction
@@ -97,7 +91,7 @@ const categoryColors: Record<string, string> = {
           :style="selectedCategory === cat ? { borderColor: categoryColors[cat] } : {}"
           @click="selectedCategory = cat"
         >
-          {{ categoryNames[cat] || cat }}
+          {{ getCategoryName(cat) }}
         </button>
       </div>
 
@@ -112,13 +106,19 @@ const categoryColors: Record<string, string> = {
           <div class="sample-card-header">
             <h3 class="sample-card-name">
               {{ sample.name }}
-              <span v-if="sample.hasBg" class="bg-indicator" title="Includes BG data">BG</span>
+              <span
+                v-if="sample.hasBg"
+                class="bg-indicator"
+                :title="t('ide.samples.bgIndicatorTitle', 'Includes BG data')"
+              >
+                BG
+              </span>
             </h3>
             <span
               class="sample-card-tag"
               :style="{ backgroundColor: categoryColors[selectedCategory] }"
             >
-              {{ categoryNames[selectedCategory] || selectedCategory }}
+              {{ getCategoryName(selectedCategory) }}
             </span>
           </div>
           <p class="sample-card-desc">{{ sample.description }}</p>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -38,6 +38,17 @@
     "gaming": "Joystick Test",
     "complex": "Complex",
     "comprehensive": "Full Demo",
+    "bgIndicatorTitle": "Includes BG data",
+    "categories": {
+      "basics": "Basics",
+      "control": "Control Flow",
+      "data": "Data & Arrays",
+      "screen": "Screen",
+      "sprites": "Sprites",
+      "interactive": "Interactive",
+      "comprehensive": "Full Demo",
+      "music": "Music"
+    },
     "allChars": "All Chars",
     "spriteTest": "Sprite Test",
     "moveTest": "Move Test",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -42,7 +42,18 @@
     "spriteTest": "スプライトテスト",
     "moveTest": "移動テスト",
     "testMoveControl": "移動制御テスト",
-    "inputDemo": "INPUT / LINPUT"
+    "inputDemo": "INPUT / LINPUT",
+    "bgIndicatorTitle": "BG\u30c7\u30fc\u30bf\u3092\u542b\u3080",
+    "categories": {
+      "basics": "\u57fa\u672c",
+      "control": "\u5236\u5fa1\u30d5\u30ed\u30fc",
+      "data": "\u30c7\u30fc\u30bf\u3068\u914d\u5217",
+      "screen": "\u753b\u9762",
+      "sprites": "\u30b9\u30d7\u30e9\u30a4\u30c8",
+      "interactive": "\u30a4\u30f3\u30bf\u30e9\u30af\u30c6\u30a3\u30d6",
+      "comprehensive": "\u30d5\u30eb\u30c7\u30e2",
+      "music": "\u97f3\u697d"
+    }
   },
   "input": {
     "submit": "OK",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -42,7 +42,18 @@
     "spriteTest": "Sprite测试",
     "moveTest": "移动测试",
     "testMoveControl": "移动控制测试",
-    "inputDemo": "INPUT / LINPUT"
+    "inputDemo": "INPUT / LINPUT",
+    "bgIndicatorTitle": "\u5305\u542b BG \u6570\u636e",
+    "categories": {
+      "basics": "\u57fa\u7840",
+      "control": "\u6d41\u7a0b\u63a7\u5236",
+      "data": "\u6570\u636e\u4e0e\u6570\u7ec4",
+      "screen": "\u5c4f\u5e55",
+      "sprites": "\u7cbe\u7075",
+      "interactive": "\u4ea4\u4e92",
+      "comprehensive": "\u5b8c\u6574\u6f14\u793a",
+      "music": "\u97f3\u4e50"
+    }
   },
   "input": {
     "submit": "确定",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -42,7 +42,18 @@
     "spriteTest": "Sprite測試",
     "moveTest": "移動測試",
     "testMoveControl": "移動控制測試",
-    "inputDemo": "INPUT / LINPUT"
+    "inputDemo": "INPUT / LINPUT",
+    "bgIndicatorTitle": "\u5305\u542b BG \u8cc7\u6599",
+    "categories": {
+      "basics": "\u57fa\u790e",
+      "control": "\u6d41\u7a0b\u63a7\u5236",
+      "data": "\u8cc7\u6599\u8207\u9663\u5217",
+      "screen": "\u87a2\u5e55",
+      "sprites": "\u7cbe\u9748",
+      "interactive": "\u4e92\u52d5",
+      "comprehensive": "\u5b8c\u6574\u793a\u7bc4",
+      "music": "\u97f3\u6a02"
+    }
   },
   "input": {
     "submit": "確定",


### PR DESCRIPTION
## Summary
- replace hardcoded SampleSelector category labels with i18n lookups
- localize SampleSelector BG indicator tooltip and add per-category locale keys
- add category label translations in en/ja/zh-CN/zh-TW ide locale files

## Validation
- pnpm -s exec eslint src/features/ide/components/SampleSelector.vue --no-warn-ignored
- pnpm -s test:run -- test/samples/sample-codes.test.ts

Closes #13