### PR TITLE
ci: add built-preview smoke test and build warning gate (#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,3 +182,59 @@ jobs:
 
       - name: Run Playwright smoke tests
         run: pnpm test:e2e
+
+  build-warnings:
+    name: Build Warning Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.2
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check for critical build warnings
+        run: pnpm verify:build-warnings
+
+  built-preview:
+    name: Built-Preview Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.2
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build production app
+        run: pnpm build
+
+      - name: Run built-preview smoke tests
+        run: pnpm test:built-preview

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -45,6 +45,9 @@ jobs:
           VITE_BASE_PATH: /fbasic-ide/
         run: pnpm vite build
 
+      - name: Check for critical build warnings
+        run: pnpm verify:build-warnings -- --with-base
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "build": "vue-tsc && vite build",
         "preview": "vite preview",
         "preview:spa": "serve -s dist -l 4317",
+        "preview:vite": "vite preview --port 4318 --host 127.0.0.1",
         "lint": "eslint . --fix && pnpm lint:style",
         "lint:style": "stylelint \"src/**/*.{css,vue}\"",
         "type-check": "vue-tsc --noEmit",
@@ -18,6 +19,7 @@
         "test:ui": "vitest --ui",
         "test:run": "vitest run",
         "test:e2e": "playwright test",
+        "test:built-preview": "playwright test --config=playwright.config.preview.ts",
         "test:run:parallel": "vitest run --pool=forks --poolOptions.forks.maxForks=8",
         "test:run:threads": "vitest run --pool=threads --poolOptions.threads.maxThreads=8",
         "test:run:single": "vitest run --pool=forks --poolOptions.forks.singleFork=true",
@@ -31,6 +33,7 @@
         "check-syntax": "tsx scripts/validation/check-syntax.ts",
         "verify:script-entrypoints": "tsx scripts/validation/verify-script-entrypoints.ts",
         "verify:build-no-unresolved-assets": "tsx scripts/validation/check-unresolved-assets.ts",
+        "verify:build-warnings": "tsx scripts/validation/check-build-warnings.ts",
         "verify:gates": "pnpm check-syntax && pnpm verify:script-entrypoints && pnpm verify:build-no-unresolved-assets",
         "verify:build-size-budgets": "node scripts/validation/check-build-size-budgets.mjs"
     },

--- a/playwright.config.preview.ts
+++ b/playwright.config.preview.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright config for built-preview smoke tests.
+ *
+ * Unlike playwright.config.ts (which uses `serve -s dist`), this config
+ * uses `vite preview` to serve the production build. This is important
+ * because `vite preview` more closely mirrors how GitHub Pages serves
+ * the site, including proper handling of the base path.
+ *
+ * Usage:
+ *   pnpm build
+ *   pnpm exec playwright test --config=playwright.config.preview.ts
+ */
+const port = Number(process.env.PLAYWRIGHT_PREVIEW_PORT ?? 4318)
+const host = process.env.PLAYWRIGHT_HOST ?? '127.0.0.1'
+const baseURL = `http://${host}:${port}`
+
+export default defineConfig({
+  testDir: './test/e2e',
+  testMatch: 'built-preview-smoke.pw.ts',
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  timeout: 90_000,
+  expect: {
+    timeout: 30_000,
+  },
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm preview:vite',
+    url: baseURL,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+})

