### PR TITLE
test: add unit tests for normalizeLocationValue (#84)

### DIFF
--- a/src/core/parser/FBasicParser.ts
+++ b/src/core/parser/FBasicParser.ts
@@ -10,14 +10,7 @@ import type { CstNode } from 'chevrotain'
 import type { ParserInfo } from '@/core/interfaces'
 
 import { parseWithChevrotain } from './FBasicChevrotainParser'
-
-function normalizeLocationValue(value: number | undefined, fallback = 1): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return fallback
-  }
-  const normalized = Math.floor(value)
-  return normalized >= 1 ? normalized : fallback
-}
+import { normalizeLocationValue } from './normalizeLocationValue'
 
 /**
  * Parser error interface

--- a/src/core/parser/normalizeLocationValue.ts
+++ b/src/core/parser/normalizeLocationValue.ts
@@ -1,0 +1,21 @@
+/**
+ * Normalize a parser diagnostic coordinate value.
+ *
+ * Ensures that location values (line, column, length) are always
+ * valid positive integers, guarding against undefined, NaN, Infinity,
+ * and non-positive values from the underlying parser.
+ *
+ * @param value - The raw numeric value (may be undefined/NaN/Infinity)
+ * @param fallback - Value returned when input is invalid (default: 1)
+ * @returns A valid positive integer >= 1
+ */
+export function normalizeLocationValue(
+  value: number | undefined,
+  fallback = 1,
+): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback
+  }
+  const normalized = Math.floor(value)
+  return normalized >= 1 ? normalized : fallback
+}

--- a/test/parser/normalizeLocationValue.test.ts
+++ b/test/parser/normalizeLocationValue.test.ts
@@ -1,0 +1,118 @@
+/**
+ * normalizeLocationValue Unit Tests
+ *
+ * Tests for the parser diagnostic coordinate normalization helper.
+ * Ensures robust handling of edge cases from the underlying Chevrotain parser.
+ *
+ * @see https://github.com/cfvbaibai/fbasic-ide/issues/84
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { normalizeLocationValue } from '@/core/parser/normalizeLocationValue'
+
+describe('normalizeLocationValue', () => {
+  describe('fallback for invalid inputs', () => {
+    it('should return default fallback for undefined input', () => {
+      expect(normalizeLocationValue(undefined)).toEqual(1)
+    })
+
+    it('should return default fallback for NaN input', () => {
+      expect(normalizeLocationValue(NaN)).toEqual(1)
+    })
+
+    it('should return default fallback for Infinity input', () => {
+      expect(normalizeLocationValue(Infinity)).toEqual(1)
+    })
+
+    it('should return default fallback for -Infinity input', () => {
+      expect(normalizeLocationValue(-Infinity)).toEqual(1)
+    })
+  })
+
+  describe('minimum value enforcement', () => {
+    it('should return fallback for zero', () => {
+      expect(normalizeLocationValue(0)).toEqual(1)
+    })
+
+    it('should return fallback for negative numbers', () => {
+      expect(normalizeLocationValue(-1)).toEqual(1)
+    })
+
+    it('should return fallback for large negative numbers', () => {
+      expect(normalizeLocationValue(-100)).toEqual(1)
+    })
+
+    it('should return fallback for decimal values below 1', () => {
+      expect(normalizeLocationValue(0.5)).toEqual(1)
+    })
+
+    it('should return fallback for 0.9999 boundary value', () => {
+      expect(normalizeLocationValue(0.9999)).toEqual(1)
+    })
+  })
+
+  describe('flooring of decimal values', () => {
+    it('should floor positive decimal values', () => {
+      expect(normalizeLocationValue(3.7)).toEqual(3)
+    })
+
+    it('should floor positive decimal values with small fractional part', () => {
+      expect(normalizeLocationValue(3.2)).toEqual(3)
+    })
+
+    it('should floor large decimal values', () => {
+      expect(normalizeLocationValue(100.9)).toEqual(100)
+    })
+
+    it('should handle exact integer as float', () => {
+      expect(normalizeLocationValue(5.0)).toEqual(5)
+    })
+  })
+
+  describe('passthrough of valid positive integers', () => {
+    it('should pass through 1', () => {
+      expect(normalizeLocationValue(1)).toEqual(1)
+    })
+
+    it('should pass through 5', () => {
+      expect(normalizeLocationValue(5)).toEqual(5)
+    })
+
+    it('should pass through large positive integers', () => {
+      expect(normalizeLocationValue(999)).toEqual(999)
+    })
+  })
+
+  describe('boundary at 1.0', () => {
+    it('should return 1 for exactly 1.0', () => {
+      expect(normalizeLocationValue(1.0)).toEqual(1)
+    })
+
+    it('should return fallback for just below 1.0', () => {
+      expect(normalizeLocationValue(0.999999)).toEqual(1)
+    })
+  })
+
+  describe('custom fallback value', () => {
+    it('should return custom fallback for undefined input', () => {
+      expect(normalizeLocationValue(undefined, 10)).toEqual(10)
+    })
+
+    it('should return custom fallback for NaN input', () => {
+      expect(normalizeLocationValue(NaN, 10)).toEqual(10)
+    })
+
+    it('should return custom fallback for zero with custom fallback', () => {
+      expect(normalizeLocationValue(0, 5)).toEqual(5)
+    })
+
+    it('should return custom fallback for negative with custom fallback', () => {
+      expect(normalizeLocationValue(-3, 7)).toEqual(7)
+    })
+
+    it('should ignore custom fallback when input is valid', () => {
+      expect(normalizeLocationValue(5, 10)).toEqual(5)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #84 — adds dedicated unit tests for the `normalizeLocationValue` helper function

## Changes
- Extract `normalizeLocationValue` from `FBasicParser.ts` into its own module (`src/core/parser/normalizeLocationValue.ts`) for testability
- Add 23 unit tests covering: undefined/NaN/Infinity/-Infinity fallback, zero/negative/decimal-below-1 minimum enforcement, decimal flooring, valid integer passthrough, boundary at 1.0, and custom fallback values
- Update `FBasicParser.ts` to import from the new module (no behavioral change)

## Test plan
- [x] 23/23 new tests pass
- [x] Full suite (1504 tests) remains green
- [ ] CI passes

🤖 Generated by Claude Code