### PR TITLE
fix: resolve #140 - localize MovementCard strings

### DIFF
--- a/src/features/ide/components/MovementCard.vue
+++ b/src/features/ide/components/MovementCard.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 import { GameIcon } from '@/shared/components/ui'
 import { MoveCharacterCode } from '@/shared/data/types'
 
@@ -26,6 +28,8 @@ defineProps<{
   slot: MovementSlotData
 }>()
 
+const { t } = useI18n()
+
 /** Direction 0–8 as MDI arrow icon names (0=none, 1=up … 8=up-left). */
 const DIRECTION_ICONS: Record<number, string> = {
   0: 'mdi:circle-outline',
@@ -39,24 +43,12 @@ const DIRECTION_ICONS: Record<number, string> = {
   8: 'mdi:arrow-top-left',
 }
 
-const DIRECTION_NAMES: Record<number, string> = {
-  0: 'none',
-  1: 'up',
-  2: 'up-right',
-  3: 'right',
-  4: 'down-right',
-  5: 'down',
-  6: 'down-left',
-  7: 'left',
-  8: 'up-left',
-}
-
 function directionIcon(dir: number): string {
   return DIRECTION_ICONS[dir] ?? 'mdi:circle-outline'
 }
 
 function directionTitle(dir: number): string {
-  return DIRECTION_NAMES[dir] ?? `dir ${dir}`
+  return t(`ide.movementCard.directions.${dir}`)
 }
 
 function characterTypeLabel(code: number): string {
@@ -68,7 +60,7 @@ function characterTypeLabel(code: number): string {
 <template>
   <div class="card move-card">
     <div class="move-card-header">
-      <span class="move-card-id" title="Action number">
+      <span class="move-card-id" :title="t('ide.movementCard.actionNumber')">
         <span>{{ slot.actionNumber }}</span>
       </span>
       <template v-if="slot.hasData">
@@ -78,7 +70,10 @@ function characterTypeLabel(code: number): string {
         >
           {{ characterTypeLabel(slot.characterType).slice(0, 5) }}
         </span>
-        <span class="move-card-status" :title="slot.isActive ? 'Active' : 'Paused'">
+        <span
+          class="move-card-status"
+          :title="slot.isActive ? t('ide.movementCard.statusActive') : t('ide.movementCard.statusPaused')"
+        >
           <GameIcon
             :icon="slot.isActive ? 'mdi:play' : 'mdi:pause'"
             size="small"
@@ -88,7 +83,7 @@ function characterTypeLabel(code: number): string {
         <span
           class="move-card-dir"
           :title="directionTitle(slot.direction)"
-          :aria-label="`direction ${directionTitle(slot.direction)}`"
+          :aria-label="t('ide.movementCard.directionAria', { direction: directionTitle(slot.direction) })"
         >
           <GameIcon
             :icon="directionIcon(slot.direction)"

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -278,7 +278,8 @@
     "inputPlaceholder": "Separate multiple values with commas"
   },
   "errorPanel": {
-    "sourceLabel": "At:"
+    "sourceLabel": "At:",
+    "stackTrace": "Stack trace"
   },
   "joystick": {
     "control": "Joystick Control",
@@ -362,10 +363,24 @@
     "description": "Set verbosity per area. {warn} = quiet; {debug} = verbose.",
     "ariaLabelFor": "Log level for {name}"
   },
+  "movementCard": {
+    "actionNumber": "Action number",
+    "statusActive": "Active",
+    "statusPaused": "Paused",
+    "directionAria": "direction {direction}",
+    "directions": {
+      "0": "none",
+      "1": "up",
+      "2": "up-right",
+      "3": "right",
+      "4": "down-right",
+      "5": "down",
+      "6": "down-left",
+      "7": "left",
+      "8": "up-left"
+    }
+  },
   "screenTab": {
     "grid": "Grid"
-  },
-  "errorPanel": {
-    "stackTrace": "Stack trace"
   }
 }

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -278,7 +278,8 @@
     "inputPlaceholder": "複数の値はカンマで区切ってください"
   },
   "errorPanel": {
-    "sourceLabel": "場所:"
+    "sourceLabel": "場所:",
+    "stackTrace": "スタックトレース"
   },
   "joystick": {
     "control": "ジョイスティック制御",
@@ -362,10 +363,24 @@
     "description": "各領域の詳細度を設定します。{warn} = 静か；{debug} = 詳細。",
     "ariaLabelFor": "{name}のログレベル"
   },
+  "movementCard": {
+    "actionNumber": "アクション番号",
+    "statusActive": "アクティブ",
+    "statusPaused": "一時停止",
+    "directionAria": "方向 {direction}",
+    "directions": {
+      "0": "なし",
+      "1": "上",
+      "2": "右上",
+      "3": "右",
+      "4": "右下",
+      "5": "下",
+      "6": "左下",
+      "7": "左",
+      "8": "左上"
+    }
+  },
   "screenTab": {
     "grid": "グリッド"
-  },
-  "errorPanel": {
-    "stackTrace": "スタックトレース"
   }
 }

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -278,7 +278,8 @@
     "inputPlaceholder": "多个值请用逗号分隔"
   },
   "errorPanel": {
-    "sourceLabel": "位置:"
+    "sourceLabel": "位置:",
+    "stackTrace": "堆栈跟踪"
   },
   "joystick": {
     "control": "手柄控制",
@@ -362,10 +363,24 @@
     "description": "设置各区域的详细程度。{warn} = 安静；{debug} = 详细。",
     "ariaLabelFor": "{name}的日志级别"
   },
