### PR TITLE
fix: resolve #152 - localize remaining hardcoded strings in StateInspector and ProgramToolbar

### DIFF
--- a/src/features/ide/components/ProgramToolbar.vue
+++ b/src/features/ide/components/ProgramToolbar.vue
@@ -201,7 +201,7 @@ onUnmounted(() => {
       </template>
 
       <!-- Dirty indicator -->
-      <span v-if="programStore.isDirty.value" class="dirty-indicator" title="Unsaved changes">
+      <span v-if="programStore.isDirty.value" class="dirty-indicator" :title="t('ide.toolbar.unsavedChanges')">
         ●
       </span>
     </div>

--- a/src/features/ide/components/StateInspector.vue
+++ b/src/features/ide/components/StateInspector.vue
@@ -133,7 +133,10 @@ defineExpose({
 
         <GameTabPane name="sprite" :label="t('ide.stateInspector.tabSprite')">
           <div class="tab-pane horizontal sprite-tab">
-            <div class="meta-line">{{ t('ide.stateInspector.spriteEnabled') }}: {{ spriteEnabled ? 'ON' : 'OFF' }}</div>
+            <div class="meta-line">
+              {{ t('ide.stateInspector.spriteEnabled') }}:
+              {{ spriteEnabled ? t('ide.stateInspector.on') : t('ide.stateInspector.off') }}
+            </div>
             <div v-if="(spriteStates ?? []).length === 0" class="empty">{{ t('ide.stateInspector.empty') }}</div>
             <div v-else class="grid-cards">
               <div
@@ -141,7 +144,8 @@ defineExpose({
                 :key="s.spriteNumber"
                 class="card"
               >
-                #{{ s.spriteNumber }} ({{ s.x }},{{ s.y }}) {{ s.visible ? 'on' : 'off' }} p={{ s.priority }}
+                #{{ s.spriteNumber }} ({{ s.x }},{{ s.y }})
+                {{ s.visible ? t('ide.stateInspector.on') : t('ide.stateInspector.off') }} p={{ s.priority }}
               </div>
             </div>
           </div>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -5,7 +5,8 @@
     "import": "Import",
     "export": "Export",
     "discardConfirm": "Discard unsaved changes?",
-    "programNamePlaceholder": "Program name"
+    "programNamePlaceholder": "Program name",
+    "unsavedChanges": "Unsaved changes"
   },
   "codeEditor": {
     "title": "Code Editor",
@@ -341,6 +342,8 @@
     "cgen": "CGEN",
     "spriteStates": "SPRITE States",
     "spriteEnabled": "SPRITE ON",
+    "on": "ON",
+    "off": "OFF",
     "moveStates": "MOVE States",
     "bgBuffer": "BG Screen Buffer",
     "cursor": "Cursor",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -5,7 +5,8 @@
     "import": "インポート",
     "export": "エクスポート",
     "discardConfirm": "未保存の変更を破棄しますか？",
-    "programNamePlaceholder": "プログラム名"
+    "programNamePlaceholder": "プログラム名",
+    "unsavedChanges": "未保存の変更"
   },
   "codeEditor": {
     "title": "コードエディター",
@@ -341,6 +342,8 @@
     "cgen": "CGEN",
     "spriteStates": "SPRITE状態",
     "spriteEnabled": "SPRITE ON",
+    "on": "ON",
+    "off": "OFF",
     "moveStates": "MOVE状態",
     "bgBuffer": "BG画面バッファ",
     "cursor": "カーソル",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -5,7 +5,8 @@
     "import": "导入",
     "export": "导出",
     "discardConfirm": "是否放弃未保存的更改？",
-    "programNamePlaceholder": "程序名称"
+    "programNamePlaceholder": "程序名称",
+    "unsavedChanges": "未保存的更改"
   },
   "codeEditor": {
     "title": "代码编辑器",
@@ -341,6 +342,8 @@
     "cgen": "CGEN",
     "spriteStates": "SPRITE 状态",
     "spriteEnabled": "SPRITE ON",
+    "on": "开",
+    "off": "关",
     "moveStates": "MOVE 状态",
     "bgBuffer": "BG 屏幕缓冲",
     "cursor": "光标",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -5,7 +5,8 @@
     "import": "匯入",
     "export": "匯出",
     "discardConfirm": "是否放棄未儲存的變更？",
-    "programNamePlaceholder": "程式名稱"
+    "programNamePlaceholder": "程式名稱",
+    "unsavedChanges": "未儲存的變更"
   },
   "codeEditor": {
     "title": "程式碼編輯器",
@@ -341,6 +342,8 @@
     "cgen": "CGEN",
     "spriteStates": "SPRITE 狀態",
     "spriteEnabled": "SPRITE ON",
+    "on": "開",
+    "off": "關",
     "moveStates": "MOVE 狀態",
     "bgBuffer": "BG 螢幕緩衝",
     "cursor": "游標",


### PR DESCRIPTION
## Summary
- Fixes #152

## Changes
- StateInspector.vue: Replaced hardcoded `'ON'/'OFF'` and `'on'/'off'` with `t('ide.stateInspector.on')` and `t('ide.stateInspector.off')`
- ProgramToolbar.vue: Changed `title="Unsaved changes"` to `:title="t('ide.toolbar.unsavedChanges')"`
- Added locale keys to all 4 locales (en, ja, zh-CN, zh-TW)

## Test plan
- [x] All 1570 tests pass
- [ ] CI passes