### PR TITLE
fix: localize remaining IDE component strings (#123)

### DIFF
--- a/src/features/ide/components/CommandPalette.vue
+++ b/src/features/ide/components/CommandPalette.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import type { CommandPaletteCommand } from '@/features/ide/composables/commandPalette'
 import { filterCommandPaletteCommands } from '@/features/ide/composables/commandPalette'
@@ -17,6 +18,8 @@ const emit = defineEmits<{
   (e: 'close'): void
   (e: 'execute', command: CommandPaletteCommand): void
 }>()
+
+const { t } = useI18n()
 
 const query = ref('')
 const selectedIndex = ref(0)
@@ -130,7 +133,7 @@ function handlePanelKeydown(event: KeyboardEvent) {
       class="command-palette-panel"
       role="dialog"
       aria-modal="true"
-      aria-label="Command palette"
+      :aria-label="t('ide.commandPalette.ariaLabel')"
       @keydown="handlePanelKeydown"
     >
       <div class="command-palette-header">
@@ -139,12 +142,12 @@ function handlePanelKeydown(event: KeyboardEvent) {
           v-model="query"
           type="text"
           class="command-palette-input"
-          placeholder="Type a command..."
-          aria-label="Search commands"
+          :placeholder="t('ide.commandPalette.searchPlaceholder')"
+          :aria-label="t('ide.commandPalette.searchLabel')"
         />
       </div>
 
-      <ul class="command-palette-list" role="listbox" aria-label="Commands">
+      <ul class="command-palette-list" role="listbox" :aria-label="t('ide.commandPalette.commandsLabel')">
         <li
           v-for="(command, index) in filteredCommands"
           :key="command.id"
@@ -165,7 +168,7 @@ function handlePanelKeydown(event: KeyboardEvent) {
         </li>
 
         <li v-if="filteredCommands.length === 0" class="command-palette-empty">
-          No matching commands
+          {{ t('ide.commandPalette.noMatches') }}
         </li>
       </ul>
     </div>

--- a/src/features/ide/components/EditorViewToggle.vue
+++ b/src/features/ide/components/EditorViewToggle.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 import { GameButton, GameIconButton } from '@/shared/components/ui'
 
 /**
@@ -17,6 +19,8 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   (e: 'update:modelValue', value: 'code' | 'bg'): void
 }>()
+
+const { t } = useI18n()
 
 interface Props {
   /** Current view: 'code' or 'bg' */
@@ -42,7 +46,7 @@ function selectBg() {
         type="default"
         icon="mdi:code-tags"
         size="small"
-        title="Code"
+        :title="t('ide.editorViewToggle.codeTitle')"
         :selected="props.modelValue === 'code'"
         @click="selectCode"
       />
@@ -51,7 +55,7 @@ function selectBg() {
         type="default"
         icon="mdi:view-grid"
         size="small"
-        title="BG"
+        :title="t('ide.editorViewToggle.bgTitle')"
         :selected="props.modelValue === 'bg'"
         @click="selectBg"
       />
@@ -65,7 +69,7 @@ function selectBg() {
         :selected="props.modelValue === 'code'"
         @click="selectCode"
       >
-        Code
+        {{ t('ide.editorViewToggle.code') }}
       </GameButton>
       <GameButton
         variant="toggle"
@@ -75,7 +79,7 @@ function selectBg() {
         :selected="props.modelValue === 'bg'"
         @click="selectBg"
       >
-        BG
+        {{ t('ide.editorViewToggle.bg') }}
       </GameButton>
     </template>
   </div>

--- a/src/features/ide/components/IdeOutputPanel.vue
+++ b/src/features/ide/components/IdeOutputPanel.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 import type { BasicVariable } from '@/core/interfaces'
 import { GameIconButton } from '@/shared/components/ui'
 
@@ -15,6 +17,8 @@ defineOptions({
 })
 
 defineProps<Props>()
+
+const { t } = useI18n()
 
 interface Props {
   // RuntimeOutput props
@@ -34,7 +38,7 @@ const logLevelPanelOpen = defineModel<boolean>('logLevelPanelOpen', { default: f
     <div class="log-level-toggle">
       <GameIconButton
         :icon="logLevelPanelOpen ? 'mdi:close' : 'mdi:format-list-bulleted-type'"
-        :title="logLevelPanelOpen ? 'Close log levels' : 'Open log levels'"
+        :title="logLevelPanelOpen ? t('ide.ideOutputPanel.closeLogLevels') : t('ide.ideOutputPanel.openLogLevels')"
         size="small"
         @click="logLevelPanelOpen = !logLevelPanelOpen"
       />

--- a/src/features/ide/components/InputModeToggle.vue
+++ b/src/features/ide/components/InputModeToggle.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 import { GameButton, GameIconButton } from '@/shared/components/ui'
 
 import type { InputMode } from '../composables/useBasicIdeState'
@@ -20,6 +22,8 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   (e: 'update:modelValue', value: InputMode): void
 }>()
+
+const { t } = useI18n()
 
 interface Props {
   /** Current input mode: 'joystick' or 'keyboard' */
@@ -45,7 +49,7 @@ function selectKeyboard() {
         type="default"
         icon="mdi:gamepad-variant"
         size="small"
-        title="Joystick Mode (STICK/STRIG)"
+        :title="t('ide.inputModeToggle.joystickTitle')"
         :selected="props.modelValue === 'joystick'"
         @click="selectJoystick"
       />
@@ -54,7 +58,7 @@ function selectKeyboard() {
         type="default"
         icon="mdi:keyboard"
         size="small"
-        title="Keyboard Mode (INKEY$)"
+        :title="t('ide.inputModeToggle.keyboardTitle')"
         :selected="props.modelValue === 'keyboard'"
         @click="selectKeyboard"
       />
@@ -68,7 +72,7 @@ function selectKeyboard() {
         :selected="props.modelValue === 'joystick'"
         @click="selectJoystick"
       >
-        Joy
+        {{ t('ide.inputModeToggle.joystick') }}
       </GameButton>
       <GameButton
         variant="toggle"
@@ -78,7 +82,7 @@ function selectKeyboard() {
         :selected="props.modelValue === 'keyboard'"
         @click="selectKeyboard"
       >
-        Key
+        {{ t('ide.inputModeToggle.keyboard') }}
       </GameButton>
     </template>
   </div>

--- a/src/features/ide/components/ProgramToolbar.vue
+++ b/src/features/ide/components/ProgramToolbar.vue
@@ -182,7 +182,7 @@ onUnmounted(() => {
           v-model="tempName"
           type="text"
           class="program-name-input"
-          placeholder="Program name"
+          :placeholder="t('ide.toolbar.programNamePlaceholder')"
           @blur="finishRename"
           @keydown="handleNameKeydown"
         />

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -4,7 +4,8 @@
     "new": "New",
     "import": "Import",
     "export": "Export",
-    "discardConfirm": "Discard unsaved changes?"
+    "discardConfirm": "Discard unsaved changes?",
+    "programNamePlaceholder": "Program name"
   },
   "codeEditor": {
     "title": "Code Editor",
@@ -95,6 +96,29 @@
         "select": "Select"
       }
     }
+  },
+  "editorViewToggle": {
+    "code": "Code",
+    "codeTitle": "Code",
+    "bg": "BG",
+    "bgTitle": "BG"
+  },
+  "inputModeToggle": {
+    "joystick": "Joy",
+    "joystickTitle": "Joystick Mode (STICK/STRIG)",
+    "keyboard": "Key",
+    "keyboardTitle": "Keyboard Mode (INKEY$)"
+  },
+  "commandPalette": {
+    "ariaLabel": "Command palette",
+    "searchPlaceholder": "Type a command...",
+    "searchLabel": "Search commands",
+    "commandsLabel": "Commands",
+    "noMatches": "No matching commands"
+  },
+  "ideOutputPanel": {
+    "closeLogLevels": "Close log levels",
+    "openLogLevels": "Open log levels"
   },
   "stateInspector": {
     "title": "State Inspector",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -4,7 +4,8 @@
     "new": "新規",
     "import": "インポート",
     "export": "エクスポート",
-    "discardConfirm": "未保存の変更を破棄しますか？"
+    "discardConfirm": "未保存の変更を破棄しますか？",
+    "programNamePlaceholder": "プログラム名"
   },
   "codeEditor": {
     "title": "コードエディター",
@@ -95,6 +96,29 @@
         "select": "セレクト"
       }
     }
+  },
+  "editorViewToggle": {
+    "code": "コード",
+    "codeTitle": "コード",
+    "bg": "BG",
+    "bgTitle": "BG"
+  },
+  "inputModeToggle": {
+    "joystick": "ジョイ",
+    "joystickTitle": "ジョイスティックモード (STICK/STRIG)",
+    "keyboard": "キー",
+    "keyboardTitle": "キーボードモード (INKEY$)"
+  },
+  "commandPalette": {
+    "ariaLabel": "コマンドパレット",
+    "searchPlaceholder": "コマンドを入力...",
+    "searchLabel": "コマンドを検索",
+    "commandsLabel": "コマンド",
+    "noMatches": "一致するコマンドがありません"
+  },
+  "ideOutputPanel": {
+    "closeLogLevels": "ログレベルを閉じる",
+    "openLogLevels": "ログレベルを開く"
   },
   "stateInspector": {
     "title": "状態インスペクタ",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -4,7 +4,8 @@
     "new": "新建",
     "import": "导入",
     "export": "导出",
-    "discardConfirm": "是否放弃未保存的更改？"
+    "discardConfirm": "是否放弃未保存的更改？",
+    "programNamePlaceholder": "程序名称"
   },
   "codeEditor": {
     "title": "代码编辑器",
@@ -95,6 +96,29 @@
         "select": "选择"
       }
     }
+  },
+  "editorViewToggle": {
+    "code": "代码",
+    "codeTitle": "代码",
+    "bg": "背景",
+    "bgTitle": "背景"
+  },
+  "inputModeToggle": {
+    "joystick": "手柄",
+    "joystickTitle": "手柄模式 (STICK/STRIG)",
+    "keyboard": "键盘",
+    "keyboardTitle": "键盘模式 (INKEY$)"
+  },
+  "commandPalette": {
+    "ariaLabel": "命令面板",
+    "searchPlaceholder": "输入命令...",
+    "searchLabel": "搜索命令",
+    "commandsLabel": "命令",
+    "noMatches": "没有匹配的命令"
+  },
+  "ideOutputPanel": {
+    "closeLogLevels": "关闭日志级别",
+    "openLogLevels": "打开日志级别"
   },
   "stateInspector": {
     "title": "状态检查",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -4,7 +4,8 @@
     "new": "新建",
     "import": "匯入",
     "export": "匯出",
-    "discardConfirm": "是否放棄未儲存的變更？"
+    "discardConfirm": "是否放棄未儲存的變更？",
+    "programNamePlaceholder": "程式名稱"
   },
   "codeEditor": {
     "title": "程式碼編輯器",
@@ -95,6 +96,29 @@
         "select": "選擇"
       }
     }
+  },
+  "editorViewToggle": {
+    "code": "程式碼",
+    "codeTitle": "程式碼",
+    "bg": "背景",
+    "bgTitle": "背景"
+  },
+  "inputModeToggle": {
+    "joystick": "搖桿",
+    "joystickTitle": "搖桿模式 (STICK/STRIG)",
+    "keyboard": "鍵盤",
+    "keyboardTitle": "鍵盤模式 (INKEY$)"
+  },
+  "commandPalette": {
+    "ariaLabel": "命令面板",
+    "searchPlaceholder": "輸入命令...",
+    "searchLabel": "搜尋命令",
+    "commandsLabel": "命令",
+    "noMatches": "沒有符合的命令"
+  },
+  "ideOutputPanel": {
+    "closeLogLevels": "關閉日誌級別",
+    "openLogLevels": "開啟日誌級別"
   },
   "stateInspector": {
     "title": "狀態檢查",


### PR DESCRIPTION
## Summary
- Fixes #123

## Changes
- Added `useI18n` to 4 IDE components (EditorViewToggle, InputModeToggle, CommandPalette, IdeOutputPanel) and updated ProgramToolbar placeholder
- Replaced 16 hardcoded English strings with `t()` calls using `ide.*` namespace
- Added locale keys to all 4 locale files (en, ja, zh-CN, zh-TW) under existing `ide.json`
- Keys added: `editorViewToggle.*`, `inputModeToggle.*`, `commandPalette.*`, `ideOutputPanel.*`, `toolbar.programNamePlaceholder`

## Test plan
- [ ] 1504 tests pass
- [ ] ESLint clean
- [ ] Type-check passes
- [ ] CI passes