### PR TITLE
fix: resolve #113 - localize LogLevelPanel strings (title, helper text, aria-label)

### DIFF
--- a/src/features/ide/components/LogLevelPanel.vue
+++ b/src/features/ide/components/LogLevelPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, reactive, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { GameBlock, GameIcon } from '@/shared/components/ui'
 import {
@@ -21,6 +22,8 @@ const props = withDefaults(
   }>(),
   { open: false }
 )
+
+const { t } = useI18n()
 
 /** Current level per logger key. */
 const levels = reactive<Record<string, LogLevelName>>(
@@ -50,12 +53,12 @@ watch(() => props.open, (open: boolean) => open && refreshLevels())
 
 <template>
   <div class="log-level-panel">
-    <GameBlock title="Log levels" title-icon="mdi:format-list-bulleted-type" class="panel-block">
+    <GameBlock :title="t('ide.logLevels.title')" title-icon="mdi:format-list-bulleted-type" class="panel-block">
       <template #right>
         <GameIcon icon="mdi:information-outline" size="small" />
       </template>
       <p class="panel-description">
-        Set verbosity per area. <strong>warn</strong> = quiet; <strong>debug</strong> = verbose.
+        {{ t('ide.logLevels.description') }}
       </p>
       <div class="logger-list">
         <div v-for="entry in LOGGER_REGISTRY" :key="entry.key" class="logger-row">
@@ -67,7 +70,7 @@ watch(() => props.open, (open: boolean) => open && refreshLevels())
             :key="`${entry.key}-${levels[entry.key] ?? 'warn'}`"
             :value="levels[entry.key] ?? 'warn'"
             class="level-select"
-            :aria-label="`Log level for ${entry.name}`"
+            :aria-label="t('ide.logLevels.ariaLabelFor', { name: entry.name })"
             @change="handleSelectChange(entry.key, $event)"
           >
             <option v-for="name in LOG_LEVEL_NAMES" :key="name" :value="name">

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -111,5 +111,10 @@
     "bgBuffer": "BG Screen Buffer",
     "cursor": "Cursor",
     "empty": "(none)"
+  },
+  "logLevels": {
+    "title": "Log Levels",
+    "description": "Set verbosity per area. {warn} = quiet; {debug} = verbose.",
+    "ariaLabelFor": "Log level for {name}"
   }
 }

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -111,5 +111,10 @@
     "bgBuffer": "BG画面バッファ",
     "cursor": "カーソル",
     "empty": "（なし）"
+  },
+  "logLevels": {
+    "title": "ログレベル",
+    "description": "各領域の詳細度を設定します。{warn} = 静か；{debug} = 詳細。",
+    "ariaLabelFor": "{name}のログレベル"
   }
 }

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -111,5 +111,10 @@
     "bgBuffer": "BG 屏幕缓冲",
     "cursor": "光标",
     "empty": "（无）"
+  },
+  "logLevels": {
+    "title": "日志级别",
+    "description": "设置各区域的详细程度。{warn} = 安静；{debug} = 详细。",
+    "ariaLabelFor": "{name}的日志级别"
   }
 }

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -111,5 +111,10 @@
     "bgBuffer": "BG 螢幕緩衝",
     "cursor": "游標",
     "empty": "（無）"
+  },
+  "logLevels": {
+    "title": "日誌級別",
+    "description": "設定各區域的詳細程度。{warn} = 安靜；{debug} = 詳細。",
+    "ariaLabelFor": "{name}的日誌級別"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #113
- Localizes LogLevelPanel strings using Vue I18n

## Changes
- Added `useI18n()` to LogLevelPanel.vue component
- Replaced hardcoded strings with `t()` calls:
  - Title: "Log levels" → `t('ide.logLevels.title')`
  - Description: "Set verbosity per area..." → `t('ide.logLevels.description')`
  - Aria-label: `Log level for ${entry.name}` → `t('ide.logLevels.ariaLabelFor', { name: entry.name })`
- Added translation keys to all 4 locale files (en, ja, zh-CN, zh-TW)

## Test plan
- [x] Targeted tests pass (1507 tests)
- [ ] CI passes