### PR TITLE
fix: resolve #156 - localize InputModal and ErrorPanel hardcoded strings

### DIFF
--- a/src/features/ide/components/ErrorPanel.vue
+++ b/src/features/ide/components/ErrorPanel.vue
@@ -36,7 +36,7 @@ const { t } = useI18n()
           </span>
         </div>
         <div v-if="error.sourceLine" class="error-source-line">
-          <span class="error-source-label">At:</span>
+          <span class="error-source-label">{{ t('ide.errorPanel.sourceLabel') }}</span>
           <code>{{ error.sourceLine }}</code>
         </div>
         <details v-if="error.stack" class="error-stack-details">

--- a/src/features/ide/components/InputModal.vue
+++ b/src/features/ide/components/InputModal.vue
@@ -58,8 +58,8 @@ watch(
           type="text"
           :placeholder="
             pendingRequest.isLinput
-              ? 'Enter text (up to 31 chars)'
-              : 'Separate multiple values with commas'
+              ? t('ide.inputModal.linputPlaceholder')
+              : t('ide.inputModal.inputPlaceholder')
           "
           class="input-modal-field"
         />

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -272,6 +272,13 @@
     "submit": "OK",
     "cancel": "Cancel"
   },
+  "inputModal": {
+    "linputPlaceholder": "Enter text (up to 31 chars)",
+    "inputPlaceholder": "Separate multiple values with commas"
+  },
+  "errorPanel": {
+    "sourceLabel": "At:"
+  },
   "joystick": {
     "control": "Joystick Control",
     "status": "Joystick Status",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -272,6 +272,13 @@
     "submit": "OK",
     "cancel": "キャンセル"
   },
+  "inputModal": {
+    "linputPlaceholder": "テキストを入力（最大31文字）",
+    "inputPlaceholder": "複数の値はカンマで区切ってください"
+  },
+  "errorPanel": {
+    "sourceLabel": "場所:"
+  },
   "joystick": {
     "control": "ジョイスティック制御",
     "status": "ジョイスティック状態",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -272,6 +272,13 @@
     "submit": "确定",
     "cancel": "取消"
   },
+  "inputModal": {
+    "linputPlaceholder": "输入文本（最多31个字符）",
+    "inputPlaceholder": "多个值请用逗号分隔"
+  },
+  "errorPanel": {
+    "sourceLabel": "位置:"
+  },
   "joystick": {
     "control": "手柄控制",
     "status": "手柄状态",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -272,6 +272,13 @@
     "submit": "確定",
     "cancel": "取消"
   },
+  "inputModal": {
+    "linputPlaceholder": "輸入文字（最多31個字元）",
+    "inputPlaceholder": "多個值請用逗號分隔"
+  },
+  "errorPanel": {
+    "sourceLabel": "位置:"
+  },
   "joystick": {
     "control": "搖桿控制",
     "status": "搖桿狀態",


### PR DESCRIPTION
## Summary
- Fixes #156 — localizes hardcoded strings in InputModal and ErrorPanel

## Changes
- **InputModal.vue**: 
  - LINPUT placeholder: `t('ide.inputModal.linputPlaceholder')`
  - INPUT placeholder: `t('ide.inputModal.inputPlaceholder')`
- **ErrorPanel.vue**: 
  - "At:" label: `t('ide.errorPanel.sourceLabel')`
- Added translations to all 4 locale files (en, ja, zh-CN, zh-TW)

## Translations
| Key | en | ja | zh-CN | zh-TW |
|-----|----|----|-------|-------|
| linputPlaceholder | Enter text (up to 31 chars) | テキストを入力（最大31文字） | 输入文本（最多31个字符） | 輸入文字（最多31個字元） |
| inputPlaceholder | Separate multiple values with commas | 複数の値はカンマで区切ってください | 多个值请用逗号分隔 | 多個值請用逗號分隔 |
| sourceLabel | At: | 場所: | 位置: | 位置: |

## Test plan
- [x] All 1570 tests pass
- [x] ESLint passes (0 errors)
- [ ] CI passes