### PR TITLE
refactor: resolve #141 - split remaining files over 500-line limit

### DIFF
--- a/src/core/sound/MusicDSLParser.ts
+++ b/src/core/sound/MusicDSLParser.ts
@@ -15,6 +15,7 @@ import {
   CHANNEL_C_DEFAULT_ENVELOPE,
   CHANNEL_C_INDEX,
 } from './constants'
+import { validateMusicString } from './musicValidation'
 import type { SoundStateManager } from './SoundStateManager'
 import type {
   CompiledAudio,
@@ -31,6 +32,8 @@ import type {
   Rest,
   SoundEvent,
 } from './types'
+
+export { validateMusicString }
 
 /**
  * Note names to semitone offset mapping (C = 0)
@@ -78,203 +81,6 @@ const LENGTH_CODE_TO_FRACTION: Record<number, number> = {
 
 /** Default length code when none specified (5 = quarter note) */
 const DEFAULT_LENGTH_CODE = 5
-
-/**
- * Valid characters in PLAY music string (excluding colon which is channel separator)
- */
-const VALID_MUSIC_CHARS = new Set([
-  'A',
-  'B',
-  'C',
-  'D',
-  'E',
-  'F',
-  'G', // Notes
-  'O',
-  'T',
-  'Y',
-  'M',
-  'V',
-  'R', // Commands
-  '#', // Sharp
-  '0',
-  '1',
-  '2',
-  '3',
-  '4',
-  '5',
-  '6',
-  '7',
-  '8',
-  '9', // Digits
-  ' ', // Space (ignored)
-])
-
-// ============================================================================
-// VALIDATION
-// ============================================================================
-
-/**
- * Validate a music string and throw error if invalid format
- * F-BASIC raises SN (Syntax) error for invalid music strings
- *
- * Validates:
- * - Invalid characters
- * - Tempo: T1-T8
- * - Octave: O0-O5
- * - Duty: Y0-Y3
- * - Envelope: M0-M1
- * - Volume: V0-V15
- * - Length codes: 0-9
- * - Sharp notes: #C, #D, #F, #G, #A, #B, #E (all sharps supported)
- */
-export function validateMusicString(musicString: string): void {
-  const input = musicString.toUpperCase()
-  let i = 0
-
-  while (i < input.length) {
-    const char = input[i]!
-
-    // Skip spaces
-    if (char === ' ') {
-      i++
-      continue
-    }
-
-    // Colon is channel separator
-    if (char === ':') {
-      i++
-      continue
-    }
-
-    // Check for invalid characters
-    if (!VALID_MUSIC_CHARS.has(char)) {
-      throw new Error(`Invalid character '${char}' in PLAY string at position ${i + 1}`)
-    }
-
-    // Validate Tempo: T1-T8
-    if (char === 'T') {
-      i++
-      const match = input.slice(i).match(/^(\d+)/)
-      if (!match?.[1]) {
-        throw new Error(`Tempo value required after T at position ${i + 1}`)
-      }
-      const value = parseInt(match[1], 10)
-      if (value < 1 || value > 8) {
-        throw new Error(`Invalid tempo T${value}: must be 1-8`)
-      }
-      i += match[1].length
-      continue
-    }
-
-    // Validate Octave: O0-O5
-    if (char === 'O') {
-      i++
-      const match = input.slice(i).match(/^(\d+)/)
-      if (!match?.[1]) {
-        throw new Error(`Octave value required after O at position ${i + 1}`)
-      }
-      const value = parseInt(match[1], 10)
-      if (value < 0 || value > 5) {
-        throw new Error(`Invalid octave O${value}: must be 0-5`)
-      }
-      i += match[1].length
-      continue
-    }
-
-    // Validate Duty: Y0-Y3
-    if (char === 'Y') {
-      i++
-      const match = input.slice(i).match(/^(\d+)/)
-      if (!match?.[1]) {
-        throw new Error(`Duty value required after Y at position ${i + 1}`)
-      }
-      const value = parseInt(match[1], 10)
-      if (value < 0 || value > 3) {
-        throw new Error(`Invalid duty Y${value}: must be 0-3`)
-      }
-      i += match[1].length
-      continue
-    }
-
-    // Validate Envelope: M0-M1
-    if (char === 'M') {
-      i++
-      const match = input.slice(i).match(/^(\d+)/)
-      if (!match?.[1]) {
-        throw new Error(`Envelope value required after M at position ${i + 1}`)
-      }
-      const value = parseInt(match[1], 10)
-      if (value < 0 || value > 1) {
-        throw new Error(`Invalid envelope M${value}: must be 0-1`)
-      }
-      i += match[1].length
-      continue
-    }
-
-    // Validate Volume: V0-V15
-    if (char === 'V') {
-      i++
-      const match = input.slice(i).match(/^(\d+)/)
-      if (!match?.[1]) {
-        throw new Error(`Volume value required after V at position ${i + 1}`)
-      }
-      const value = parseInt(match[1], 10)
-      if (value < 0 || value > 15) {
-        throw new Error(`Invalid volume V${value}: must be 0-15`)
-      }
-      i += match[1].length
-      continue
-    }
-
-    // Validate Sharp: # must be followed by a valid note (C, D, E, F, G, A, B)
-    if (char === '#') {
-      i++
-      const nextChar = input[i]
-      if (!nextChar) {
-        throw new Error(`Sharp (#) at position ${i} must be followed by a note`)
-      }
-      if (!'CDEFGAB'.includes(nextChar)) {
-        throw new Error(
-          `Invalid sharp #${nextChar} at position ${i}: # must be followed by a note (C, D, E, F, G, A, B)`
-        )
-      }
-      i++
-      // Optional length code
-      if (input[i] && /[0-9]/.test(input[i]!)) {
-        i++
-      }
-      continue
-    }
-
-    // Rest: R with optional length
-    if (char === 'R') {
-      i++
-      if (input[i] && /[0-9]/.test(input[i]!)) {
-        i++
-      }
-      continue
-    }
-
-    // Natural notes: C, D, E, F, G, A, B with optional length
-    if ('CDEFGAB'.includes(char)) {
-      i++
-      if (input[i] && /[0-9]/.test(input[i]!)) {
-        i++
-      }
-      continue
-    }
-
-    // Digits should only appear after commands/notes
-    if (/[0-9]/.test(char)) {
-      throw new Error(
-        `Unexpected digit '${char}' at position ${i}: digits must follow a command or note`
-      )
-    }
-
-    i++
-  }
-}
 
 // ============================================================================
 // STAGE 1: Parse string to MusicScore (symbolic notation)

--- a/src/core/sound/musicValidation.ts
+++ b/src/core/sound/musicValidation.ts
@@ -1,0 +1,199 @@
+/**
+ * Music DSL Validation
+ *
+ * Validates PLAY command music strings for correct syntax.
+ * F-BASIC raises SN (Syntax) error for invalid music strings.
+ */
+
+/**
+ * Valid characters in PLAY music string (excluding colon which is channel separator)
+ */
+const VALID_MUSIC_CHARS = new Set([
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G', // Notes
+  'O',
+  'T',
+  'Y',
+  'M',
+  'V',
+  'R', // Commands
+  '#', // Sharp
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9', // Digits
+  ' ', // Space (ignored)
+])
+
+/**
+ * Validate a music string and throw error if invalid format
+ * F-BASIC raises SN (Syntax) error for invalid music strings
+ *
+ * Validates:
+ * - Invalid characters
+ * - Tempo: T1-T8
+ * - Octave: O0-O5
+ * - Duty: Y0-Y3
+ * - Envelope: M0-M1
+ * - Volume: V0-V15
+ * - Length codes: 0-9
+ * - Sharp notes: #C, #D, #F, #G, #A, #B, #E (all sharps supported)
+ */
+export function validateMusicString(musicString: string): void {
+  const input = musicString.toUpperCase()
+  let i = 0
+
+  while (i < input.length) {
+    const char = input[i]!
+
+    // Skip spaces
+    if (char === ' ') {
+      i++
+      continue
+    }
+
+    // Colon is channel separator
+    if (char === ':') {
+      i++
+      continue
+    }
+
+    // Check for invalid characters
+    if (!VALID_MUSIC_CHARS.has(char)) {
+      throw new Error(`Invalid character '${char}' in PLAY string at position ${i + 1}`)
+    }
+
+    // Validate Tempo: T1-T8
+    if (char === 'T') {
+      i++
+      const match = input.slice(i).match(/^(\d+)/)
+      if (!match?.[1]) {
+        throw new Error(`Tempo value required after T at position ${i + 1}`)
+      }
+      const value = parseInt(match[1], 10)
+      if (value < 1 || value > 8) {
+        throw new Error(`Invalid tempo T${value}: must be 1-8`)
+      }
+      i += match[1].length
+      continue
+    }
+
+    // Validate Octave: O0-O5
+    if (char === 'O') {
+      i++
+      const match = input.slice(i).match(/^(\d+)/)
+      if (!match?.[1]) {
+        throw new Error(`Octave value required after O at position ${i + 1}`)
+      }
+      const value = parseInt(match[1], 10)
+      if (value < 0 || value > 5) {
+        throw new Error(`Invalid octave O${value}: must be 0-5`)
+      }
+      i += match[1].length
+      continue
+    }
+
+    // Validate Duty: Y0-Y3
+    if (char === 'Y') {
+      i++
+      const match = input.slice(i).match(/^(\d+)/)
+      if (!match?.[1]) {
+        throw new Error(`Duty value required after Y at position ${i + 1}`)
+      }
+      const value = parseInt(match[1], 10)
+      if (value < 0 || value > 3) {
+        throw new Error(`Invalid duty Y${value}: must be 0-3`)
+      }
+      i += match[1].length
+      continue
+    }
+
+    // Validate Envelope: M0-M1
+    if (char === 'M') {
+      i++
+      const match = input.slice(i).match(/^(\d+)/)
+      if (!match?.[1]) {
+        throw new Error(`Envelope value required after M at position ${i + 1}`)
+      }
+      const value = parseInt(match[1], 10)
+      if (value < 0 || value > 1) {
+        throw new Error(`Invalid envelope M${value}: must be 0-1`)
+      }
+      i += match[1].length
+      continue
+    }
+
+    // Validate Volume: V0-V15
+    if (char === 'V') {
+      i++
+      const match = input.slice(i).match(/^(\d+)/)
+      if (!match?.[1]) {
+        throw new Error(`Volume value required after V at position ${i + 1}`)
+      }
+      const value = parseInt(match[1], 10)
+      if (value < 0 || value > 15) {
+        throw new Error(`Invalid volume V${value}: must be 0-15`)
+      }
+      i += match[1].length
+      continue
+    }
+
+    // Validate Sharp: # must be followed by a valid note (C, D, E, F, G, A, B)
+    if (char === '#') {
+      i++
+      const nextChar = input[i]
+      if (!nextChar) {
+        throw new Error(`Sharp (#) at position ${i} must be followed by a note`)
+      }
+      if (!'CDEFGAB'.includes(nextChar)) {
+        throw new Error(
+          `Invalid sharp #${nextChar} at position ${i}: # must be followed by a note (C, D, E, F, G, A, B)`
+        )
+      }
+      i++
+      // Optional length code
+      if (input[i] && /[0-9]/.test(input[i]!)) {
+        i++
+      }
+      continue
+    }
+
+    // Rest: R with optional length
+    if (char === 'R') {
+      i++
+      if (input[i] && /[0-9]/.test(input[i]!)) {
+        i++
+      }
+      continue
+    }
+
+    // Natural notes: C, D, E, F, G, A, B with optional length
+    if ('CDEFGAB'.includes(char)) {
+      i++
+      if (input[i] && /[0-9]/.test(input[i]!)) {
+        i++
+      }
+      continue
+    }
+
+    // Digits should only appear after commands/notes
+    if (/[0-9]/.test(char)) {
+      throw new Error(
+        `Unexpected digit '${char}' at position ${i}: digits must follow a command or note`
+      )
+    }
+
+    i++
+  }
+}

--- a/src/core/workers/AnimationWorker.ts
+++ b/src/core/workers/AnimationWorker.ts
@@ -8,22 +8,25 @@
  * Responsibilities:
  * - Poll sync section for commands from Executor Worker (direct, no message passing)
  * - Calculate sprite positions (x += dx * speed * dt)
- * - Handle screen wrapping (modulo 256×240)
+ * - Handle screen wrapping (modulo 256x240)
  * - Manage movement lifecycle (isActive, remainingDistance)
  * - Write positions to shared buffer (ONLY writer)
  * - Write acknowledgment when command is processed
  * - Run at fixed 60Hz tick rate
  */
 
-import { DEFAULT_SPRITE_FRAME_RATE, MAX_SPRITES, SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
-import { SHARED_DISPLAY_BUFFER_BYTES } from '@/core/animation/sharedDisplayBuffer'
+import { DEFAULT_SPRITE_FRAME_RATE, MAX_SPRITES, SHARED_DISPLAY_BUFFER_BYTES } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import { SCREEN_DIMENSIONS } from '@/core/constants'
-import type { MoveDefinition } from '@/core/sprite/types'
 import { logWorker } from '@/shared/logger'
 
+import type { WorkerMovementState } from './animationSyncHandlers'
+import {
+  pollSyncCommands,
+} from './animationSyncHandlers'
+
 /**
- * Animation Worker command types (Main Thread → Animation Worker via message)
+ * Animation Worker command types (Main Thread -> Animation Worker via message)
  *
  * Note: Animation commands (START/STOP/ERASE/SET_POSITION) come from Executor Worker
  * via direct shared buffer sync, not via postMessage.
@@ -31,25 +34,6 @@ import { logWorker } from '@/shared/logger'
 export type AnimationWorkerCommand =
   | { type: 'SET_SHARED_BUFFER'; buffer: SharedArrayBuffer }
   | { type: 'TICK'; deltaTime: number }
-
-/**
- * Movement state tracked by Animation Worker
- * Position is the single source of truth, written to shared buffer
- */
-interface WorkerMovementState {
-  actionNumber: number
-  definition: MoveDefinition
-  x: number
-  y: number
-  remainingDistance: number
-  totalDistance: number // Total distance in dots (2 × MOVE distance parameter)
-  speedDotsPerSecond: number
-  directionDeltaX: number
-  directionDeltaY: number
-  isActive: boolean
-  currentFrameIndex: number
-  frameCounter: number
-}
 
 const TARGET_FPS = 60
 const FRAME_INTERVAL_MS = 1000 / TARGET_FPS
@@ -123,242 +107,6 @@ export class AnimationWorker {
   }
 
   /**
-   * Poll sync section for commands from Executor Worker (direct communication).
-   * Processes any pending command and writes acknowledgment when complete.
-   */
-  private pollSyncCommands(): void {
-    if (!this.accessor) return
-
-    const command = this.accessor.readSyncCommand()
-    if (!command) return // No pending command
-
-    try {
-      switch (command.commandType) {
-        case SyncCommandType.NONE:
-          // Should not happen as readSyncCommand returns null for NONE
-          break
-        case SyncCommandType.START_MOVEMENT:
-          this.handleStartMovementFromSync(command.actionNumber, command.params)
-          break
-        case SyncCommandType.STOP_MOVEMENT:
-          this.handleStopMovementFromSync(command.actionNumber)
-          break
-        case SyncCommandType.ERASE_MOVEMENT:
-          this.handleEraseMovementFromSync(command.actionNumber)
-          break
-        case SyncCommandType.SET_POSITION:
-          this.handleSetPositionFromSync(command.actionNumber, command.params.startX, command.params.startY)
-          break
-        case SyncCommandType.CLEAR_ALL_MOVEMENTS:
-          logWorker.debug('[AnimationWorker] CLEAR_ALL_MOVEMENTS: clearing all sprite data')
-          this.handleClearAllMovementsFromSync()
-          // Clear the command immediately after processing so it's not re-read every tick
-          this.accessor.clearSyncCommand()
-          break
-      }
-
-      // Write acknowledgment
-      this.accessor.notifyAck()
-    } catch (error) {
-      logWorker.error('[AnimationWorker] Error processing sync command:', error)
-      // Still write ack to prevent Executor Worker from hanging
-      this.accessor.notifyAck()
-    }
-  }
-
-  /**
-   * Handle START_MOVEMENT from sync buffer.
-   */
-  private handleStartMovementFromSync(
-    actionNumber: number,
-    params: {
-      startX: number
-      startY: number
-      direction: number
-      speed: number
-      distance: number
-      priority: number
-    }
-  ): void {
-    const { deltaX, deltaY } = this.getDirectionDeltas(params.direction)
-    const speedDotsPerSecond = params.speed === 0 ? 60 / 256 : 60 / params.speed
-    const totalDistance = 2 * params.distance
-
-    // Read characterType and colorCombination from buffer (set by DEF MOVE)
-    // These values are already in the buffer from the DEF MOVE command
-    const characterType = this.accessor?.readSpriteCharacterType(actionNumber) ?? 0
-    const colorCombination = this.accessor?.readSpriteColorCombination(actionNumber) ?? 0
-
-    const definition: MoveDefinition = {
-      actionNumber,
-      characterType,
-      direction: params.direction,
-      speed: params.speed,
-      distance: params.distance,
-      priority: params.priority as 0 | 1,
-      colorCombination,
-    }
-
-    const movementState: WorkerMovementState = {
-      actionNumber,
-      definition,
-      x: params.startX,
-      y: params.startY,
-      remainingDistance: totalDistance,
-      totalDistance,
-      speedDotsPerSecond,
-      directionDeltaX: deltaX,
-      directionDeltaY: deltaY,
-      isActive: true,
-      currentFrameIndex: 0,
-      frameCounter: 0,
-    }
-
-    this.movementStates.set(actionNumber, movementState)
-
-    // Write initial position to shared buffer
-    if (this.accessor) {
-      this.accessor.writeSpriteState(
-        actionNumber,
-        params.startX,
-        params.startY,
-        true, // isActive = true (moving)
-        true, // isVisible = true (becomes visible on MOVE)
-        0, // frameIndex
-        totalDistance, // remainingDistance
-        totalDistance, // totalDistance
-        params.direction,
-        params.speed,
-        params.priority,
-        definition.characterType,
-        definition.colorCombination
-      )
-    }
-
-    // Start tick loop if not already running
-    if (!this.isRunning) {
-      this.startTickLoop()
-    }
-  }
-
-  /**
-   * Handle STOP_MOVEMENT from sync buffer.
-   */
-  private handleStopMovementFromSync(actionNumber: number): void {
-    logWorker.debug('[AnimationWorker] STOP_MOVEMENT from sync:', actionNumber)
-
-    const movement = this.movementStates.get(actionNumber)
-    if (movement && this.accessor) {
-      movement.isActive = false
-      // Write inactive state to shared buffer with all animation parameters
-      // isVisible stays true after CUT (sprite remains visible but stops moving)
-      this.accessor.writeSpriteState(
-        actionNumber,
-        movement.x,
-        movement.y,
-        false, // isActive = false (stopped)
-        true, // isVisible = true (remains visible after CUT)
-        movement.currentFrameIndex,
-        movement.remainingDistance,
-        movement.totalDistance,
-        movement.definition.direction,
-        movement.definition.speed,
-        movement.definition.priority,
-        movement.definition.characterType,
-        movement.definition.colorCombination
-      )
-    }
-  }
-
-  /**
-   * Handle ERASE_MOVEMENT from sync buffer.
-   */
-  private handleEraseMovementFromSync(actionNumber: number): void {
-    logWorker.debug('[AnimationWorker] ERASE_MOVEMENT from sync:', actionNumber)
-
-    this.movementStates.delete(actionNumber)
-    // Write inactive state to shared buffer (reset all values, characterType=-1 marks as uninitialized)
-    if (this.accessor) {
-      this.accessor.writeSpriteState(actionNumber, 0, 0, false, false, 0, 0, 0, 0, 0, 0, -1, 0)
-    }
-
-    // Only stop tick loop if NOT using direct sync and no active movements
-    if (
-      !this.accessor &&
-      (this.movementStates.size === 0 || !Array.from(this.movementStates.values()).some(m => m.isActive))
-    ) {
-      this.stopTickLoop()
-    }
-  }
-
-  /**
-   * Handle SET_POSITION from sync buffer.
-   */
-  private handleSetPositionFromSync(actionNumber: number, x: number, y: number): void {
-    const movement = this.movementStates.get(actionNumber)
-    if (movement) {
-      movement.x = x
-      movement.y = y
-    }
-
-    // Write position to shared buffer while preserving characterType and colorCombination
-    // These are set by DEF MOVE and should NOT be overwritten by SET_POSITION
-    if (this.accessor) {
-      // Read existing characterType and colorCombination before overwriting
-      const existingCharacterType = this.accessor.readSpriteCharacterType(actionNumber)
-      const existingColorCombination = this.accessor.readSpriteColorCombination(actionNumber)
-
-      const isActive = movement?.isActive ?? false
-      const isVisible = movement ? true : false // isVisible is true if movement exists (has been MOVE'd without ERA)
-      const frameIndex = movement?.currentFrameIndex ?? 0
-      const def = movement?.definition
-
-      this.accessor.writeSpriteState(
-        actionNumber,
-        x,
-        y,
-        isActive,
-        isVisible,
-        frameIndex,
-        movement?.remainingDistance ?? 0,
-        movement?.totalDistance ?? 0,
-        def?.direction ?? 0,
-        def?.speed ?? 0,
-        def?.priority ?? 0,
-        // IMPORTANT: Preserve characterType and colorCombination from DEF MOVE
-        // Don't use def?.characterType ?? 0 because movement may not exist yet
-        existingCharacterType,
-        existingColorCombination
-      )
-    }
-  }
-
-  /**
-   * Handle CLEAR_ALL_MOVEMENTS from sync buffer.
-   * Called when user clicks CLEAR button - clears all internal movement states and sprite buffer.
-   */
-  private handleClearAllMovementsFromSync(): void {
-    logWorker.debug(
-      '[AnimationWorker] CLEAR_ALL_MOVEMENTS: clearing',
-      this.movementStates.size,
-      'movement states and all sprite data'
-    )
-
-    // Clear all internal movement states
-    this.movementStates.clear()
-
-    // Clear sprite buffer (single writer: only AnimationWorker writes to sprite portion)
-    // This sets all positions to 0, isActive=false, isVisible=false, characterType=-1
-    if (this.accessor) {
-      this.accessor.clearAllSprites()
-    }
-  }
-
-  /**
-   * Start the tick loop (60Hz fixed)
-   */
-
-  /**
    * Start the tick loop (60Hz fixed)
    */
   private startTickLoop(): void {
@@ -401,7 +149,7 @@ export class AnimationWorker {
     if (!this.accessor) return
 
     // Poll for sync commands from Executor Worker (direct communication)
-    this.pollSyncCommands()
+    pollSyncCommands(this.movementStates, this.accessor)
 
     // Cap deltaTime to prevent teleportation
     const cappedDeltaTime = Math.min(deltaTime, MAX_DELTA_TIME_MS)
@@ -501,36 +249,6 @@ export class AnimationWorker {
     // When using direct sync, the loop must keep running to poll for commands (SET_POSITION, etc.)
     if (!this.accessor && !Array.from(this.movementStates.values()).some(m => m.isActive)) {
       this.stopTickLoop()
-    }
-  }
-
-  /**
-   * Calculate direction deltas from direction code
-   * Direction: 0=none, 1=up, 2=up-right, 3=right, 4=down-right,
-   *            5=down, 6=down-left, 7=left, 8=up-left
-   */
-  private getDirectionDeltas(direction: number): { deltaX: number; deltaY: number } {
-    switch (direction) {
-      case 0:
-        return { deltaX: 0, deltaY: 0 }
-      case 1:
-        return { deltaX: 0, deltaY: -1 }
-      case 2:
-        return { deltaX: 1, deltaY: -1 }
-      case 3:
-        return { deltaX: 1, deltaY: 0 }
-      case 4:
-        return { deltaX: 1, deltaY: 1 }
-      case 5:
-        return { deltaX: 0, deltaY: 1 }
-      case 6:
-        return { deltaX: -1, deltaY: 1 }
-      case 7:
-        return { deltaX: -1, deltaY: 0 }
-      case 8:
-        return { deltaX: -1, deltaY: -1 }
-      default:
-        return { deltaX: 0, deltaY: 0 }
     }
   }
 

--- a/src/core/workers/animationSyncHandlers.ts
+++ b/src/core/workers/animationSyncHandlers.ts
@@ -1,0 +1,299 @@
+/**
+ * Animation Worker Sync Command Handlers
+ *
+ * Handles direct synchronization commands from Executor Worker via shared buffer sync section.
+ * These are extracted from AnimationWorker to keep the main class under 500 lines.
+ */
+
+import { SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
+import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
+import type { MoveDefinition } from '@/core/sprite/types'
+import { logWorker } from '@/shared/logger'
+
+/**
+ * Movement state tracked by Animation Worker
+ * Position is the single source of truth, written to shared buffer
+ */
+export interface WorkerMovementState {
+  actionNumber: number
+  definition: MoveDefinition
+  x: number
+  y: number
+  remainingDistance: number
+  totalDistance: number // Total distance in dots (2 * MOVE distance parameter)
+  speedDotsPerSecond: number
+  directionDeltaX: number
+  directionDeltaY: number
+  isActive: boolean
+  currentFrameIndex: number
+  frameCounter: number
+}
+
+/**
+ * Calculate direction deltas from direction code
+ * Direction: 0=none, 1=up, 2=up-right, 3=right, 4=down-right,
+ *            5=down, 6=down-left, 7=left, 8=up-left
+ */
+export function getDirectionDeltas(direction: number): { deltaX: number; deltaY: number } {
+  switch (direction) {
+    case 0:
+      return { deltaX: 0, deltaY: 0 }
+    case 1:
+      return { deltaX: 0, deltaY: -1 }
+    case 2:
+      return { deltaX: 1, deltaY: -1 }
+    case 3:
+      return { deltaX: 1, deltaY: 0 }
+    case 4:
+      return { deltaX: 1, deltaY: 1 }
+    case 5:
+      return { deltaX: 0, deltaY: 1 }
+    case 6:
+      return { deltaX: -1, deltaY: 1 }
+    case 7:
+      return { deltaX: -1, deltaY: 0 }
+    case 8:
+      return { deltaX: -1, deltaY: -1 }
+    default:
+      return { deltaX: 0, deltaY: 0 }
+  }
+}
+
+/**
+ * Handle START_MOVEMENT from sync buffer.
+ */
+export function handleStartMovementFromSync(
+  actionNumber: number,
+  params: {
+    startX: number
+    startY: number
+    direction: number
+    speed: number
+    distance: number
+    priority: number
+  },
+  movementStates: Map<number, WorkerMovementState>,
+  accessor: SharedDisplayBufferAccessor
+): void {
+  const { deltaX, deltaY } = getDirectionDeltas(params.direction)
+  const speedDotsPerSecond = params.speed === 0 ? 60 / 256 : 60 / params.speed
+  const totalDistance = 2 * params.distance
+
+  // Read characterType and colorCombination from buffer (set by DEF MOVE)
+  // These values are already in the buffer from the DEF MOVE command
+  const characterType = accessor.readSpriteCharacterType(actionNumber) ?? 0
+  const colorCombination = accessor.readSpriteColorCombination(actionNumber) ?? 0
+
+  const definition: MoveDefinition = {
+    actionNumber,
+    characterType,
+    direction: params.direction,
+    speed: params.speed,
+    distance: params.distance,
+    priority: params.priority as 0 | 1,
+    colorCombination,
+  }
+
+  const movementState: WorkerMovementState = {
+    actionNumber,
+    definition,
+    x: params.startX,
+    y: params.startY,
+    remainingDistance: totalDistance,
+    totalDistance,
+    speedDotsPerSecond,
+    directionDeltaX: deltaX,
+    directionDeltaY: deltaY,
+    isActive: true,
+    currentFrameIndex: 0,
+    frameCounter: 0,
+  }
+
+  movementStates.set(actionNumber, movementState)
+
+  // Write initial position to shared buffer
+  accessor.writeSpriteState(
+    actionNumber,
+    params.startX,
+    params.startY,
+    true, // isActive = true (moving)
+    true, // isVisible = true (becomes visible on MOVE)
+    0, // frameIndex
+    totalDistance, // remainingDistance
+    totalDistance, // totalDistance
+    params.direction,
+    params.speed,
+    params.priority,
+    definition.characterType,
+    definition.colorCombination
+  )
+}
+
+/**
+ * Handle STOP_MOVEMENT from sync buffer.
+ */
+export function handleStopMovementFromSync(
+  actionNumber: number,
+  movementStates: Map<number, WorkerMovementState>,
+  accessor: SharedDisplayBufferAccessor
+): void {
+  logWorker.debug('[AnimationWorker] STOP_MOVEMENT from sync:', actionNumber)
+
+  const movement = movementStates.get(actionNumber)
+  if (movement) {
+    movement.isActive = false
+    // Write inactive state to shared buffer with all animation parameters
+    // isVisible stays true after CUT (sprite remains visible but stops moving)
+    accessor.writeSpriteState(
+      actionNumber,
+      movement.x,
+      movement.y,
+      false, // isActive = false (stopped)
+      true, // isVisible = true (remains visible after CUT)
+      movement.currentFrameIndex,
+      movement.remainingDistance,
+      movement.totalDistance,
+      movement.definition.direction,
+      movement.definition.speed,
+      movement.definition.priority,
+      movement.definition.characterType,
+      movement.definition.colorCombination
+    )
+  }
+}
+
+/**
+ * Handle ERASE_MOVEMENT from sync buffer.
+ */
+export function handleEraseMovementFromSync(
+  actionNumber: number,
+  movementStates: Map<number, WorkerMovementState>,
+  accessor: SharedDisplayBufferAccessor
+): void {
+  logWorker.debug('[AnimationWorker] ERASE_MOVEMENT from sync:', actionNumber)
+
+  movementStates.delete(actionNumber)
+  // Write inactive state to shared buffer (reset all values, characterType=-1 marks as uninitialized)
+  accessor.writeSpriteState(actionNumber, 0, 0, false, false, 0, 0, 0, 0, 0, 0, -1, 0)
+}
+
+/**
+ * Handle SET_POSITION from sync buffer.
+ */
+export function handleSetPositionFromSync(
+  actionNumber: number,
+  x: number,
+  y: number,
+  movementStates: Map<number, WorkerMovementState>,
+  accessor: SharedDisplayBufferAccessor
+): void {
+  const movement = movementStates.get(actionNumber)
+  if (movement) {
+    movement.x = x
+    movement.y = y
+  }
+
+  // Write position to shared buffer while preserving characterType and colorCombination
+  // These are set by DEF MOVE and should NOT be overwritten by SET_POSITION
+  // Read existing characterType and colorCombination before overwriting
+  const existingCharacterType = accessor.readSpriteCharacterType(actionNumber)
+  const existingColorCombination = accessor.readSpriteColorCombination(actionNumber)
+
+  const isActive = movement?.isActive ?? false
+  const isVisible = movement ? true : false // isVisible is true if movement exists (has been MOVE'd without ERA)
+  const frameIndex = movement?.currentFrameIndex ?? 0
+  const def = movement?.definition
+
+  accessor.writeSpriteState(
+    actionNumber,
+    x,
+    y,
+    isActive,
+    isVisible,
+    frameIndex,
+    movement?.remainingDistance ?? 0,
+    movement?.totalDistance ?? 0,
+    def?.direction ?? 0,
+    def?.speed ?? 0,
+    def?.priority ?? 0,
+    // IMPORTANT: Preserve characterType and colorCombination from DEF MOVE
+    // Don't use def?.characterType ?? 0 because movement may not exist yet
+    existingCharacterType,
+    existingColorCombination
+  )
+}
+
+/**
+ * Handle CLEAR_ALL_MOVEMENTS from sync buffer.
+ * Called when user clicks CLEAR button - clears all internal movement states and sprite buffer.
+ */
+export function handleClearAllMovementsFromSync(
+  movementStates: Map<number, WorkerMovementState>,
+  accessor: SharedDisplayBufferAccessor
+): void {
+  logWorker.debug(
+    '[AnimationWorker] CLEAR_ALL_MOVEMENTS: clearing',
+    movementStates.size,
+    'movement states and all sprite data'
+  )
+
+  // Clear all internal movement states
+  movementStates.clear()
+
+  // Clear sprite buffer (single writer: only AnimationWorker writes to sprite portion)
+  // This sets all positions to 0, isActive=false, isVisible=false, characterType=-1
+  accessor.clearAllSprites()
+}
+
+/**
+ * Poll sync section for commands from Executor Worker (direct communication).
+ * Processes any pending command and writes acknowledgment when complete.
+ */
+export function pollSyncCommands(
+  movementStates: Map<number, WorkerMovementState>,
+  accessor: SharedDisplayBufferAccessor
+): boolean {
+  const command = accessor.readSyncCommand()
+  if (!command) return false // No pending command
+
+  try {
+    switch (command.commandType) {
+      case SyncCommandType.NONE:
+        // Should not happen as readSyncCommand returns null for NONE
+        break
+      case SyncCommandType.START_MOVEMENT:
+        handleStartMovementFromSync(command.actionNumber, command.params, movementStates, accessor)
+        break
+      case SyncCommandType.STOP_MOVEMENT:
+        handleStopMovementFromSync(command.actionNumber, movementStates, accessor)
+        break
+      case SyncCommandType.ERASE_MOVEMENT:
+        handleEraseMovementFromSync(command.actionNumber, movementStates, accessor)
+        break
+      case SyncCommandType.SET_POSITION:
+        handleSetPositionFromSync(
+          command.actionNumber,
+          command.params.startX,
+          command.params.startY,
+          movementStates,
+          accessor
+        )
+        break
+      case SyncCommandType.CLEAR_ALL_MOVEMENTS:
+        logWorker.debug('[AnimationWorker] CLEAR_ALL_MOVEMENTS: clearing all sprite data')
+        handleClearAllMovementsFromSync(movementStates, accessor)
+        // Clear the command immediately after processing so it's not re-read every tick
+        accessor.clearSyncCommand()
+        break
+    }
+
+    // Write acknowledgment
+    accessor.notifyAck()
+  } catch (error) {
+    logWorker.error('[AnimationWorker] Error processing sync command:', error)
+    // Still write ack to prevent Executor Worker from hanging
+    accessor.notifyAck()
+  }
+
+  return true
+}

--- a/src/features/ide/composables/messageHandlerContext.ts
+++ b/src/features/ide/composables/messageHandlerContext.ts
@@ -1,0 +1,70 @@
+/**
+ * Types and interfaces for BASIC IDE web worker message handling
+ */
+import type { Ref } from 'vue'
+
+import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
+import type { DecodedScreenState } from '@/core/animation/sharedDisplayBufferAccessor'
+import type {
+  AnyServiceWorkerMessage,
+  RequestInputMessage,
+  ScreenCell,
+} from '@/core/interfaces'
+import type { SpriteState } from '@/core/sprite/types'
+
+import type { WebWorkerManager } from './useBasicIdeWebWorkerUtils'
+
+/**
+ * Pending action for a sprite when its Konva node does not exist yet;
+ * applied when node is created or START_MOVEMENT is handled.
+ */
+export type PendingSpriteAction = { type: 'POSITION'; x: number; y: number }
+
+/** Per-sprite action queue (action number -> list of pending actions). */
+export type SpriteActionQueues = Map<number, PendingSpriteAction[]>
+
+export interface MessageHandlerContext {
+  output: Ref<string[]>
+  errors: Ref<
+    Array<{ line: number; message: string; type: string; stack?: string; sourceLine?: string }>
+  >
+  debugOutput: Ref<string>
+  screenBuffer: Ref<ScreenCell[][]>
+  cursorX: Ref<number>
+  cursorY: Ref<number>
+  bgPalette: Ref<number>
+  backdropColor?: Ref<number>
+  spritePalette?: Ref<number>
+  cgenMode?: Ref<number>
+  /** Sprite states from DEF SPRITE and SPRITE commands (updated via SPRITE_STATES message) */
+  spriteStates?: Ref<SpriteState[]>
+  /** Whether sprite display is enabled (SPRITE ON/OFF) */
+  spriteEnabled?: Ref<boolean>
+  // movementStates removed - read from shared buffer instead
+  frontSpriteNodes?: Ref<Map<number, unknown>>
+  backSpriteNodes?: Ref<Map<number, unknown>>
+  /** Per-sprite action queue; POSITION etc. when node does not exist; consumed when START_MOVEMENT is handled. */
+  spriteActionQueues?: Ref<SpriteActionQueues>
+  webWorkerManager: WebWorkerManager
+  /** Shared display buffer views; main reads screen/cursor/scalars when SCREEN_CHANGED. */
+  sharedDisplayViews?: SharedDisplayViews
+  /** Called when SCREEN_CHANGED is received to schedule a render (Screen.vue reads from shared buffer). */
+  scheduleRender?: () => void
+  /** Coalesced version: at most one schedule per frame. Prefer this for SCREEN_CHANGED to avoid main-thread flood. */
+  scheduleRenderForScreenChanged?: () => void
+  /** Called by Screen.vue after decoding shared buffer to update refs (screenBuffer, cursorX, etc.). */
+  setDecodedScreenState?: (decoded: DecodedScreenState) => void
+  /** Pending INPUT/LINPUT request from worker; set when REQUEST_INPUT is received, cleared on submit/cancel. */
+  pendingInputRequest?: Ref<RequestInputMessage['data'] | null>
+  /** Send INPUT_VALUE to worker to resolve a pending input request. */
+  respondToInputRequest?: (requestId: string, values: string[], cancelled: boolean) => void
+}
+
+/**
+ * Message queue for non-critical messages
+ * Processed during requestAnimationFrame to align with rendering
+ */
+export interface QueuedMessage {
+  message: AnyServiceWorkerMessage
+  context: MessageHandlerContext
+}

--- a/src/features/ide/composables/screenHandlers.ts
+++ b/src/features/ide/composables/screenHandlers.ts
@@ -1,0 +1,244 @@
+/**
+ * Screen-related message handlers for BASIC IDE web worker communication
+ */
+import type { AnyServiceWorkerMessage, ScreenCell, ScreenUpdateMessage } from '@/core/interfaces'
+import { clearBackgroundTileCache } from '@/features/ide/composables/useCanvasBackgroundRenderer'
+import { clearSpriteImageCache } from '@/features/ide/composables/useKonvaSpriteRenderer'
+import { setRuntimePaletteCombination } from '@/shared/data/palette'
+import { logComposable, logIdeMessages } from '@/shared/logger'
+
+import type { MessageHandlerContext } from './messageHandlerContext'
+
+/**
+ * Handle SCREEN_CHANGED message from web worker (shared buffer path).
+ * Uses coalesced schedule so many SCREEN_CHANGED (e.g. loop with PRINT) only trigger one render per frame.
+ */
+export function handleScreenChangedMessage(
+  _message: AnyServiceWorkerMessage,
+  context: MessageHandlerContext
+): void {
+  const schedule = context.scheduleRenderForScreenChanged ?? context.scheduleRender
+  if (schedule) {
+    schedule()
+  }
+}
+
+/**
+ * Handle SPRITE_STATES message from web worker.
+ * Updates sprite states and triggers a render to display static sprites (DEF SPRITE, SPRITE commands).
+ */
+export function handleSpriteStatesMessage(
+  message: AnyServiceWorkerMessage,
+  context: MessageHandlerContext
+): void {
+  if (message.type !== 'SPRITE_STATES') return
+
+  const { spriteStates, spriteEnabled } = message.data
+  logIdeMessages.debug('📤 Handling SPRITE_STATES:', { statesCount: spriteStates?.length, enabled: spriteEnabled })
+
+  // Update sprite states in context (these are passed to Screen.vue via useScreenContext)
+  if (context.spriteStates && spriteStates) {
+    context.spriteStates.value = spriteStates
+  }
+  if (context.spriteEnabled !== undefined && spriteEnabled !== undefined) {
+    context.spriteEnabled.value = spriteEnabled
+  }
+
+  // Schedule a full render to display the sprites
+  const schedule = context.scheduleRender
+  if (schedule) {
+    schedule()
+  }
+}
+
+/**
+ * Handle screen update message from web worker (legacy SCREEN_UPDATE; worker no longer sends for shared buffer path)
+ */
+export function handleScreenUpdateMessage(message: AnyServiceWorkerMessage, context: MessageHandlerContext): void {
+  if (message.type !== 'SCREEN_UPDATE') return
+
+  const update = message.data
+  if (!update) {
+    logComposable.warn('SCREEN_UPDATE message has no data')
+    return
+  }
+  if (!context?.screenBuffer) {
+    logComposable.warn('SCREEN_UPDATE: context or screenBuffer missing, skipping')
+    return
+  }
+
+  switch (update.updateType) {
+    case 'character':
+      handleCharacterUpdate(context, update)
+      break
+    case 'cursor':
+      if (update.cursorX !== undefined) context.cursorX.value = update.cursorX
+      if (update.cursorY !== undefined) context.cursorY.value = update.cursorY
+      break
+    case 'clear':
+      handleClearUpdate(context)
+      break
+    case 'full':
+      if (update.screenBuffer) {
+        context.screenBuffer.value = update.screenBuffer
+      }
+      if (update.cursorX !== undefined) context.cursorX.value = update.cursorX
+      if (update.cursorY !== undefined) context.cursorY.value = update.cursorY
+      break
+    case 'color':
+      handleColorUpdate(context, update)
+      break
+    case 'palette':
+      handlePaletteUpdate(context, update)
+      break
+    case 'backdrop':
+      handleBackdropUpdate(context, update)
+      break
+    case 'cgen':
+      handleCgenUpdate(context, update)
+      break
+    case 'palette-combination':
+      handlePaletteCombinationUpdate(context, update)
+      break
+  }
+}
+
+function handleCharacterUpdate(context: MessageHandlerContext, update: ScreenUpdateMessage['data']): void {
+  if (update.x !== undefined && update.y !== undefined && update.character !== undefined) {
+    const x = update.x
+    const y = update.y
+    const character = update.character
+
+    // Ensure row exists
+    context.screenBuffer.value[y] ??= []
+
+    // Ensure cell exists
+    const currentRow = context.screenBuffer.value[y]
+    currentRow[x] ??= {
+      character: ' ',
+      colorPattern: 0,
+      x,
+      y,
+    }
+
+    // Update character - force reactivity by creating new object
+    const currentCell = currentRow[x]
+    const newCell: ScreenCell = {
+      character,
+      colorPattern: currentCell.colorPattern,
+      x: currentCell.x,
+      y: currentCell.y,
+    }
+    currentRow[x] = newCell
+
+    // Also trigger reactivity by reassigning the row
+    context.screenBuffer.value[y] = [...currentRow]
+  }
+}
+
+function handleClearUpdate(context: MessageHandlerContext): void {
+  // Clear screen buffer
+  for (let y = 0; y < 24; y++) {
+    const row = context.screenBuffer.value[y]
+    if (row) {
+      for (let x = 0; x < 28; x++) {
+        const cell = row[x]
+        if (cell) {
+          cell.character = ' '
+        }
+      }
+    }
+  }
+  context.cursorX.value = 0
+  context.cursorY.value = 0
+}
+
+function handleColorUpdate(context: MessageHandlerContext, update: ScreenUpdateMessage['data']): void {
+  // Update color pattern for cells specified in colorUpdates
+  if (update.colorUpdates) {
+    for (const colorUpdate of update.colorUpdates) {
+      const { x, y, pattern } = colorUpdate
+
+      // Ensure row exists
+      context.screenBuffer.value[y] ??= []
+
+      // Ensure cell exists
+      const currentRow = context.screenBuffer.value[y]
+      currentRow[x] ??= {
+        character: ' ',
+        colorPattern: 0,
+        x,
+        y,
+      }
+
+      // Update color pattern - force reactivity by creating new object
+      const currentCell = currentRow[x]
+      const newCell: ScreenCell = {
+        character: currentCell.character,
+        colorPattern: pattern,
+        x: currentCell.x,
+        y: currentCell.y,
+      }
+      currentRow[x] = newCell
+
+      // Also trigger reactivity by reassigning the row
+      context.screenBuffer.value[y] = [...currentRow]
+    }
+  }
+}
+
+function handlePaletteUpdate(context: MessageHandlerContext, update: ScreenUpdateMessage['data']): void {
+  // Update background and sprite palette codes
+  if (update.bgPalette !== undefined) {
+    context.bgPalette.value = update.bgPalette
+    logComposable.debug('Updated background palette:', update.bgPalette)
+  }
+  if (update.spritePalette !== undefined) {
+    // Note: spritePalette is stored but not currently used in rendering
+    // It will be used when sprite system is implemented
+    logComposable.debug('Updated sprite palette:', update.spritePalette)
+  }
+}
+
+function handleBackdropUpdate(context: MessageHandlerContext, update: ScreenUpdateMessage['data']): void {
+  // Update backdrop color
+  if (update.backdropColor !== undefined && context.backdropColor) {
+    context.backdropColor.value = update.backdropColor
+    logComposable.debug('Updated backdrop color:', update.backdropColor)
+  }
+}
+
+function handleCgenUpdate(context: MessageHandlerContext, update: ScreenUpdateMessage['data']): void {
+  // Update character generator mode
+  if (update.cgenMode !== undefined) {
+    if (context.cgenMode) {
+      context.cgenMode.value = update.cgenMode
+    }
+    logComposable.debug('Updated character generator mode:', update.cgenMode)
+  }
+}
+
+function handlePaletteCombinationUpdate(context: MessageHandlerContext, update: ScreenUpdateMessage['data']): void {
+  if (
+    update.paletteTarget &&
+    update.paletteIndex !== undefined &&
+    update.paletteCombination !== undefined &&
+    update.paletteColors
+  ) {
+    setRuntimePaletteCombination(
+      update.paletteTarget,
+      update.paletteIndex,
+      update.paletteCombination,
+      update.paletteColors
+    )
+    clearBackgroundTileCache()
+    clearSpriteImageCache()
+    context.scheduleRender?.()
+    logComposable.debug('Updated runtime palette combination:', {
+      target: update.paletteTarget,
+      paletteIndex: update.paletteIndex,
+      combination: update.paletteCombination,
+      colors: update.paletteColors,
+    })
+  }
+}

--- a/src/features/ide/composables/useBasicIdeMessageHandlers.ts
+++ b/src/features/ide/composables/useBasicIdeMessageHandlers.ts
@@ -3,40 +3,24 @@
  *
  * Use loglevel: log.getLogger('ide-messages').setLevel('debug') in console for verbose logs.
  */
-import type { Ref } from 'vue'
-
-import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
-import type { DecodedScreenState } from '@/core/animation/sharedDisplayBufferAccessor'
-import type {
-  AnyServiceWorkerMessage,
-  ErrorMessage,
-  RequestInputMessage,
-  ResultMessage,
-  ScreenCell,
-} from '@/core/interfaces'
+import type { AnyServiceWorkerMessage, ErrorMessage, ResultMessage } from '@/core/interfaces'
 import type { Note, Rest } from '@/core/sound/types'
-import type { SpriteState } from '@/core/sprite/types'
-import { clearBackgroundTileCache } from '@/features/ide/composables/useCanvasBackgroundRenderer'
-import { clearSpriteImageCache } from '@/features/ide/composables/useKonvaSpriteRenderer'
 import { ExecutionError } from '@/features/ide/errors/ExecutionError'
-import { setRuntimePaletteCombination } from '@/shared/data/palette'
 import { logComposable, logIdeMessages } from '@/shared/logger'
 
-import type { WebWorkerManager } from './useBasicIdeWebWorkerUtils'
+import type { MessageHandlerContext,QueuedMessage } from './messageHandlerContext'
+import { handleScreenChangedMessage, handleScreenUpdateMessage, handleSpriteStatesMessage } from './screenHandlers'
 import { extendExecutionTimeout } from './useBasicIdeWebWorkerUtils'
 import { useWebAudioPlayer } from './useWebAudioPlayer'
 
 export { ExecutionError }
+export type { MessageHandlerContext, PendingSpriteAction, SpriteActionQueues } from './messageHandlerContext'
+export { handleScreenUpdateMessage } from './screenHandlers'
 
 /**
  * Message queue for non-critical messages
  * Processed during requestAnimationFrame to align with rendering
  */
-interface QueuedMessage {
-  message: AnyServiceWorkerMessage
-  context: MessageHandlerContext
-}
-
 const messageQueue: QueuedMessage[] = []
 let isProcessingQueue = false
 let queueAnimationFrame: number | null = null
@@ -135,52 +119,6 @@ function flushMessageQueue(): void {
 }
 
 /**
- * Pending action for a sprite when its Konva node does not exist yet;
- * applied when node is created or START_MOVEMENT is handled.
- */
-export type PendingSpriteAction = { type: 'POSITION'; x: number; y: number }
-
-/** Per-sprite action queue (action number → list of pending actions). */
-export type SpriteActionQueues = Map<number, PendingSpriteAction[]>
-
-export interface MessageHandlerContext {
-  output: Ref<string[]>
-  errors: Ref<
-    Array<{ line: number; message: string; type: string; stack?: string; sourceLine?: string }>
-  >
-  debugOutput: Ref<string>
-  screenBuffer: Ref<ScreenCell[][]>
-  cursorX: Ref<number>
-  cursorY: Ref<number>
-  bgPalette: Ref<number>
-  backdropColor?: Ref<number>
-  spritePalette?: Ref<number>
-  cgenMode?: Ref<number>
-  /** Sprite states from DEF SPRITE and SPRITE commands (updated via SPRITE_STATES message) */
-  spriteStates?: Ref<SpriteState[]>
-  /** Whether sprite display is enabled (SPRITE ON/OFF) */
-  spriteEnabled?: Ref<boolean>
-  // movementStates removed - read from shared buffer instead
-  frontSpriteNodes?: Ref<Map<number, unknown>>
-  backSpriteNodes?: Ref<Map<number, unknown>>
-  /** Per-sprite action queue; POSITION etc. when node does not exist; consumed when START_MOVEMENT is handled. */
-  spriteActionQueues?: Ref<SpriteActionQueues>
-  webWorkerManager: WebWorkerManager
-  /** Shared display buffer views; main reads screen/cursor/scalars when SCREEN_CHANGED. */
-  sharedDisplayViews?: SharedDisplayViews
-  /** Called when SCREEN_CHANGED is received to schedule a render (Screen.vue reads from shared buffer). */
-  scheduleRender?: () => void
-  /** Coalesced version: at most one schedule per frame. Prefer this for SCREEN_CHANGED to avoid main-thread flood. */
-  scheduleRenderForScreenChanged?: () => void
-  /** Called by Screen.vue after decoding shared buffer to update refs (screenBuffer, cursorX, etc.). */
-  setDecodedScreenState?: (decoded: DecodedScreenState) => void
-  /** Pending INPUT/LINPUT request from worker; set when REQUEST_INPUT is received, cleared on submit/cancel. */
-  pendingInputRequest?: Ref<RequestInputMessage['data'] | null>
-  /** Send INPUT_VALUE to worker to resolve a pending input request. */
-  respondToInputRequest?: (requestId: string, values: string[], cancelled: boolean) => void
-}
-
-/**
  * Handle output message from web worker
  */
 export function handleOutputMessage(message: AnyServiceWorkerMessage, context: MessageHandlerContext): void {
@@ -198,212 +136,6 @@ export function handleOutputMessage(message: AnyServiceWorkerMessage, context: M
       message: outputText,
       type: 'runtime',
     })
-  }
-}
-
-/**
- * Handle SCREEN_CHANGED message from web worker (shared buffer path).
- * Uses coalesced schedule so many SCREEN_CHANGED (e.g. loop with PRINT) only trigger one render per frame.
- */
-export function handleScreenChangedMessage(
-  _message: AnyServiceWorkerMessage,
-  context: MessageHandlerContext
-): void {
-  const schedule = context.scheduleRenderForScreenChanged ?? context.scheduleRender
-  if (schedule) {
-    schedule()
-  }
-}
-
-/**
- * Handle SPRITE_STATES message from web worker.
- * Updates sprite states and triggers a render to display static sprites (DEF SPRITE, SPRITE commands).
- */
-export function handleSpriteStatesMessage(
-  message: AnyServiceWorkerMessage,
-  context: MessageHandlerContext
-): void {
-  if (message.type !== 'SPRITE_STATES') return
-
-  const { spriteStates, spriteEnabled } = message.data
-  logIdeMessages.debug('📤 Handling SPRITE_STATES:', { statesCount: spriteStates?.length, enabled: spriteEnabled })
-
-  // Update sprite states in context (these are passed to Screen.vue via useScreenContext)
-  if (context.spriteStates && spriteStates) {
-    context.spriteStates.value = spriteStates
-  }
-  if (context.spriteEnabled !== undefined && spriteEnabled !== undefined) {
-    context.spriteEnabled.value = spriteEnabled
-  }
-
-  // Schedule a full render to display the sprites
-  const schedule = context.scheduleRender
-  if (schedule) {
-    schedule()
-  }
-}
-
-/**
- * Handle screen update message from web worker (legacy SCREEN_UPDATE; worker no longer sends for shared buffer path)
- */
-export function handleScreenUpdateMessage(message: AnyServiceWorkerMessage, context: MessageHandlerContext): void {
-  if (message.type !== 'SCREEN_UPDATE') return
-
-  const update = message.data
-  if (!update) {
-    logComposable.warn('SCREEN_UPDATE message has no data')
-    return
-  }
-  if (!context?.screenBuffer) {
-    logComposable.warn('SCREEN_UPDATE: context or screenBuffer missing, skipping')
-    return
-  }
-
-  switch (update.updateType) {
-    case 'character':
-      if (update.x !== undefined && update.y !== undefined && update.character !== undefined) {
-        const x = update.x
-        const y = update.y
-        const character = update.character
-
-        // Ensure row exists
-        context.screenBuffer.value[y] ??= []
-
-        // Ensure cell exists
-        const currentRow = context.screenBuffer.value[y]
-        currentRow[x] ??= {
-          character: ' ',
-          colorPattern: 0,
-          x,
-          y,
-        }
-
-        // Update character - force reactivity by creating new object
-        const currentCell = currentRow[x]
-        const newCell: ScreenCell = {
-          character,
-          colorPattern: currentCell.colorPattern,
-          x: currentCell.x,
-          y: currentCell.y,
-        }
-        currentRow[x] = newCell
-
-        // Also trigger reactivity by reassigning the row
-        context.screenBuffer.value[y] = [...currentRow]
-      }
-      break
-    case 'cursor':
-      if (update.cursorX !== undefined) context.cursorX.value = update.cursorX
-      if (update.cursorY !== undefined) context.cursorY.value = update.cursorY
-      break
-    case 'clear':
-      // Clear screen buffer
-      for (let y = 0; y < 24; y++) {
-        const row = context.screenBuffer.value[y]
-        if (row) {
-          for (let x = 0; x < 28; x++) {
-            const cell = row[x]
-            if (cell) {
-              cell.character = ' '
-            }
-          }
-        }
-      }
-      context.cursorX.value = 0
-      context.cursorY.value = 0
-      break
-    case 'full':
-      if (update.screenBuffer) {
-        context.screenBuffer.value = update.screenBuffer
-      }
-      if (update.cursorX !== undefined) context.cursorX.value = update.cursorX
-      if (update.cursorY !== undefined) context.cursorY.value = update.cursorY
-      break
-    case 'color':
-      // Update color pattern for cells specified in colorUpdates
-      if (update.colorUpdates) {
-        for (const colorUpdate of update.colorUpdates) {
-          const { x, y, pattern } = colorUpdate
-
-          // Ensure row exists
-          context.screenBuffer.value[y] ??= []
-
-          // Ensure cell exists
-          const currentRow = context.screenBuffer.value[y]
-          currentRow[x] ??= {
-            character: ' ',
-            colorPattern: 0,
-            x,
-            y,
-          }
-
-          // Update color pattern - force reactivity by creating new object
-          const currentCell = currentRow[x]
-          const newCell: ScreenCell = {
-            character: currentCell.character,
-            colorPattern: pattern,
-            x: currentCell.x,
-            y: currentCell.y,
-          }
-          currentRow[x] = newCell
-
-          // Also trigger reactivity by reassigning the row
-          context.screenBuffer.value[y] = [...currentRow]
-        }
-      }
-      break
-    case 'palette':
-      // Update background and sprite palette codes
-      if (update.bgPalette !== undefined) {
-        context.bgPalette.value = update.bgPalette
-        logComposable.debug('Updated background palette:', update.bgPalette)
-      }
-      if (update.spritePalette !== undefined) {
-        // Note: spritePalette is stored but not currently used in rendering
-        // It will be used when sprite system is implemented
-        logComposable.debug('Updated sprite palette:', update.spritePalette)
-      }
-      break
-    case 'backdrop':
-      // Update backdrop color
-      if (update.backdropColor !== undefined && context.backdropColor) {
-        context.backdropColor.value = update.backdropColor
-        logComposable.debug('Updated backdrop color:', update.backdropColor)
-      }
-      break
-    case 'cgen':
-      // Update character generator mode
-      if (update.cgenMode !== undefined) {
-        if (context.cgenMode) {
-          context.cgenMode.value = update.cgenMode
-        }
-        logComposable.debug('Updated character generator mode:', update.cgenMode)
-      }
-      break
-    case 'palette-combination':
-      if (
-        update.paletteTarget &&
-        update.paletteIndex !== undefined &&
-        update.paletteCombination !== undefined &&
-        update.paletteColors
-      ) {
-        setRuntimePaletteCombination(
-          update.paletteTarget,
-          update.paletteIndex,
-          update.paletteCombination,
-          update.paletteColors
-        )
-        clearBackgroundTileCache()
-        clearSpriteImageCache()
-        context.scheduleRender?.()
-        logComposable.debug('Updated runtime palette combination:', {
-          target: update.paletteTarget,
-          paletteIndex: update.paletteIndex,
-          combination: update.paletteCombination,
-          colors: update.paletteColors,
-        })
-      }
-      break
   }
 }
 
@@ -551,33 +283,6 @@ export function handlePlaySoundMessage(message: AnyServiceWorkerMessage, _contex
 
   // Play sequentially: next PLAY starts after current melody finishes (F-BASIC behavior)
   audioPlayer.playMusicSequential(channels)
-}
-
-/**
- * Handle animation command message from web worker
- *
- * NOTE: All animation commands are now handled via direct sync (Executor Worker → Animation Worker)
- * through shared buffer using Atomics. Main thread reads animation state ONLY from shared buffer.
- *
- * Per real F-BASIC hardware behavior:
- * - POSITION on inactive sprite: No immediate screen change; stores as start position for next MOVE
- * - POSITION on active sprite: Takes effect immediately (render loop reads from shared buffer)
- *
- * This handler is obsolete and should no longer receive messages.
- */
-// Omitted: handleAnimationCommandMessage - Animation commands now handled via shared buffer sync
-
-/**
-    case 2:
-    case 8:
-      return -1 // Up directions
-    case 4:
-    case 5:
-    case 6:
-      return 1 // Down directions
-    default:
-      return 0
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes #141

## Changes
- **useBasicIdeMessageHandlers.ts** (674→379 lines): Extracted `screenHandlers.ts` (screen/sprite state handlers) and `messageHandlerContext.ts` (shared types: `MessageHandlerContext`, `PendingSpriteAction`, `SpriteActionQueues`, `QueuedMessage`)
- **MusicDSLParser.ts** (593→399 lines): Extracted `musicValidation.ts` (`validateMusicString()` function)
- **AnimationWorker.ts** (568→286 lines): Extracted `animationSyncHandlers.ts` (sync command handlers: poll, start/stop/erase movement, set position, clear all, direction deltas, `WorkerMovementState` interface)

## Test plan
- [x] All 116 test suites pass (1570 tests)
- [x] TypeScript type-check passes
- [x] ESLint passes
- [x] All 3 files now under 500 lines