### PR TITLE
refactor: resolve #157 - remove  type cast in IdePage.vue

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, shallowRef, useTemplateRef } from 'vue'
 
+import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import type {
   BasicVariable,
@@ -112,7 +113,16 @@ const sendStrigEvent = basicIde?.sendStrigEvent ?? (() => {})
 const sharedDisplayBufferAccessor =
   basicIde?.sharedDisplayBufferAccessor ?? ({} as SharedDisplayBufferAccessor)
 const sharedAnimationBuffer = basicIde?.sharedAnimationBuffer ?? ({} as SharedArrayBuffer)
-const sharedDisplayViews = basicIde?.sharedDisplayViews ?? ({ buffer: {} as SharedArrayBuffer } as any)
+const sharedDisplayViews: SharedDisplayViews = basicIde?.sharedDisplayViews ?? {
+  buffer: {} as SharedArrayBuffer,
+  spriteView: {} as Float64Array,
+  charView: {} as Uint8Array,
+  patternView: {} as Uint8Array,
+  cursorView: {} as Uint8Array,
+  sequenceView: {} as Int32Array,
+  scalarsView: {} as Uint8Array,
+  animationSyncView: {} as Float64Array,
+}
 const sharedJoystickBuffer = basicIde?.sharedJoystickBuffer ?? ({} as SharedArrayBuffer)
 const setDecodedScreenState = basicIde?.setDecodedScreenState ?? (() => {})
 const registerScheduleRender = basicIde?.registerScheduleRender ?? (() => {})


### PR DESCRIPTION
## Summary
- Fixes #157 — removes the last `as any` type cast in the codebase

## Changes
- **IdePage.vue**: 
  - Added import: `import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'`
  - Replaced `as any` cast with explicit type annotation and a complete fallback object matching all properties of `SharedDisplayViews`

## Technical Details
The original code `({ buffer: {} as SharedArrayBuffer } as any)` only provided a partial implementation of the `SharedDisplayViews` interface, requiring `as any` to bypass type checking.

The fix creates a properly typed fallback object that satisfies all properties of the interface. The fallback is only used in E2E lite mode where the screen context is never provided, so the empty typed arrays are safe.

## Test plan
- [x] All 1570 tests pass
- [x] ESLint passes
- [x] TypeScript type-check passes
- [ ] CI passes