### PR TITLE
fix: animation worker init readiness handshake (#104)

### DIFF
--- a/src/core/workers/animation-worker.ts
+++ b/src/core/workers/animation-worker.ts
@@ -20,5 +20,8 @@ self.onmessage = (event: MessageEvent) => {
   worker.handleMessage(event.data)
 }
 
+// Explicit startup handshake so main thread can gate readiness.
+self.postMessage({ type: 'READY' })
+
 // Export for type checking (no runtime effect in workers)
 export {}

--- a/src/features/ide/composables/useAnimationWorker.ts
+++ b/src/features/ide/composables/useAnimationWorker.ts
@@ -12,6 +12,23 @@ import { type Ref, ref, watch } from 'vue'
 
 import type { AnimationWorkerCommand } from '@/core/workers/AnimationWorker'
 
+const ANIMATION_WORKER_READY_TIMEOUT_MS = 5000
+
+interface AnimationWorkerReadyMessage {
+  type: 'READY'
+}
+
+function isAnimationWorkerReadyMessage(data: unknown): data is AnimationWorkerReadyMessage {
+  return typeof data === 'object' && data !== null && 'type' in data && data.type === 'READY'
+}
+
+function toWorkerError(event: Event): Error {
+  if (event instanceof ErrorEvent && event.message) {
+    return new Error(`Animation Worker error: ${event.message}`)
+  }
+  return new Error('Animation Worker failed to initialize')
+}
+
 export interface UseAnimationWorkerOptions {
   sharedAnimationBuffer: Ref<SharedArrayBuffer | null>
   onReady?: () => void
@@ -36,13 +53,6 @@ export function useAnimationWorker(options: UseAnimationWorkerOptions) {
    * Initialize the Animation Worker
    */
   async function initialize(): Promise<void> {
-    console.log('[useAnimationWorker] initialize() called', {
-      isReady: isReady.value,
-      isInitializing: isInitializing.value,
-      hasBuffer: !!sharedAnimationBuffer.value,
-      bufferByteLength: sharedAnimationBuffer.value?.byteLength,
-    })
-
     if (isReady.value) {
       return
     }
@@ -55,7 +65,6 @@ export function useAnimationWorker(options: UseAnimationWorkerOptions) {
     initError.value = null
 
     try {
-      console.log('[useAnimationWorker] Creating Animation Worker...')
       // Create Animation Worker
       // Vite will bundle this automatically with the ?worker suffix pattern
       worker = new Worker(
@@ -65,28 +74,52 @@ export function useAnimationWorker(options: UseAnimationWorkerOptions) {
         }
       )
 
-      // Set up error handler
-      worker.onerror = (event) => {
-        const error = new Error(`Animation Worker error: ${event.message}`)
-        initError.value = error
-        onError?.(error)
-      }
-
-      // Wait for worker to be ready
+      // Wait for explicit READY handshake from worker.
+      const activeWorker = worker
       await new Promise<void>((resolve, reject) => {
-        if (!worker) {
+        if (!activeWorker) {
           reject(new Error('Worker failed to initialize'))
           return
         }
 
+        let settled = false
         const timeout = setTimeout(() => {
-          reject(new Error('Animation Worker initialization timeout'))
-        }, 5000)
+          if (settled) return
+          settled = true
+          cleanup()
+          reject(new Error('Animation Worker initialization timeout waiting for READY'))
+        }, ANIMATION_WORKER_READY_TIMEOUT_MS)
 
-        // Assume worker is ready immediately after creation
-        // (no handshake needed, just send the buffers)
-        clearTimeout(timeout)
-        resolve()
+        const handleError = (event: Event) => {
+          if (settled) return
+          settled = true
+          cleanup()
+          reject(toWorkerError(event))
+        }
+
+        const handleMessage = (event: MessageEvent<unknown>) => {
+          if (!isAnimationWorkerReadyMessage(event.data) || settled) {
+            return
+          }
+          settled = true
+          cleanup()
+          resolve()
+        }
+
+        const cleanup = () => {
+          clearTimeout(timeout)
+          activeWorker.removeEventListener('error', handleError)
+          activeWorker.removeEventListener('message', handleMessage)
+        }
+
+        activeWorker.addEventListener('error', handleError)
+        activeWorker.addEventListener('message', handleMessage)
+      })
+
+      worker.addEventListener('error', event => {
+        const error = toWorkerError(event)
+        initError.value = error
+        onError?.(error)
       })
 
       // Send shared buffers to animation worker (if available)
@@ -113,12 +146,6 @@ export function useAnimationWorker(options: UseAnimationWorkerOptions) {
 
   // Watch for buffer changes and send to worker when available
   watch(sharedAnimationBuffer, (newBuffer) => {
-    console.log('[useAnimationWorker] sharedAnimationBuffer changed:', {
-      isReady: isReady.value,
-      hasWorker: !!worker,
-      hasBuffer: !!newBuffer,
-      byteLength: newBuffer?.byteLength,
-    })
     if (isReady.value && worker) {
       if (newBuffer) {
         const setBufferCommand: AnimationWorkerCommand = {
@@ -126,7 +153,6 @@ export function useAnimationWorker(options: UseAnimationWorkerOptions) {
           buffer: newBuffer,
         }
         worker.postMessage(setBufferCommand)
-        console.log('[useAnimationWorker] Sent SET_SHARED_BUFFER to AnimationWorker, byteLength:', newBuffer.byteLength)
       }
     }
   })

--- a/test/ide/useAnimationWorker.test.ts
+++ b/test/ide/useAnimationWorker.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+import { useAnimationWorker } from '@/features/ide/composables/useAnimationWorker'
+
+type WorkerMessageHandler = (event: MessageEvent<unknown>) => void
+type WorkerErrorHandler = (event: Event) => void
+
+class MockWorker {
+  static instances: MockWorker[] = []
+
+  readonly postMessage = vi.fn()
+  readonly terminate = vi.fn()
+
+  private messageHandlers = new Set<WorkerMessageHandler>()
+  private errorHandlers = new Set<WorkerErrorHandler>()
+
+  constructor(_url: URL, _options: WorkerOptions) {
+    MockWorker.instances.push(this)
+  }
+
+  addEventListener(type: 'message' | 'error', listener: EventListenerOrEventListenerObject): void {
+    if (typeof listener !== 'function') {
+      return
+    }
+    if (type === 'message') {
+      this.messageHandlers.add(listener as WorkerMessageHandler)
+      return
+    }
+    this.errorHandlers.add(listener as WorkerErrorHandler)
+  }
+
+  removeEventListener(type: 'message' | 'error', listener: EventListenerOrEventListenerObject): void {
+    if (typeof listener !== 'function') {
+      return
+    }
+    if (type === 'message') {
+      this.messageHandlers.delete(listener as WorkerMessageHandler)
+      return
+    }
+    this.errorHandlers.delete(listener as WorkerErrorHandler)
+  }
+
+  emitMessage(data: unknown): void {
+    const event = { data } as MessageEvent<unknown>
+    for (const handler of this.messageHandlers) {
+      handler(event)
+    }
+  }
+
+  emitError(message: string): void {
+    const event = new ErrorEvent('error', { message })
+    for (const handler of this.errorHandlers) {
+      handler(event)
+    }
+  }
+}
+
+describe('useAnimationWorker', () => {
+  beforeEach(() => {
+    MockWorker.instances = []
+    vi.stubGlobal('Worker', MockWorker)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('resolves initialize only after READY message', async () => {
+    const onReady = vi.fn()
+    const sharedAnimationBuffer = ref<SharedArrayBuffer | null>(new SharedArrayBuffer(64))
+    const manager = useAnimationWorker({
+      sharedAnimationBuffer,
+      onReady,
+    })
+
+    const initializePromise = manager.initialize()
+    await Promise.resolve()
+
+    expect(manager.isInitializing.value).toBe(true)
+    expect(manager.isReady.value).toBe(false)
+    expect(onReady).not.toHaveBeenCalled()
+
+    const worker = MockWorker.instances[0]
+    expect(worker).toBeDefined()
+    worker!.emitMessage({ type: 'READY' })
+    await initializePromise
+
+    expect(manager.isReady.value).toBe(true)
+    expect(manager.isInitializing.value).toBe(false)
+    expect(onReady).toHaveBeenCalledTimes(1)
+    expect(worker!.postMessage).toHaveBeenCalledWith({
+      type: 'SET_SHARED_BUFFER',
+      buffer: sharedAnimationBuffer.value,
+    })
+  })
+
+  it('rejects initialize when worker errors before READY', async () => {
+    const onError = vi.fn()
+    const manager = useAnimationWorker({
+      sharedAnimationBuffer: ref<SharedArrayBuffer | null>(new SharedArrayBuffer(64)),
+      onError,
+    })
+
+    const initializePromise = manager.initialize()
+    const worker = MockWorker.instances[0]
+    expect(worker).toBeDefined()
+    worker!.emitError('boom')
+
+    await expect(initializePromise).rejects.toThrow('Animation Worker error: boom')
+    expect(manager.isReady.value).toBe(false)
+    expect(manager.isInitializing.value).toBe(false)
+    expect(manager.initError.value?.message).toContain('Animation Worker error: boom')
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends latest shared buffer after READY even when set during initialization', async () => {
+    const sharedAnimationBuffer = ref<SharedArrayBuffer | null>(null)
+    const manager = useAnimationWorker({
+      sharedAnimationBuffer,
+    })
+
+    const initializePromise = manager.initialize()
+    const worker = MockWorker.instances[0]
+    expect(worker).toBeDefined()
+
+    const nextBuffer = new SharedArrayBuffer(128)
+    sharedAnimationBuffer.value = nextBuffer
+    await nextTick()
+    expect(worker!.postMessage).not.toHaveBeenCalled()
+
+    worker!.emitMessage({ type: 'READY' })
+    await initializePromise
+
+    expect(worker!.postMessage).toHaveBeenCalledTimes(1)
+    expect(worker!.postMessage).toHaveBeenCalledWith({
+      type: 'SET_SHARED_BUFFER',
+      buffer: nextBuffer,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- wait for an explicit `READY` message before resolving `useAnimationWorker.initialize()`
- reject initialization on pre-READY worker errors/timeouts and keep `isReady=false`
- add focused unit tests for READY success, pre-READY error, and buffer handoff during initialization

## Validation
- `pnpm -s exec vitest run test/ide/useAnimationWorker.test.ts`
- `pnpm -s exec eslint src/features/ide/composables/useAnimationWorker.ts src/core/workers/animation-worker.ts test/ide/useAnimationWorker.test.ts --no-warn-ignored`

Closes #104