### PR TITLE
refactor: buffer-driven StateInspector MOVE tab (#103)

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -403,7 +403,6 @@ function toggleInputMode() {
         :cgen-mode="cgenMode"
         :sprite-states="spriteStates"
         :sprite-enabled="spriteEnabled"
-        :movement-positions-from-buffer="movementPositionsFromBuffer"
         :shared-display-buffer-accessor="sharedDisplayBufferAccessor"
       />
 

--- a/src/features/ide/components/IdeBottomArea.vue
+++ b/src/features/ide/components/IdeBottomArea.vue
@@ -34,7 +34,6 @@ interface Props {
   cgenMode: number
   spriteStates: SpriteState[]
   spriteEnabled: boolean
-  movementPositionsFromBuffer: Map<number, { x: number; y: number }>
   sharedDisplayBufferAccessor: SharedDisplayBufferAccessor
 }
 
@@ -67,7 +66,6 @@ defineExpose({
         :cgen-mode="cgenMode"
         :sprite-states="spriteStates"
         :sprite-enabled="spriteEnabled"
-        :movement-positions-from-buffer="movementPositionsFromBuffer"
         :shared-display-buffer-accessor="sharedDisplayBufferAccessor"
       />
     </div>

--- a/src/features/ide/components/MovementCard.vue
+++ b/src/features/ide/components/MovementCard.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
-import type { MovementState } from '@/core/sprite/types'
 import { GameIcon } from '@/shared/components/ui'
 import { MoveCharacterCode } from '@/shared/data/types'
 
 /** Single movement slot data for display in StateInspector */
 export interface MovementSlotData {
   actionNumber: number
-  m: MovementState | undefined
   hasData: boolean
   x: number
   y: number
@@ -73,12 +71,12 @@ function characterTypeLabel(code: number): string {
       <span class="move-card-id" title="Action number">
         <span>{{ slot.actionNumber }}</span>
       </span>
-      <template v-if="slot.hasData || slot.m">
+      <template v-if="slot.hasData">
         <span
           class="move-card-char"
-          :title="characterTypeLabel(slot.characterType || slot.m?.definition.characterType || 0)"
+          :title="characterTypeLabel(slot.characterType)"
         >
-          {{ characterTypeLabel(slot.characterType || slot.m?.definition.characterType || 0).slice(0, 5) }}
+          {{ characterTypeLabel(slot.characterType).slice(0, 5) }}
         </span>
         <span class="move-card-status" :title="slot.isActive ? 'Active' : 'Paused'">
           <GameIcon
@@ -89,11 +87,11 @@ function characterTypeLabel(code: number): string {
         </span>
         <span
           class="move-card-dir"
-          :title="directionTitle(slot.direction || slot.m?.definition.direction || 0)"
-          :aria-label="`direction ${directionTitle(slot.direction || slot.m?.definition.direction || 0)}`"
+          :title="directionTitle(slot.direction)"
+          :aria-label="`direction ${directionTitle(slot.direction)}`"
         >
           <GameIcon
-            :icon="directionIcon(slot.direction || slot.m?.definition.direction || 0)"
+            :icon="directionIcon(slot.direction)"
             size="small"
             class="move-card-icon"
           />
@@ -103,34 +101,34 @@ function characterTypeLabel(code: number): string {
     <div class="move-card-body">
       <div class="move-card-cell">
         <GameIcon
-          v-if="slot.hasData || slot.m"
+          v-if="slot.hasData"
           icon="mdi:crosshairs-gps"
           size="small"
           class="move-card-icon"
         />
         <span class="move-card-value">
-          {{ (slot.hasData || slot.m) ? `${slot.x},${slot.y}` : '' }}
+          {{ slot.hasData ? `${slot.x},${slot.y}` : '' }}
         </span>
       </div>
       <div class="move-card-cell move-card-cell-left">
         <GameIcon
-          v-if="slot.hasData || slot.m"
+          v-if="slot.hasData"
           icon="mdi:ruler"
           size="small"
           class="move-card-icon"
         />
         <span class="move-card-value">
-          {{ (slot.hasData || slot.m) ? Math.round(slot.remainingDistance) : '' }}
+          {{ slot.hasData ? Math.round(slot.remainingDistance) : '' }}
         </span>
       </div>
       <div class="move-card-cell move-card-cell-right">
         <GameIcon
-          v-if="slot.hasData || slot.m"
+          v-if="slot.hasData"
           icon="mdi:speedometer"
           size="small"
           class="move-card-icon"
         />
-        <span class="move-card-value">{{ (slot.hasData || slot.m) ? slot.speed : '' }}</span>
+        <span class="move-card-value">{{ slot.hasData ? slot.speed : '' }}</span>
       </div>
     </div>
   </div>

--- a/src/features/ide/components/StateInspector.vue
+++ b/src/features/ide/components/StateInspector.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n'
 
 import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import type { ScreenCell } from '@/core/interfaces'
-import type { MovementState, SpriteState } from '@/core/sprite/types'
+import type { SpriteState } from '@/core/sprite/types'
 import { GameBlock, GameTabPane, GameTabs } from '@/shared/components/ui'
 import { COLORS } from '@/shared/data/palette'
 
@@ -26,10 +26,6 @@ const props = withDefaults(
     cgenMode?: number
     spriteStates?: SpriteState[]
     spriteEnabled?: boolean
-    /** @deprecated Use sharedAnimationView instead - local state will be removed */
-    movementStates?: MovementState[]
-    /** @deprecated All data now read from sharedDisplayBufferAccessor */
-    movementPositionsFromBuffer?: Map<number, { x: number; y: number }>
     /** Shared display buffer accessor for reading sprite state */
     sharedDisplayBufferAccessor?: SharedDisplayBufferAccessor
   }>(),
@@ -43,8 +39,6 @@ const props = withDefaults(
     cgenMode: 2,
     spriteStates: () => [],
     spriteEnabled: false,
-    movementStates: () => [],
-    movementPositionsFromBuffer: () => new Map(),
   }
 )
 
@@ -70,8 +64,6 @@ const moveSlots = ref<MovementSlotData[]>([])
  */
 function updateMoveSlotsData(): void {
   const accessor = props.sharedDisplayBufferAccessor
-  const states = props.movementStates ?? []
-  const byAction = new Map(states.map(m => [m.actionNumber, m]))
 
   const slots: MovementSlotData[] = []
   for (let actionNumber = 0; actionNumber < MOVE_SLOT_COUNT; actionNumber++) {
@@ -88,14 +80,11 @@ function updateMoveSlotsData(): void {
     const characterType = accessor?.readSpriteCharacterType(actionNumber) ?? 0
     const colorCombination = accessor?.readSpriteColorCombination(actionNumber) ?? 0
 
-    // Fall back to local state for definition if not in buffer yet
-    const m = byAction.get(actionNumber)
     // Show slot if: active moving, OR has non-zero position
     const hasData = Boolean(isActive || (accessor && (x !== 0 || y !== 0)))
 
     slots.push({
       actionNumber,
-      m: m ?? undefined,
       hasData,
       x: Math.round(x),
       y: Math.round(y),

--- a/test/ide/StateInspector.test.ts
+++ b/test/ide/StateInspector.test.ts
@@ -1,0 +1,87 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
+import StateInspector from '@/features/ide/components/StateInspector.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+type InspectorAccessor = Pick<
+  SharedDisplayBufferAccessor,
+  | 'readSpritePosition'
+  | 'readSpriteIsActive'
+  | 'readSpriteRemainingDistance'
+  | 'readSpriteTotalDistance'
+  | 'readSpriteDirection'
+  | 'readSpriteSpeed'
+  | 'readSpritePriority'
+  | 'readSpriteCharacterType'
+  | 'readSpriteColorCombination'
+>
+
+function createAccessorMock(): SharedDisplayBufferAccessor {
+  const accessor: InspectorAccessor = {
+    readSpritePosition: (actionNumber: number) =>
+      actionNumber === 0 ? { x: 12.4, y: 6.6 } : { x: 0, y: 0 },
+    readSpriteIsActive: (actionNumber: number) => actionNumber === 0,
+    readSpriteRemainingDistance: (actionNumber: number) => (actionNumber === 0 ? 18 : 0),
+    readSpriteTotalDistance: (actionNumber: number) => (actionNumber === 0 ? 24 : 0),
+    readSpriteDirection: (actionNumber: number) => (actionNumber === 0 ? 3 : 0),
+    readSpriteSpeed: (actionNumber: number) => (actionNumber === 0 ? 4 : 0),
+    readSpritePriority: (actionNumber: number) => (actionNumber === 0 ? 1 : 0),
+    readSpriteCharacterType: (actionNumber: number) => (actionNumber === 0 ? 2 : 0),
+    readSpriteColorCombination: (actionNumber: number) => (actionNumber === 0 ? 1 : 0),
+  }
+  return accessor as SharedDisplayBufferAccessor
+}
+
+describe('StateInspector MOVE tab data', () => {
+  it('builds MOVE card slot data from shared display buffer accessor only', async () => {
+    const wrapper = mount(StateInspector, {
+      props: {
+        sharedDisplayBufferAccessor: createAccessorMock(),
+      },
+      global: {
+        stubs: {
+          GameBlock: defineComponent({ template: '<div><slot /></div>' }),
+          GameTabs: defineComponent({ template: '<div><slot /></div>' }),
+          GameTabPane: defineComponent({ template: '<div><slot /></div>' }),
+          ActivePaletteDisplay: true,
+          MovementCard: defineComponent({
+            props: {
+              slot: {
+                type: Object,
+                required: true,
+              },
+            },
+            template:
+              '<div class="movement-card-stub" :data-action="slot.actionNumber" :data-has-data="slot.hasData" :data-x="slot.x" :data-y="slot.y" :data-direction="slot.direction" :data-speed="slot.speed" :data-character-type="slot.characterType" />',
+          }),
+        },
+      },
+    })
+
+    ;(wrapper.vm as { updateMoveSlotsData: () => void }).updateMoveSlotsData()
+    await wrapper.vm.$nextTick()
+
+    const moveCard = wrapper.find('.movement-card-stub[data-action="0"]')
+    expect(moveCard.exists()).toBe(true)
+    expect(moveCard.attributes('data-has-data')).toBe('true')
+    expect(moveCard.attributes('data-x')).toBe('12')
+    expect(moveCard.attributes('data-y')).toBe('7')
+    expect(moveCard.attributes('data-direction')).toBe('3')
+    expect(moveCard.attributes('data-speed')).toBe('4')
+    expect(moveCard.attributes('data-character-type')).toBe('2')
+
+    const emptySlot = wrapper.find('.movement-card-stub[data-action="1"]')
+    expect(emptySlot.exists()).toBe(true)
+    expect(emptySlot.attributes('data-has-data')).toBe('false')
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary\n- remove deprecated MOVE props from StateInspector and parent wiring\n- render MovementCard strictly from shared display buffer fields (no local movement fallback)\n- add targeted MOVE slot test for buffer-driven inspector data\n\nCloses #103