+  "movementCard": {
+    "actionNumber": "动作编号",
+    "statusActive": "活动",
+    "statusPaused": "暂停",
+    "directionAria": "方向 {direction}",
+    "directions": {
+      "0": "无",
+      "1": "上",
+      "2": "右上",
+      "3": "右",
+      "4": "右下",
+      "5": "下",
+      "6": "左下",
+      "7": "左",
+      "8": "左上"
+    }
+  },
   "screenTab": {
     "grid": "网格"
-  },
-  "errorPanel": {
-    "stackTrace": "堆栈跟踪"
   }
 }

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -278,7 +278,8 @@
     "inputPlaceholder": "多個值請用逗號分隔"
   },
   "errorPanel": {
-    "sourceLabel": "位置:"
+    "sourceLabel": "位置:",
+    "stackTrace": "堆疊追蹤"
   },
   "joystick": {
     "control": "搖桿控制",
@@ -362,10 +363,24 @@
     "description": "設定各區域的詳細程度。{warn} = 安靜；{debug} = 詳細。",
     "ariaLabelFor": "{name}的日誌級別"
   },
+  "movementCard": {
+    "actionNumber": "動作編號",
+    "statusActive": "活動",
+    "statusPaused": "暫停",
+    "directionAria": "方向 {direction}",
+    "directions": {
+      "0": "無",
+      "1": "上",
+      "2": "右上",
+      "3": "右",
+      "4": "右下",
+      "5": "下",
+      "6": "左下",
+      "7": "左",
+      "8": "左上"
+    }
+  },
   "screenTab": {
     "grid": "網格"
-  },
-  "errorPanel": {
-    "stackTrace": "堆疊追蹤"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #140 — localizes all hardcoded strings in MovementCard.vue

## Changes
- Added `useI18n` import and `const { t } = useI18n()`
- Created `ide.movementCard.*` locale keys:
  - Direction names (none, up, up-right, right, down-right, down, down-left, left, up-left)
  - Status labels (Active, Paused)
  - Action number tooltip
  - Direction ARIA label template
- Replaced `DIRECTION_NAMES` map with `t()` calls
- Added translations to all 4 locale files (en, ja, zh-CN, zh-TW)

## Test plan
- [x] All 1570 tests pass
- [x] ESLint passes
- [ ] CI passes