### PR TITLE
fix: localize ProgramToolbar discard-changes confirm dialog (#102)

### DIFF
--- a/src/features/ide/components/ProgramToolbar.vue
+++ b/src/features/ide/components/ProgramToolbar.vue
@@ -21,7 +21,7 @@ const nameInputEl = useTemplateRef<HTMLInputElement>('nameInputEl')
 // Confirm dialog for unsaved changes
 function confirmDiscard(): boolean {
   if (!programStore.isDirty.value) return true
-  return confirm('Discard unsaved changes?')
+  return confirm(t('ide.toolbar.discardConfirm'))
 }
 
 // File operations

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -3,7 +3,8 @@
   "toolbar": {
     "new": "New",
     "import": "Import",
-    "export": "Export"
+    "export": "Export",
+    "discardConfirm": "Discard unsaved changes?"
   },
   "codeEditor": {
     "title": "Code Editor",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -3,7 +3,8 @@
   "toolbar": {
     "new": "新規",
     "import": "インポート",
-    "export": "エクスポート"
+    "export": "エクスポート",
+    "discardConfirm": "未保存の変更を破棄しますか？"
   },
   "codeEditor": {
     "title": "コードエディター",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -3,7 +3,8 @@
   "toolbar": {
     "new": "新建",
     "import": "导入",
-    "export": "导出"
+    "export": "导出",
+    "discardConfirm": "是否放弃未保存的更改？"
   },
   "codeEditor": {
     "title": "代码编辑器",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -3,7 +3,8 @@
   "toolbar": {
     "new": "新建",
     "import": "匯入",
-    "export": "匯出"
+    "export": "匯出",
+    "discardConfirm": "是否放棄未儲存的變更？"
   },
   "codeEditor": {
     "title": "程式碼編輯器",

--- a/test/ide/ProgramToolbar.test.ts
+++ b/test/ide/ProgramToolbar.test.ts
@@ -1,0 +1,62 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import ProgramToolbar from '@/features/ide/components/ProgramToolbar.vue'
+
+const mockConfirm = vi.fn()
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.toolbar.new': 'New',
+        'ide.toolbar.import': 'Import',
+        'ide.toolbar.export': 'Export',
+        'ide.toolbar.discardConfirm': 'Discard unsaved changes?',
+      }
+      return messages[key] ?? key
+    },
+    locale: ref('en'),
+  }),
+}))
+
+vi.mock('@/features/ide/composables/useProgramStore', () => ({
+  useProgramStore: () => ({
+    isDirty: ref(true),
+    programName: 'Test Program',
+    newProgram: vi.fn(),
+    open: vi.fn(),
+    save: vi.fn(),
+    currentProgram: ref(null),
+    loadProgram: vi.fn(),
+  }),
+}))
+
+describe('ProgramToolbar', () => {
+  beforeEach(() => {
+    vi.stubGlobal('confirm', mockConfirm)
+    mockConfirm.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('calls confirm with localized discard message when New is clicked and program is dirty', async () => {
+    mockConfirm.mockReturnValue(false)
+
+    const wrapper = mount(ProgramToolbar, {
+      props: { isCompact: false },
+    })
+
+    // Find the New button (first button in file-buttons)
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toBeGreaterThanOrEqual(1)
+    await buttons[0]!.trigger('click')
+
+    expect(mockConfirm).toHaveBeenCalledWith('Discard unsaved changes?')
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #102

## Changes
- Replaced hardcoded `confirm('Discard unsaved changes?')` with `confirm(t('ide.toolbar.discardConfirm'))`
- Added `ide.toolbar.discardConfirm` key to all 4 locale files (en, ja, zh-CN, zh-TW)
- Added test verifying the confirm dialog uses the localized string

## Test plan
- [ ] 1518 tests pass (including new ProgramToolbar test)
- [ ] ESLint clean
- [ ] CI passes