### PR TITLE
test: add negative selector and NaN tests for ON GOSUB parity (#90)

### DIFF
--- a/test/executors/OnExecutor.test.ts
+++ b/test/executors/OnExecutor.test.ts
@@ -26,7 +26,7 @@ describe('OnExecutor', () => {
 
   describe('ON ... GOTO', () => {
     it('should jump to first line when expression is 1', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET X = 1
 20 ON X GOTO 100, 200, 300
 30 PRINT "Skipped"
@@ -37,17 +37,14 @@ describe('OnExecutor', () => {
 210 END
 300 PRINT "Third"
 310 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('First\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('First\nOK\n')
     })
 
     it('should jump to second line when expression is 2', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET X = 2
 20 ON X GOTO 100, 200, 300
 30 PRINT "Skipped"
@@ -58,17 +55,14 @@ describe('OnExecutor', () => {
 210 END
 300 PRINT "Third"
 310 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('Second\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Second\nOK\n')
     })
 
     it('should jump to third line when expression is 3', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET X = 3
 20 ON X GOTO 100, 200, 300
 30 PRINT "Skipped"
@@ -79,20 +73,15 @@ describe('OnExecutor', () => {
 210 END
 300 PRINT "Third"
 310 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('Third\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Third\nOK\n')
     })
 
     it('should proceed to next line when expression is 0', async () => {
-      // Manual: "When the value of the equation is 0 or when it exceeds the
-      // specified number of lines, it moves to the next sentence after the
-      // ON sentence."
-      const source = `
+      // Manual: value of 0 or exceeding line count falls through to next statement
+      const result = await interpreter.execute(`
 10 LET X = 0
 20 ON X GOTO 100, 200, 300
 30 PRINT "Next"
@@ -103,20 +92,15 @@ describe('OnExecutor', () => {
 210 END
 300 PRINT "Third"
 310 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('Next\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Next\nOK\n')
     })
 
     it('should proceed to next line when expression exceeds number of lines', async () => {
-      // Manual: "When the value of the equation is 0 or when it exceeds the
-      // specified number of lines, it moves to the next sentence after the
-      // ON sentence."
-      const source = `
+      // Manual: value of 0 or exceeding line count falls through to next statement
+      const result = await interpreter.execute(`
 10 LET X = 5
 20 ON X GOTO 100, 200, 300
 30 PRINT "Next"
@@ -127,17 +111,14 @@ describe('OnExecutor', () => {
 210 END
 300 PRINT "Third"
 310 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('Next\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Next\nOK\n')
     })
 
     it('should handle ON with expression', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET X = 1
 20 ON X + 1 GOTO 100, 200, 300
 30 PRINT "Skipped"
@@ -148,17 +129,14 @@ describe('OnExecutor', () => {
 210 END
 300 PRINT "Third"
 310 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('Second\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Second\nOK\n')
     })
 
     it('should handle negative expression value', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET X = -1
 20 ON X GOTO 100, 200, 300
 30 PRINT "Next"
@@ -169,18 +147,15 @@ describe('OnExecutor', () => {
 210 END
 300 PRINT "Third"
 310 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('Next\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Next\nOK\n')
     })
 
     it('should handle fractional expression value (truncated to integer)', async () => {
-      // Use expression that results in fractional value: 5 / 2 = 2.5, truncated to 2
-      const source = `
+      // 5 / 2 = 2.5 truncated to 2, so should jump to second line
+      const result = await interpreter.execute(`
 10 LET X = 5
 20 ON X / 2 GOTO 100, 200, 300
 30 PRINT "Skipped"
@@ -191,20 +166,16 @@ describe('OnExecutor', () => {
 210 END
 300 PRINT "Third"
 310 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      // 5 / 2 = 2.5 truncated to 2, so should jump to second line
-      expect(outputs).toEqual('Second\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Second\nOK\n')
     })
   })
 
   describe('ON ... GOSUB', () => {
     it('should jump to first line when expression is 1', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET N = 1
 20 ON N GOSUB 100, 200, 300
 30 PRINT "After"
@@ -215,18 +186,14 @@ describe('OnExecutor', () => {
 210 RETURN
 300 PRINT "Third"
 310 RETURN
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      // PRINT "After" doesn't end with semicolon, so adds newline
-      expect(outputs).toEqual('First\nAfter\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('First\nAfter\nOK\n')
     })
 
     it('should proceed to next line when expression is 0', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET N = 0
 20 ON N GOSUB 100, 200, 300
 30 PRINT "Next"
@@ -237,17 +204,14 @@ describe('OnExecutor', () => {
 210 RETURN
 300 PRINT "Third"
 310 RETURN
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('Next\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Next\nOK\n')
     })
 
     it('should proceed to next line when expression exceeds number of lines', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET N = 4
 20 ON N GOSUB 100, 200, 300
 30 PRINT "Next"
@@ -258,17 +222,54 @@ describe('OnExecutor', () => {
 210 RETURN
 300 PRINT "Third"
 310 RETURN
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('Next\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Next\nOK\n')
+    })
+
+    it('should handle negative expression value', async () => {
+      const result = await interpreter.execute(`
+10 LET N = -1
+20 ON N GOSUB 100, 200, 300
+30 PRINT "Next"
+40 END
+100 PRINT "First"
+110 RETURN
+200 PRINT "Second"
+210 RETURN
+300 PRINT "Third"
+310 RETURN
+`)
+      expect(result.success).toBe(true)
+      expect(result.errors).toHaveLength(0)
+      expect(deviceAdapter.getAllOutputs()).toEqual('Next\nOK\n')
+    })
+
+    it('should return a clear runtime error for NaN selector value', async () => {
+      // parseFloat("NaN") returns NaN, and Number.isFinite(NaN) is false
+      const result = await interpreter.execute(`
+10 LET N$ = "NaN"
+20 ON N$ GOSUB 100, 200
+30 PRINT "This should not print"
+40 END
+100 PRINT "First"
+110 RETURN
+200 PRINT "Second"
+210 RETURN
+`)
+      expect(result.success).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors.map(e => e.message).join(' ')).toEqual(
+        'ON: expression must evaluate to a number'
+      )
+      expect(deviceAdapter.getAllOutputs()).toEqual(
+        'RUNTIME: ON: expression must evaluate to a number'
+      )
     })
 
     it('should return a clear runtime error for Infinity selector value', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET N$ = "Infinity"
 20 ON N$ GOSUB 100, 200
 30 PRINT "This should not print"
@@ -277,20 +278,19 @@ describe('OnExecutor', () => {
 110 RETURN
 200 PRINT "Second"
 210 RETURN
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
-      const errorMessages = result.errors.map(e => e.message).join(' ')
-      expect(errorMessages).toEqual('ON: expression must evaluate to a number')
-
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('RUNTIME: ON: expression must evaluate to a number')
+      expect(result.errors.map(e => e.message).join(' ')).toEqual(
+        'ON: expression must evaluate to a number'
+      )
+      expect(deviceAdapter.getAllOutputs()).toEqual(
+        'RUNTIME: ON: expression must evaluate to a number'
+      )
     })
 
     it('should return to the statement after each ON GOSUB across repeated invocations', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET N = 1
 20 ON N GOSUB 100, 200
 30 LET N = 2
@@ -301,18 +301,15 @@ describe('OnExecutor', () => {
 110 RETURN
 200 PRINT "Second"
 210 RETURN
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('First\nSecond\nAfter\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('First\nSecond\nAfter\nOK\n')
     })
 
     it('should handle ON-GOSUB matching manual example structure', async () => {
-      // From manual page 66 example structure
-      const source = `
+      // From manual page 66: N=2 calls line 200 which sets X$="HOPE"
+      const result = await interpreter.execute(`
 10 REM * ON-GOSUB *
 20 LET N = 2
 30 ON N GOSUB 100,200,300,400,500,600
@@ -325,22 +322,16 @@ describe('OnExecutor', () => {
 400 X$="MAN": RETURN
 500 X$="PERFECTION": RETURN
 600 X$="WEDDING": RETURN
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      // Manual example: N=2, so ON N GOSUB calls line 200 which sets X$="HOPE"
-      // Then prints: " 2 IS THE SYMBOL OF HOPE."
-      // PRINT doesn't end with semicolon, so adds newline
-      expect(outputs).toEqual(' 2 IS THE SYMBOL OF HOPE.\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual(' 2 IS THE SYMBOL OF HOPE.\nOK\n')
     })
   })
 
   describe('ON ... RETURN', () => {
     it('should return to first line when expression is 1', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 GOSUB 100
 20 PRINT "After"
 30 END
@@ -353,18 +344,14 @@ describe('OnExecutor', () => {
 310 RETURN
 400 PRINT "Third"
 410 RETURN
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      // PRINT "After" doesn't end with semicolon, so adds newline
-      expect(outputs).toEqual('First\nAfter\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('First\nAfter\nOK\n')
     })
 
     it('should return to second line when expression is 2', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 GOSUB 100
 20 PRINT "After"
 30 END
@@ -377,20 +364,17 @@ describe('OnExecutor', () => {
 310 RETURN
 400 PRINT "Third"
 410 RETURN
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      // PRINT "After" doesn't end with semicolon, so adds newline
-      expect(outputs).toEqual('Second\nAfter\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Second\nAfter\nOK\n')
     })
   })
 
   describe('ON ... RESTORE', () => {
     it('should restore data pointer to first line when expression is 1', async () => {
-      const source = `
+      // Should read from line 10: 10, 20, 30
+      const result = await interpreter.execute(`
 10 DATA 10, 20, 30
 20 DATA 40, 50, 60
 30 DATA 70, 80, 90
@@ -399,20 +383,15 @@ describe('OnExecutor', () => {
 60 READ A, B, C
 70 PRINT A, B, C
 80 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      // Should read from line 10: 10, 20, 30
-      // Numbers get leading space, comma separator uses tab stops
-      // PRINT doesn't end with semicolon, so adds newline
-      expect(outputs).toEqual(' 10\t 20\t 30\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual(' 10\t 20\t 30\nOK\n')
     })
 
     it('should restore data pointer to second line when expression is 2', async () => {
-      const source = `
+      // Should read from line 20: 40, 50, 60
+      const result = await interpreter.execute(`
 10 DATA 10, 20, 30
 20 DATA 40, 50, 60
 30 DATA 70, 80, 90
@@ -421,19 +400,15 @@ describe('OnExecutor', () => {
 60 READ A, B, C
 70 PRINT A, B, C
 80 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      // Should read from line 20: 40, 50, 60
-      // Numbers get leading space, comma separator uses tab stops
-      expect(outputs).toEqual(' 40\t 50\t 60\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual(' 40\t 50\t 60\nOK\n')
     })
 
     it('should proceed to next line when expression is 0 or out of range', async () => {
-      const source = `
+      // Should read from default position (beginning): 10
+      const result = await interpreter.execute(`
 10 DATA 10, 20
 20 DATA 30, 40
 30 LET X = 0
@@ -441,21 +416,16 @@ describe('OnExecutor', () => {
 50 READ A
 60 PRINT A
 70 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      // Should read from default position (beginning): 10
-      const outputs = deviceAdapter.getAllOutputs()
-      // Numbers get leading space
-      expect(outputs).toEqual(' 10\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual(' 10\nOK\n')
     })
   })
 
   describe('Error Handling', () => {
     it('should return a clear runtime error for non-numeric string expression', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET X$ = "ABC"
 20 ON X$ GOTO 100, 200
 30 PRINT "This should not print"
@@ -464,20 +434,19 @@ describe('OnExecutor', () => {
 110 END
 200 PRINT "Second"
 210 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
-      const errorMessages = result.errors.map(e => e.message).join(' ')
-      expect(errorMessages).toEqual('ON: expression must evaluate to a number')
-
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('RUNTIME: ON: expression must evaluate to a number')
+      expect(result.errors.map(e => e.message).join(' ')).toEqual(
+        'ON: expression must evaluate to a number'
+      )
+      expect(deviceAdapter.getAllOutputs()).toEqual(
+        'RUNTIME: ON: expression must evaluate to a number'
+      )
     })
 
     it('should return a clear runtime error for Infinity expression values', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET X$ = "Infinity"
 20 ON X$ GOTO 100, 200
 30 PRINT "This should not print"
@@ -486,39 +455,32 @@ describe('OnExecutor', () => {
 110 END
 200 PRINT "Second"
 210 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
-      const errorMessages = result.errors.map(e => e.message).join(' ')
-      expect(errorMessages).toEqual('ON: expression must evaluate to a number')
-
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('RUNTIME: ON: expression must evaluate to a number')
+      expect(result.errors.map(e => e.message).join(' ')).toEqual(
+        'ON: expression must evaluate to a number'
+      )
+      expect(deviceAdapter.getAllOutputs()).toEqual(
+        'RUNTIME: ON: expression must evaluate to a number'
+      )
     })
 
     it('should error on ON to non-existent line number', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET X = 1
 20 ON X GOTO 999
 30 PRINT "This should not print"
 40 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
-      const errorMessages = result.errors.map(e => e.message).join(' ')
-      expect(errorMessages).toEqual('ON: line number 999 not found')
-
-      // Verify that PRINT statements after the error are not executed
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('RUNTIME: ON: line number 999 not found')
+      expect(result.errors.map(e => e.message).join(' ')).toEqual('ON: line number 999 not found')
+      expect(deviceAdapter.getAllOutputs()).toEqual('RUNTIME: ON: line number 999 not found')
     })
 
     it('should handle ON with multiple line numbers where one is invalid', async () => {
-      const source = `
+      const result = await interpreter.execute(`
 10 LET X = 2
 20 ON X GOTO 100, 999, 300
 30 PRINT "This should not print"
@@ -527,30 +489,18 @@ describe('OnExecutor', () => {
 110 END
 300 PRINT "Third"
 310 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
-      const errorMessages = result.errors.map(e => e.message).join(' ')
-      expect(errorMessages).toEqual('ON: line number 999 not found')
-
-      // Verify that PRINT statements after the error are not executed
-      const outputs = deviceAdapter.getAllOutputs()
-      expect(outputs).toEqual('RUNTIME: ON: line number 999 not found')
+      expect(result.errors.map(e => e.message).join(' ')).toEqual('ON: line number 999 not found')
+      expect(deviceAdapter.getAllOutputs()).toEqual('RUNTIME: ON: line number 999 not found')
     })
   })
 
   describe('Comparison with IF-THEN', () => {
     it('should work like multiple IF-THEN statements', async () => {
-      // Manual page 66 shows ON X GOTO 1000,2000,3000,4000,5000
-      // is equivalent to:
-      // IF X=1 THEN 1000
-      // IF X=2 THEN 2000
-      // IF X=3 THEN 3000
-      // IF X=4 THEN 4000
-      // IF X=5 THEN 5000
-      const source = `
+      // Manual page 66: ON X GOTO is equivalent to multiple IF X=N THEN statements
+      const result = await interpreter.execute(`
 10 LET X = 3
 20 ON X GOTO 100, 200, 300, 400, 500
 30 PRINT "Skipped"
@@ -565,14 +515,10 @@ describe('OnExecutor', () => {
 410 END
 500 PRINT "Five"
 510 END
-`
-      const result = await interpreter.execute(source)
-
+`)
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
-      const outputs = deviceAdapter.getAllOutputs()
-      // PRINT "Three" doesn't end with semicolon, so adds newline
-      expect(outputs).toEqual('Three\nOK\n')
+      expect(deviceAdapter.getAllOutputs()).toEqual('Three\nOK\n')
     })
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #90

## Changes
- Added negative selector test for ON GOSUB (mirrors existing ON GOTO test)
- Added NaN selector test for ON GOSUB with clear runtime error assertion
- Compacted test file to stay under 500-line limit

## Test plan
- [ ] 26/26 OnExecutor tests pass (up from 24)
- [ ] All 1506 tests pass
- [ ] CI passes