### PR TITLE
fix: resolve #165 - localize last 3 remaining hardcoded strings

### DIFF
--- a/src/features/ide/components/ErrorPanel.vue
+++ b/src/features/ide/components/ErrorPanel.vue
@@ -40,7 +40,7 @@ const { t } = useI18n()
           <code>{{ error.sourceLine }}</code>
         </div>
         <details v-if="error.stack" class="error-stack-details">
-          <summary>Stack trace</summary>
+          <summary>{{ t('ide.errorPanel.stackTrace') }}</summary>
           <pre class="error-stack">{{ error.stack }}</pre>
         </details>
       </div>

--- a/src/features/ide/components/ScreenTab.vue
+++ b/src/features/ide/components/ScreenTab.vue
@@ -73,7 +73,7 @@ const isGridShown = computed(() => showGrid.value)
           @click="toggleGrid"
         >
           <GameIcon icon="mdi:grid" size="small" />
-          Grid
+          {{ t('ide.screenTab.grid') }}
         </GameButton>
       </div>
     </template>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -353,5 +353,11 @@
     "title": "Log Levels",
     "description": "Set verbosity per area. {warn} = quiet; {debug} = verbose.",
     "ariaLabelFor": "Log level for {name}"
+  },
+  "screenTab": {
+    "grid": "Grid"
+  },
+  "errorPanel": {
+    "stackTrace": "Stack trace"
   }
 }

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -353,5 +353,11 @@
     "title": "ログレベル",
     "description": "各領域の詳細度を設定します。{warn} = 静か；{debug} = 詳細。",
     "ariaLabelFor": "{name}のログレベル"
+  },
+  "screenTab": {
+    "grid": "グリッド"
+  },
+  "errorPanel": {
+    "stackTrace": "スタックトレース"
   }
 }

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -353,5 +353,11 @@
     "title": "日志级别",
     "description": "设置各区域的详细程度。{warn} = 安静；{debug} = 详细。",
     "ariaLabelFor": "{name}的日志级别"
+  },
+  "screenTab": {
+    "grid": "网格"
+  },
+  "errorPanel": {
+    "stackTrace": "堆栈跟踪"
   }
 }

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -353,5 +353,11 @@
     "title": "日誌級別",
     "description": "設定各區域的詳細程度。{warn} = 安靜；{debug} = 詳細。",
     "ariaLabelFor": "{name}的日誌級別"
+  },
+  "screenTab": {
+    "grid": "網格"
+  },
+  "errorPanel": {
+    "stackTrace": "堆疊追蹤"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #165 — localizes the last 3 remaining hardcoded English strings in the IDE

## Changes
- **ScreenTab.vue**: Changed hardcoded "Grid" to `t('ide.screenTab.grid')`
- **ErrorPanel.vue**: Changed hardcoded "Stack trace" to `t('ide.errorPanel.stackTrace')`
- Added locale keys to all 4 locale files (en, ja, zh-CN, zh-TW)
- Note: ProgramToolbar.vue "Unsaved changes" was already localized in a prior effort

## Test plan
- [x] All 1570 tests pass
- [x] ESLint passes (0 errors)
- [ ] CI passes