### PR TITLE
fix: localize diagnostics and testing pages (#121)

### DIFF
--- a/src/features/diagnostics/PerformanceDiagnosticsPage.vue
+++ b/src/features/diagnostics/PerformanceDiagnosticsPage.vue
@@ -7,6 +7,7 @@
  */
 
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import RuntimeOutput from '@/features/ide/components/RuntimeOutput.vue'
 import { useBasicIde as useBasicIdeEnhanced } from '@/features/ide/composables/useBasicIdeEnhanced'
@@ -20,6 +21,8 @@ import { GameBlock, GameButton, GameLayout, GameSelect, GameSwitch } from '@/sha
 defineOptions({
   name: 'PerformanceDiagnosticsPage',
 })
+
+const { t } = useI18n()
 
 const {
   code,
@@ -104,7 +107,7 @@ const {
   <GameLayout>
     <div class="perf-diagnostics-container">
       <!-- Page Header -->
-      <GameBlock title="Performance Diagnostics" title-icon="mdi:speedometer">
+      <GameBlock :title="t('diagnostics.title')" title-icon="mdi:speedometer">
         <p class="description">
           Diagnose PRINT performance issues by running test scenarios and measuring timing at each
           stage: worker execution, message passing, and screen rendering.
@@ -112,7 +115,7 @@ const {
       </GameBlock>
 
       <!-- Test Controls -->
-      <GameBlock title="Test Scenarios" title-icon="mdi:test-tube">
+      <GameBlock :title="t('diagnostics.testScenarios')" title-icon="mdi:test-tube">
         <div class="scenario-buttons">
           <GameButton @click="runTest('light')" :disabled="isRunning" type="primary">
             Light (50 iterations)
@@ -134,7 +137,7 @@ const {
       </GameBlock>
 
       <!-- Settings -->
-      <GameBlock title="Settings" title-icon="mdi:cog">
+      <GameBlock :title="t('diagnostics.settings')" title-icon="mdi:cog">
         <div class="settings-grid">
           <div class="setting-item">
             <label class="setting-label">Screen Rendering</label>
@@ -164,7 +167,7 @@ const {
       </GameBlock>
 
       <!-- Real-time Metrics -->
-      <GameBlock title="Performance Metrics" title-icon="mdi:chart-line">
+      <GameBlock :title="t('diagnostics.performanceMetrics')" title-icon="mdi:chart-line">
         <div class="metrics-grid">
           <div class="metric-card">
             <div class="metric-label">FPS</div>
@@ -186,7 +189,7 @@ const {
       </GameBlock>
 
       <!-- CPU Time Breakdown -->
-      <GameBlock title="CPU Time Breakdown" title-icon="mdi:clock-outline">
+      <GameBlock :title="t('diagnostics.cpuTimeBreakdown')" title-icon="mdi:clock-outline">
         <div class="breakdown-bars">
           <div class="breakdown-item">
             <span class="breakdown-label">Worker Execution</span>
@@ -225,7 +228,12 @@ const {
       </GameBlock>
 
       <!-- Screen Output -->
-      <GameBlock v-if="renderingEnabled" title="Screen Output" title-icon="mdi:monitor" class="screen-output-block">
+      <GameBlock
+        v-if="renderingEnabled"
+        :title="t('diagnostics.screenOutput')"
+        title-icon="mdi:monitor"
+        class="screen-output-block"
+      >
         <RuntimeOutput
           :output="outputForDisplay"
           :is-running="isRunning"

--- a/src/features/testing/PositionSyncLoadTestPage.vue
+++ b/src/features/testing/PositionSyncLoadTestPage.vue
@@ -8,6 +8,7 @@
  */
 
 import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import RuntimeOutput from '@/features/ide/components/RuntimeOutput.vue'
 import { useBasicIde as useBasicIdeEnhanced } from '@/features/ide/composables/useBasicIdeEnhanced'
@@ -17,6 +18,8 @@ import { GameBlock, GameButton, GameLayout } from '@/shared/components/ui'
 defineOptions({
   name: 'PositionSyncLoadTestPage',
 })
+
+const { t } = useI18n()
 
 const {
   code,
@@ -129,7 +132,7 @@ onBeforeUnmount(() => {
   <GameLayout>
     <div class="load-test-container">
       <GameBlock
-        title="Position sync load test"
+        :title="t('testing.positionSync.title')"
         title-icon="mdi:speedometer"
         class="metrics-panel"
       >
@@ -156,7 +159,7 @@ onBeforeUnmount(() => {
         </template>
       </GameBlock>
 
-      <GameBlock title="Screen" title-icon="mdi:monitor" class="screen-panel">
+      <GameBlock :title="t('testing.screen')" title-icon="mdi:monitor" class="screen-panel">
         <RuntimeOutput
           :output="output"
           :is-running="isRunning"

--- a/src/features/testing/PrintVsSpritesTestPage.vue
+++ b/src/features/testing/PrintVsSpritesTestPage.vue
@@ -8,6 +8,7 @@
  */
 
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import RuntimeOutput from '@/features/ide/components/RuntimeOutput.vue'
 import { useBasicIde as useBasicIdeEnhanced } from '@/features/ide/composables/useBasicIdeEnhanced'
@@ -17,6 +18,8 @@ import { GameBlock, GameButton, GameLayout } from '@/shared/components/ui'
 defineOptions({
   name: 'PrintVsSpritesTestPage',
 })
+
+const { t } = useI18n()
 
 const {
   code,
@@ -129,7 +132,7 @@ onBeforeUnmount(() => {
   <GameLayout>
     <div class="test-container">
       <GameBlock
-        title="PRINT vs moving sprites (Phase 6.1)"
+        :title="t('testing.printVsSprites.title')"
         title-icon="mdi:animation-outline"
         class="info-panel"
       >
@@ -156,7 +159,7 @@ onBeforeUnmount(() => {
         </template>
       </GameBlock>
 
-      <GameBlock title="Screen" title-icon="mdi:monitor" class="screen-panel">
+      <GameBlock :title="t('testing.screen')" title-icon="mdi:monitor" class="screen-panel">
         <RuntimeOutput
           :output="outputForDisplay"
           :is-running="isRunning"

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -5,6 +5,7 @@ import { createI18n } from 'vue-i18n'
 
 import enBgEditor from './locales/en/bg-editor.json'
 import enCommon from './locales/en/common.json'
+import enDiagnostics from './locales/en/diagnostics.json'
 import enHome from './locales/en/home.json'
 import enIde from './locales/en/ide.json'
 import enImageAnalyzer from './locales/en/image-analyzer.json'
@@ -12,8 +13,10 @@ import enMonacoEditor from './locales/en/monaco-editor.json'
 import enNavigation from './locales/en/navigation.json'
 import enSoundTest from './locales/en/sound-test.json'
 import enSpriteViewer from './locales/en/sprite-viewer.json'
+import enTesting from './locales/en/testing.json'
 import jaBgEditor from './locales/ja/bg-editor.json'
 import jaCommon from './locales/ja/common.json'
+import jaDiagnostics from './locales/ja/diagnostics.json'
 import jaHome from './locales/ja/home.json'
 import jaIde from './locales/ja/ide.json'
 import jaImageAnalyzer from './locales/ja/image-analyzer.json'
@@ -21,8 +24,10 @@ import jaMonacoEditor from './locales/ja/monaco-editor.json'
 import jaNavigation from './locales/ja/navigation.json'
 import jaSoundTest from './locales/ja/sound-test.json'
 import jaSpriteViewer from './locales/ja/sprite-viewer.json'
+import jaTesting from './locales/ja/testing.json'
 import zhCNBgEditor from './locales/zh-CN/bg-editor.json'
 import zhCNCommon from './locales/zh-CN/common.json'
+import zhCNDiagnostics from './locales/zh-CN/diagnostics.json'
 import zhCNHome from './locales/zh-CN/home.json'
 import zhCNIde from './locales/zh-CN/ide.json'
 import zhCNImageAnalyzer from './locales/zh-CN/image-analyzer.json'
@@ -30,8 +35,10 @@ import zhCNMonacoEditor from './locales/zh-CN/monaco-editor.json'
 import zhCNNavigation from './locales/zh-CN/navigation.json'
 import zhCNSoundTest from './locales/zh-CN/sound-test.json'
 import zhCNSpriteViewer from './locales/zh-CN/sprite-viewer.json'
+import zhCNTesting from './locales/zh-CN/testing.json'
 import zhTWBgEditor from './locales/zh-TW/bg-editor.json'
 import zhTWCommon from './locales/zh-TW/common.json'
+import zhTWDiagnostics from './locales/zh-TW/diagnostics.json'
 import zhTWHome from './locales/zh-TW/home.json'
 import zhTWIde from './locales/zh-TW/ide.json'
 import zhTWImageAnalyzer from './locales/zh-TW/image-analyzer.json'
@@ -39,6 +46,7 @@ import zhTWMonacoEditor from './locales/zh-TW/monaco-editor.json'
 import zhTWNavigation from './locales/zh-TW/navigation.json'
 import zhTWSoundTest from './locales/zh-TW/sound-test.json'
 import zhTWSpriteViewer from './locales/zh-TW/sprite-viewer.json'
+import zhTWTesting from './locales/zh-TW/testing.json'
 import type { Locale, MessageSchema } from './types'
 
 // Get saved locale from localStorage or default to browser language
@@ -78,6 +86,8 @@ const i18n = createI18n<{ message: MessageSchema }, Locale>({
       monacoEditor: enMonacoEditor,
       bgEditor: enBgEditor,
       soundTest: enSoundTest,
+      diagnostics: enDiagnostics,
+      testing: enTesting,
     },
     ja: {
       navigation: jaNavigation,
@@ -89,6 +99,8 @@ const i18n = createI18n<{ message: MessageSchema }, Locale>({
       monacoEditor: jaMonacoEditor,
       bgEditor: jaBgEditor,
       soundTest: jaSoundTest,
+      diagnostics: jaDiagnostics,
+      testing: jaTesting,
     },
     'zh-CN': {
       navigation: zhCNNavigation,
@@ -100,6 +112,8 @@ const i18n = createI18n<{ message: MessageSchema }, Locale>({
       monacoEditor: zhCNMonacoEditor,
       bgEditor: zhCNBgEditor,
       soundTest: zhCNSoundTest,
+      diagnostics: zhCNDiagnostics,
+      testing: zhCNTesting,
     },
     'zh-TW': {
       navigation: zhTWNavigation,
@@ -111,6 +125,8 @@ const i18n = createI18n<{ message: MessageSchema }, Locale>({
       monacoEditor: zhTWMonacoEditor,
       bgEditor: zhTWBgEditor,
       soundTest: zhTWSoundTest,
+      diagnostics: zhTWDiagnostics,
+      testing: zhTWTesting,
     },
   },
 })

--- a/src/shared/i18n/locales/en/diagnostics.json
+++ b/src/shared/i18n/locales/en/diagnostics.json
@@ -1,0 +1,8 @@
+{
+  "title": "Performance Diagnostics",
+  "testScenarios": "Test Scenarios",
+  "settings": "Settings",
+  "performanceMetrics": "Performance Metrics",
+  "cpuTimeBreakdown": "CPU Time Breakdown",
+  "screenOutput": "Screen Output"
+}

--- a/src/shared/i18n/locales/en/testing.json
+++ b/src/shared/i18n/locales/en/testing.json
@@ -1,0 +1,9 @@
+{
+  "screen": "Screen",
+  "printVsSprites": {
+    "title": "PRINT vs moving sprites (Phase 6.1)"
+  },
+  "positionSync": {
+    "title": "Position sync load test"
+  }
+}

--- a/src/shared/i18n/locales/ja/diagnostics.json
+++ b/src/shared/i18n/locales/ja/diagnostics.json
@@ -1,0 +1,8 @@
+{
+  "title": "パフォーマンス診断",
+  "testScenarios": "テストシナリオ",
+  "settings": "設定",
+  "performanceMetrics": "パフォーマンス指標",
+  "cpuTimeBreakdown": "CPU時間の内訳",
+  "screenOutput": "画面出力"
+}

--- a/src/shared/i18n/locales/ja/testing.json
+++ b/src/shared/i18n/locales/ja/testing.json
@@ -1,0 +1,9 @@
+{
+  "screen": "画面",
+  "printVsSprites": {
+    "title": "PRINT vs 移動スプライト（フェーズ6.1）"
+  },
+  "positionSync": {
+    "title": "位置同期負荷テスト"
+  }
+}

--- a/src/shared/i18n/locales/zh-CN/diagnostics.json
+++ b/src/shared/i18n/locales/zh-CN/diagnostics.json
@@ -1,0 +1,8 @@
+{
+  "title": "性能诊断",
+  "testScenarios": "测试场景",
+  "settings": "设置",
+  "performanceMetrics": "性能指标",
+  "cpuTimeBreakdown": "CPU 时间分解",
+  "screenOutput": "屏幕输出"
+}

--- a/src/shared/i18n/locales/zh-CN/testing.json
+++ b/src/shared/i18n/locales/zh-CN/testing.json
@@ -1,0 +1,9 @@
+{
+  "screen": "屏幕",
+  "printVsSprites": {
+    "title": "PRINT 与移动精灵对比（阶段 6.1）"
+  },
+  "positionSync": {
+    "title": "位置同步负载测试"
+  }
+}

--- a/src/shared/i18n/locales/zh-TW/diagnostics.json
+++ b/src/shared/i18n/locales/zh-TW/diagnostics.json
@@ -1,0 +1,8 @@
+{
+  "title": "效能診斷",
+  "testScenarios": "測試場景",
+  "settings": "設定",
+  "performanceMetrics": "效能指標",
+  "cpuTimeBreakdown": "CPU 時間分解",
+  "screenOutput": "螢幕輸出"
+}

--- a/src/shared/i18n/locales/zh-TW/testing.json
+++ b/src/shared/i18n/locales/zh-TW/testing.json
@@ -1,0 +1,9 @@
+{
+  "screen": "螢幕",
+  "printVsSprites": {
+    "title": "PRINT 與移動精靈對比（階段 6.1）"
+  },
+  "positionSync": {
+    "title": "位置同步負載測試"
+  }
+}

--- a/src/shared/i18n/types.ts
+++ b/src/shared/i18n/types.ts
@@ -7,6 +7,7 @@
 
 import type enBgEditor from './locales/en/bg-editor.json'
 import type enCommon from './locales/en/common.json'
+import type enDiagnostics from './locales/en/diagnostics.json'
 import type enHome from './locales/en/home.json'
 import type enIde from './locales/en/ide.json'
 import type enImageAnalyzer from './locales/en/image-analyzer.json'
@@ -14,6 +15,7 @@ import type enMonacoEditor from './locales/en/monaco-editor.json'
 import type enNavigation from './locales/en/navigation.json'
 import type enSoundTest from './locales/en/sound-test.json'
 import type enSpriteViewer from './locales/en/sprite-viewer.json'
+import type enTesting from './locales/en/testing.json'
 
 // Define the master schema from English locale
 export type MessageSchema = {
@@ -26,6 +28,8 @@ export type MessageSchema = {
   monacoEditor: typeof enMonacoEditor
   bgEditor: typeof enBgEditor
   soundTest: typeof enSoundTest
+  diagnostics: typeof enDiagnostics
+  testing: typeof enTesting
 }
 
 // Define available locales


### PR DESCRIPTION
## Summary
- Fixes #121

## Changes
- Added `useI18n` to 3 page-level components (PerformanceDiagnosticsPage, PrintVsSpritesTestPage, PositionSyncLoadTestPage)
- Replaced 10 hardcoded English strings with `t()` calls
- Created 8 locale files (4 languages × 2 namespaces: `diagnostics`, `testing`)
- Registered `diagnostics` and `testing` namespaces in i18n index and types

## Test plan
- [ ] ESLint clean
- [ ] Type-check passes
- [ ] CI passes