### PR TITLE
fix: resolve #142 - add missing aria-labels and keyboard support

### DIFF
--- a/src/features/ide/components/SampleSelector.vue
+++ b/src/features/ide/components/SampleSelector.vue
@@ -80,7 +80,7 @@ const categoryColors: Record<string, string> = {
       <!-- Header -->
       <div class="sample-selector-header">
         <h2 class="sample-selector-title">{{ t('ide.samples.title', 'Load Sample') }}</h2>
-        <button class="sample-selector-close" @click="emit('close')">
+        <button class="sample-selector-close" :aria-label="t('ide.samples.closeAriaLabel')" @click="emit('close')">
           <span class="mdi mdi-close"></span>
         </button>
       </div>

--- a/src/shared/components/ui/GameUpload.vue
+++ b/src/shared/components/ui/GameUpload.vue
@@ -108,21 +108,35 @@ const handleDrop = (event: DragEvent) => {
       style="display: none"
     />
 
-    <div v-if="drag" class="game-upload-drag-area bg-game-surface shadow-game-base" @click="handleClick">
+    <button
+      v-if="drag"
+      type="button"
+      class="game-upload-drag-area bg-game-surface shadow-game-base"
+      :disabled="disabled"
+      :aria-label="t('common.upload.dragAndDrop')"
+      @click="handleClick"
+    >
       <GameIcon icon="mdi:upload" size="large" />
       <p class="game-upload-text">
         {{ t('common.upload.dragAndDrop') }}
         <span class="game-upload-link">{{ t('common.upload.clickToBrowse') }}</span>
       </p>
-    </div>
+    </button>
 
-    <div v-else class="game-upload-button-wrapper" @click="handleClick">
+    <button
+      v-else
+      type="button"
+      class="game-upload-button-wrapper"
+      :disabled="disabled"
+      :aria-label="t('common.buttons.upload')"
+      @click="handleClick"
+    >
       <slot>
         <GameButton :disabled="disabled" icon="mdi:upload">
           {{ t('common.buttons.upload') }}
         </GameButton>
       </slot>
-    </div>
+    </button>
   </div>
 </template>
 
@@ -143,6 +157,16 @@ const handleDrop = (event: DragEvent) => {
   cursor: pointer;
   transition: all 0.2s ease;
   text-align: center;
+
+  /* Reset button styles */
+  width: 100%;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+}
+
+.game-upload-drag-area:disabled {
+  cursor: not-allowed;
 }
 
 .game-upload-dragging .game-upload-drag-area {
@@ -174,6 +198,21 @@ const handleDrop = (event: DragEvent) => {
 
 .game-upload-disabled {
   opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.game-upload-button-wrapper {
+  /* Reset button styles */
+  display: inline-block;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.game-upload-button-wrapper:disabled {
   cursor: not-allowed;
 }
 </style>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -34,6 +34,7 @@
   },
   "samples": {
     "title": "Load Sample",
+    "closeAriaLabel": "Close",
     "load": "Sample",
     "placeholder": "Sample",
     "basic": "Basic",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -34,6 +34,7 @@
   },
   "samples": {
     "title": "サンプルを読み込む",
+    "closeAriaLabel": "閉じる",
     "load": "サンプル",
     "placeholder": "サンプル",
     "basic": "基本",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -34,6 +34,7 @@
   },
   "samples": {
     "title": "加载示例",
+    "closeAriaLabel": "关闭",
     "load": "示例",
     "placeholder": "示例",
     "basic": "基础",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -34,6 +34,7 @@
   },
   "samples": {
     "title": "載入範例",
+    "closeAriaLabel": "關閉",
     "load": "範例",
     "placeholder": "範例",
     "basic": "基礎",


### PR DESCRIPTION
## Summary
- Fixes #142 — adds missing accessibility attributes for interactive elements

## Changes

### SampleSelector.vue
- Added `aria-label` to close button with i18n support (`t('ide.samples.closeAriaLabel')`)

### GameUpload.vue
- Converted clickable `<div>` elements to `<button>` elements
- Added `type="button"` and `aria-label` attributes
- Added proper `:disabled` binding
- Added CSS resets for button default styles
- Enabled keyboard navigation (Tab, Enter, Space)

### Locale Files
- Added `closeAriaLabel` key to all 4 locales (en, ja, zh-CN, zh-TW)

## Test plan
- [x] All 1570 tests pass
- [x] ESLint passes
- [ ] CI passes
- [ ] Manual keyboard navigation test