--- a/scripts/validation/check-build-warnings.ts
+++ b/scripts/validation/check-build-warnings.ts
@@ -1,0 +1,87 @@
+import { spawn } from 'node:child_process'
+
+/**
+ * Patterns that indicate critical build warnings that should fail CI.
+ *
+ * "Circular chunk:" - Rollup circular dependency between chunks.
+ *   These can cause TDZ (Temporal Dead Zone) runtime errors in production
+ *   that do NOT reproduce in dev mode. See vite.config.ts manualChunks
+ *   comment for historical context.
+ */
+const CRITICAL_WARNING_PATTERNS: readonly RegExp[] = [
+  /Circular chunk:/i,
+]
+
+async function runBuildAndCapture(): Promise<string> {
+  const viteArgs = process.argv.includes('--with-base')
+    ? ['vite', 'build', '--base', '/fbasic-ide/']
+    : ['vite', 'build']
+
+  return new Promise((resolve, reject) => {
+    const child =
+      process.platform === 'win32'
+        ? spawn('cmd.exe', ['/d', '/s', '/c', 'pnpm', '-s', ...viteArgs], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+          })
+        : spawn('pnpm', ['-s', ...viteArgs], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+          })
+
+    let combinedOutput = ''
+
+    child.stdout.on('data', (chunk) => {
+      const text = String(chunk)
+      combinedOutput += text
+      process.stdout.write(text)
+    })
+
+    child.stderr.on('data', (chunk) => {
+      const text = String(chunk)
+      combinedOutput += text
+      process.stderr.write(text)
+    })
+
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`vite build failed with exit code ${code ?? 'unknown'}`))
+        return
+      }
+      resolve(combinedOutput)
+    })
+  })
+}
+
+async function main(): Promise<void> {
+  const buildOutput = await runBuildAndCapture()
+
+  const matched: string[] = []
+  for (const pattern of CRITICAL_WARNING_PATTERNS) {
+    const lines = buildOutput
+      .split('\n')
+      .filter((line) => pattern.test(line))
+    matched.push(...lines.map((l) => l.trim()))
+  }
+
+  if (matched.length > 0) {
+    console.error(
+      `[check-build-warnings] Found ${matched.length} critical build warning(s):`
+    )
+    for (const line of matched) {
+      console.error(`  - ${line}`)
+    }
+    console.error(
+      '[check-build-warnings] Critical build warnings detected. CI failed.'
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    '[check-build-warnings] No critical build warnings found. Build is clean.'
+  )
+}
+
+main().catch((error) => {
+  console.error('[check-build-warnings] Unexpected error:', error)
+  process.exit(1)
+})

--- a/test/e2e/built-preview-smoke.pw.ts
+++ b/test/e2e/built-preview-smoke.pw.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Built-preview smoke test.
+ *
+ * This test runs against the *production build* served via `vite preview`
+ * rather than the dev server. It catches prod-only runtime errors such as
+ * Rollup chunk ordering issues, Monaco TDZ violations, and missing assets
+ * that do NOT reproduce in dev mode.
+ *
+ * The test intentionally collects ALL uncaught page errors
+ * so that any runtime regression is surfaced immediately.
+ */
+
+test.describe('built-preview smoke', () => {
+  test('IDE boots without runtime errors on production build', async ({ page }) => {
+    const pageErrors: Error[] = []
+
+    page.on('pageerror', (error) => {
+      pageErrors.push(error)
+    })
+
+    await page.goto('/#/ide')
+    await page.waitForLoadState('networkidle')
+
+    // Verify key IDE UI elements rendered (proves the app booted successfully)
+    await expect(page.getByTestId('monaco-editor-container')).toBeVisible({
+      timeout: 30_000,
+    })
+    await expect(page.getByTestId('ide-screen-stage')).toBeVisible()
+    await expect(page.getByTestId('ide-run-button')).toBeVisible()
+
+    // Fail on any uncaught runtime errors (TDZ, missing exports, etc.)
+    expect(
+      pageErrors,
+      `Production build has uncaught page errors: ${pageErrors.map((e) => e.message).join(' | ')}`
+    ).toEqual([])
+  })
+
+  test('Home page boots without runtime errors on production build', async ({ page }) => {
+    const pageErrors: Error[] = []
+
+    page.on('pageerror', (error) => {
+      pageErrors.push(error)
+    })
+
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.locator('.features-grid .game-card')).toHaveCount(3, {
+      timeout: 30_000,
+    })
+
+    expect(
+      pageErrors,
+      `Production build has uncaught page errors: ${pageErrors.map((e) => e.message).join(' | ')}`
+    ).toEqual([])
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "src/**/*.ts",
     "src/**/*.d.ts",
     "test/**/*.ts",
-    "scripts/validation/script-entrypoint-integrity.ts"
+    "scripts/validation/script-entrypoint-integrity.ts",
+    "playwright.config.preview.ts"
   ],
   "exclude": [
     "src/**/__tests__/*",


### PR DESCRIPTION
## Summary
- Fixes #107

## Changes
- **Build warning gate** (`scripts/validation/check-build-warnings.ts`): Fails CI when Rollup outputs circular chunk or other critical warnings during build
- **Built-preview smoke tests** (`test/e2e/built-preview-smoke.pw.ts`): Playwright tests that load the production build via `vite preview` and fail on any uncaught page errors. Tests IDE route (`/#/ide`) and home page (`/`)
- **Preview Playwright config** (`playwright.config.preview.ts`): Dedicated config using `vite preview` on port 4318
- **CI workflow** (`.github/workflows/ci.yml`): Two new jobs — `build-warnings` and `built-preview` smoke test
- **Deploy workflow** (`.github/workflows/deploy-pages.yml`): Build warning check before artifact upload
- **Package scripts**: Added `preview:vite`, `test:built-preview`, `verify:build-warnings`

## Test plan
- [ ] Build warning gate detects circular chunk warnings
- [ ] Built-preview smoke tests pass (2/2: IDE boots, home page boots)
- [ ] Existing E2E tests pass (6/6, no regressions)
- [ ] CI passes