### PR TITLE
fix: gate runtime console tracing behind logger policy (#15)

### DIFF
--- a/src/features/ide/composables/useAnimationWorker.ts
+++ b/src/features/ide/composables/useAnimationWorker.ts
@@ -11,6 +11,7 @@
 import { type Ref, ref, watch } from 'vue'
 
 import type { AnimationWorkerCommand } from '@/core/workers/AnimationWorker'
+import { logComposable } from '@/shared/logger'
 
 const ANIMATION_WORKER_READY_TIMEOUT_MS = 5000
 
@@ -53,6 +54,13 @@ export function useAnimationWorker(options: UseAnimationWorkerOptions) {
    * Initialize the Animation Worker
    */
   async function initialize(): Promise<void> {
+    logComposable.debug('[useAnimationWorker] initialize() called', {
+      isReady: isReady.value,
+      isInitializing: isInitializing.value,
+      hasBuffer: !!sharedAnimationBuffer.value,
+      bufferByteLength: sharedAnimationBuffer.value?.byteLength,
+    })
+
     if (isReady.value) {
       return
     }
@@ -65,6 +73,8 @@ export function useAnimationWorker(options: UseAnimationWorkerOptions) {
     initError.value = null
 
     try {
+      logComposable.debug('[useAnimationWorker] Creating Animation Worker...')
+
       // Create Animation Worker
       // Vite will bundle this automatically with the ?worker suffix pattern
       worker = new Worker(
@@ -146,6 +156,12 @@ export function useAnimationWorker(options: UseAnimationWorkerOptions) {
 
   // Watch for buffer changes and send to worker when available
   watch(sharedAnimationBuffer, (newBuffer) => {
+    logComposable.debug('[useAnimationWorker] sharedAnimationBuffer changed:', {
+      isReady: isReady.value,
+      hasWorker: !!worker,
+      hasBuffer: !!newBuffer,
+      byteLength: newBuffer?.byteLength,
+    })
     if (isReady.value && worker) {
       if (newBuffer) {
         const setBufferCommand: AnimationWorkerCommand = {
@@ -153,6 +169,7 @@ export function useAnimationWorker(options: UseAnimationWorkerOptions) {
           buffer: newBuffer,
         }
         worker.postMessage(setBufferCommand)
+        logComposable.debug('[useAnimationWorker] Sent SET_SHARED_BUFFER to AnimationWorker, byteLength:', newBuffer.byteLength)
       }
     }
   })

--- a/src/features/ide/composables/useKonvaScreenRenderer.ts
+++ b/src/features/ide/composables/useKonvaScreenRenderer.ts
@@ -9,6 +9,7 @@ import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplay
 import type { ScreenCell } from '@/core/interfaces'
 import type { SpriteState } from '@/core/sprite/types'
 import { COLORS } from '@/shared/data/palette'
+import { logScreen } from '@/shared/logger'
 
 import {
   clearBackgroundTileCache,
@@ -63,7 +64,7 @@ export function initializeKonvaLayers(stage: Konva.Stage): KonvaScreenLayers {
   layers.spriteFrontLayer = new Konva.Layer()
   stage.add(layers.spriteFrontLayer)
 
-  console.log('[initializeKonvaLayers] Created layers:', {
+  logScreen.debug('[initializeKonvaLayers] Created layers:', {
     stageChildren: stage.getChildren().length,
   })
 
@@ -192,7 +193,7 @@ export async function renderSpriteLayer(
     movementsToRender.push(actionNumber)
   }
 
-  console.log('[renderSpriteLayer] Rendering', {
+  logScreen.debug('[renderSpriteLayer] Rendering', {
     priority,
     movementsToRender: movementsToRender.length,
     actions: movementsToRender,
@@ -201,7 +202,7 @@ export async function renderSpriteLayer(
   for (const actionNumber of movementsToRender) {
     // Render animated sprite (DEF MOVE) - both active and stopped movements
     const konvaImage = await createAnimatedSpriteKonvaImage(actionNumber, spritePaletteCode, accessor)
-    console.log('[renderSpriteLayer] After createAnimatedSpriteKonvaImage:', {
+    logScreen.debug('[renderSpriteLayer] After createAnimatedSpriteKonvaImage:', {
       action: actionNumber,
       hasImage: !!konvaImage,
       x: konvaImage?.x() ?? 'null',
@@ -219,7 +220,12 @@ export async function renderSpriteLayer(
     }
   }
 
-  console.log('[renderSpriteLayer] Before layer.batchDraw(), nodeMap size:', nodeMap.size, 'layer children:', layer.getChildren().length)
+  logScreen.debug(
+    '[renderSpriteLayer] Before layer.batchDraw(), nodeMap size:',
+    nodeMap.size,
+    'layer children:',
+    layer.getChildren().length
+  )
   // Draw the layer using batchDraw() for better performance with multiple sprite updates
   layer.batchDraw()
 
@@ -343,15 +349,6 @@ export async function renderAllScreenLayers(
 }> {
   const backgroundOnly = options?.backgroundOnly ?? false
   // lastBackgroundBuffer kept for API compatibility (background is now Canvas2D)
-
-  // Commented out to reduce log flooding
-  // console.log('[renderAllScreenLayers] Called with', {
-  //   backgroundOnly,
-  //   spriteStatesCount: spriteStates.length,
-  //   hasFrontLayer: !!layers.spriteFrontLayer,
-  //   hasBackLayer: !!layers.spriteBackLayer,
-  //   spriteEnabled,
-  // })
 
   // 1. Render backdrop layer (if layer exists, otherwise handled by template)
   if (layers.backdropLayer) {

--- a/test/validation/RuntimeConsoleTracing.test.ts
+++ b/test/validation/RuntimeConsoleTracing.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+const RUNTIME_TRACE_FILES = [
+  'src/core/animation/AnimationManager.ts',
+  'src/core/workers/WebWorkerInterpreter.ts',
+  'src/core/workers/AnimationWorker.ts',
+  'src/features/ide/composables/useAnimationWorker.ts',
+  'src/features/ide/composables/useKonvaScreenRenderer.ts',
+] as const
+
+describe('Runtime tracing policy', () => {
+  test.each(RUNTIME_TRACE_FILES)('%s has no raw console.log tracing', (relativePath) => {
+    const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8')
+    expect(source).not.toMatch(/\bconsole\.log\s*\(/)
+  })
+})


### PR DESCRIPTION
## Summary
- replace raw runtime `console.log` traces in `useAnimationWorker` and `useKonvaScreenRenderer` with project loggers (`logComposable` / `logScreen`) at debug level
- remove leftover commented raw trace block in `renderAllScreenLayers`
- add a regression guard test to block `console.log` reintroduction in core/runtime files covered by issue #15

## Validation
- `pnpm -s exec vitest run test/validation/RuntimeConsoleTracing.test.ts`
- `pnpm -s exec eslint src/features/ide/composables/useAnimationWorker.ts src/features/ide/composables/useKonvaScreenRenderer.ts test/validation/RuntimeConsoleTracing.test.ts --no-warn-ignored`

Closes #15