### PR TITLE
chore: remove debug console.log calls from production composables (#118)

### DIFF
--- a/src/features/ide/composables/useBasicIdeEnhanced.ts
+++ b/src/features/ide/composables/useBasicIdeEnhanced.ts
@@ -80,32 +80,7 @@ export function useBasicIde() {
   }
 
   const debugBuffer = () => {
-    const accessor = screen.sharedDisplayBufferAccessor
-    console.group('🔍 Shared Animation/Sprite Buffer')
-
-    // Show ALL sprite slots (0-7), no filtering
-    for (let i = 0; i < 8; i++) {
-      console.log(`Sprite ${i}:`, {
-        actionNumber: i,
-        position: accessor.readSpritePosition(i),
-        isActive: accessor.readSpriteIsActive(i),
-        isVisible: accessor.readSpriteIsVisible(i),
-        frameIndex: accessor.readSpriteFrameIndex(i),
-        remainingDistance: accessor.readSpriteRemainingDistance(i),
-        totalDistance: accessor.readSpriteTotalDistance(i),
-        direction: accessor.readSpriteDirection(i),
-        speed: accessor.readSpriteSpeed(i),
-        priority: accessor.readSpritePriority(i),
-        characterType: accessor.readSpriteCharacterType(i),
-        colorCombination: accessor.readSpriteColorCombination(i),
-      })
-    }
-
-    // Show sync command state
-    const syncCommand = accessor.readSyncCommand()
-    console.log('Sync Command:', syncCommand ?? '(none)')
-
-    console.groupEnd()
+    // no-op: console.log debug output removed; retained for API compatibility
   }
 
   watch(

--- a/src/features/ide/composables/useMovementStateSync.ts
+++ b/src/features/ide/composables/useMovementStateSync.ts
@@ -40,11 +40,6 @@ export function useMovementStateSync(options: UseMovementStateSyncOptions) {
   watch(
     movementStatesFromBuffer,
     (newStates) => {
-      console.log('[useMovementStateSync] movementStates from buffer changed', {
-        newStatesCount: newStates.length,
-        actionNumbers: newStates.map(m => m.actionNumber),
-      })
-
       if (newStates.length === 0) {
         localMovementStates.value = []
         return
@@ -57,13 +52,8 @@ export function useMovementStateSync(options: UseMovementStateSyncOptions) {
         isActive: false, // Will be synced from buffer by animation loop
       }))
 
-      console.log('[useMovementStateSync] After sync, localMovementStates', {
-        total: localMovementStates.value.length,
-      })
-
       // Trigger callback after sync
       if (onSync) {
-        console.log('[useMovementStateSync] Calling onSync callback')
         onSync()
       }
     },


### PR DESCRIPTION
## Summary
- Fixes #118

## Changes
- Removed 3 `console.log()` calls from `useMovementStateSync.ts`
- Removed `console.group()`/`console.log()`/`console.groupEnd()` from `useBasicIdeEnhanced.ts` debugBuffer function (now a no-op retained for API compatibility)
- `useKonvaScreenRenderer.ts` and `useAnimationWorker.ts` were already migrated to the logger system — no changes needed

## Test plan
- [ ] All 1504 tests pass
- [ ] ESLint clean on changed files
- [ ] CI passes