### PR TITLE
test: add IDE boot and run smoke test coverage (#96)

### DIFF
--- a/test/e2e/ide-smoke.pw.ts
+++ b/test/e2e/ide-smoke.pw.ts
@@ -12,3 +12,44 @@ test('App boots and renders home feature cards', async ({ page }) => {
   await expect(page.locator('.features-grid .game-card')).toHaveCount(3)
   expect(pageErrors, `Unexpected page errors: ${pageErrors.map(err => err.message).join(' | ')}`).toEqual([])
 })
+
+test('IDE boots and key components mount', async ({ page }) => {
+  const pageErrors: Error[] = []
+  page.on('pageerror', (error) => {
+    pageErrors.push(error)
+  })
+
+  await page.goto('/ide')
+  await page.waitForLoadState('networkidle')
+
+  await expect(page.getByTestId('monaco-editor-container')).toBeVisible()
+  await expect(page.getByTestId('ide-screen-stage')).toBeVisible()
+  await expect(page.getByTestId('ide-run-button')).toBeVisible()
+  await expect(page.getByTestId('ide-stop-button')).toBeVisible()
+
+  expect(pageErrors, `Unexpected page errors: ${pageErrors.map(err => err.message).join(' | ')}`).toEqual([])
+})
+
+test('IDE run button is enabled and clickable', async ({ page }) => {
+  const pageErrors: Error[] = []
+  page.on('pageerror', (error) => {
+    pageErrors.push(error)
+  })
+
+  await page.goto('/ide')
+  await page.waitForLoadState('networkidle')
+
+  const runButton = page.getByTestId('ide-run-button')
+  await expect(runButton).toBeEnabled()
+  await runButton.click()
+
+  // After clicking run, stop button should become enabled
+  const stopButton = page.getByTestId('ide-stop-button')
+  await expect(stopButton).toBeEnabled({ timeout: 10_000 })
+
+  // Click stop to return to idle state
+  await stopButton.click()
+  await expect(page.getByTestId('ide-run-button')).toBeEnabled({ timeout: 10_000 })
+
+  expect(pageErrors, `Unexpected page errors: ${pageErrors.map(err => err.message).join(' | ')}`).toEqual([])
+})


### PR DESCRIPTION
## Summary
- Fixes #96

## Changes
- Added "IDE boots and key components mount" test: verifies `/ide` route loads, Monaco editor container, screen stage, and run/stop buttons are visible with no page errors
- Added "IDE run button is enabled and clickable" test: verifies run button starts enabled, clicking it enables stop button, clicking stop returns to idle

## Test plan
- [x] Targeted E2E tests pass (3/3, 12.6s)
- [x] CI passes