### PR TITLE
fix: show COI warning banner when isolation is missing (#111)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,28 @@ defineOptions({
 const { locale } = useI18n()
 const showCoiWarning = ref(false)
 
+const isE2ELiteMode = () => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  return new URLSearchParams(window.location.search).get('e2e') === 'lite'
+}
+
+const syncCoiWarningFromEnvironment = () => {
+  if (typeof window === 'undefined' || isE2ELiteMode()) {
+    showCoiWarning.value = false
+    return
+  }
+
+  showCoiWarning.value = window.crossOriginIsolated === false
+}
+
 const handleCoiServiceWorkerRegistrationFailed = (event: Event) => {
+  if (isE2ELiteMode()) {
+    return
+  }
+
   const customEvent = event as CustomEvent<CoiServiceWorkerRegistrationFailedDetail>
   if (customEvent.detail?.errorMessage) {
     showCoiWarning.value = true
@@ -51,6 +72,7 @@ watch(
 )
 
 onMounted(() => {
+  syncCoiWarningFromEnvironment()
   window.addEventListener(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, handleCoiServiceWorkerRegistrationFailed)
 })
 

--- a/test/App.test.ts
+++ b/test/App.test.ts
@@ -23,11 +23,61 @@ vi.mock('@/shared/utils/reloadPage', () => ({
 }))
 
 describe('App', () => {
+  const originalCrossOriginIsolated = window.crossOriginIsolated
+
+  const setCrossOriginIsolated = (value: boolean) => {
+    Object.defineProperty(window, 'crossOriginIsolated', {
+      configurable: true,
+      value,
+    })
+  }
+
   afterEach(() => {
+    setCrossOriginIsolated(originalCrossOriginIsolated)
+    window.history.replaceState({}, '', '/')
     vi.restoreAllMocks()
   })
 
+  it('shows warning banner on mount when cross-origin isolation is missing', async () => {
+    setCrossOriginIsolated(false)
+
+    const wrapper = mount(App)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.coi-warning-banner').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('does not show warning banner on mount when cross-origin isolation is available', () => {
+    setCrossOriginIsolated(true)
+
+    const wrapper = mount(App)
+
+    expect(wrapper.find('.coi-warning-banner').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('does not show warning banner in e2e lite mode', async () => {
+    setCrossOriginIsolated(false)
+    window.history.replaceState({}, '', '/?e2e=lite')
+
+    const wrapper = mount(App)
+
+    expect(wrapper.find('.coi-warning-banner').exists()).toBe(false)
+
+    window.dispatchEvent(
+      new CustomEvent(COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT, {
+        detail: { errorMessage: 'registration blocked' },
+      })
+    )
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.coi-warning-banner').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
   it('shows warning banner when coi registration failure event is received', async () => {
+    setCrossOriginIsolated(true)
     const wrapper = mount(App)
 
     window.dispatchEvent(


### PR DESCRIPTION
## Summary
- show COI warning banner on app mount whenever window.crossOriginIsolated === false
- keep existing registration-failure event path and suppress banner in e2e=lite mode
- add App tests for mount-time COI detection and e2e-lite suppression

## Testing
- pnpm -s test:run -- test/App.test.ts
- pnpm -s exec eslint src/App.vue test/App.test.ts --no-warn-ignored
- pnpm -s type-check

Closes #111