### PR TITLE
test: resolve #158 - add unit tests for untested core modules

### DIFF
--- a/test/core/animation/bufferScreenOperations.test.ts
+++ b/test/core/animation/bufferScreenOperations.test.ts
@@ -1,0 +1,333 @@
+/**
+ * bufferScreenOperations unit tests
+ *
+ * Covers cellIndex, read/write screen char/pattern, cursor operations,
+ * sequence operations, and bulk screen state read/write.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  cellIndex,
+  incrementSequence,
+  readCursor,
+  readScreenBuffer,
+  readScreenChar,
+  readScreenPattern,
+  readScreenState,
+  readSequence,
+  writeCursor,
+  writeScreenChar,
+  writeScreenPattern,
+  writeScreenState,
+} from '@/core/animation/bufferScreenOperations'
+import { COLS, ROWS } from '@/core/animation/sharedDisplayBuffer'
+
+describe('bufferScreenOperations', () => {
+  describe('cellIndex', () => {
+    it('should return 0 for (0,0)', () => {
+      expect(cellIndex(0, 0)).toEqual(0)
+    })
+
+    it('should calculate index as y * COLS + x', () => {
+      expect(cellIndex(5, 3)).toEqual(3 * COLS + 5)
+    })
+
+    it('should return index for last cell', () => {
+      expect(cellIndex(COLS - 1, ROWS - 1)).toEqual(ROWS * COLS - 1)
+    })
+  })
+
+  describe('readScreenChar / writeScreenChar', () => {
+    let charView: Uint8Array
+
+    beforeEach(() => {
+      charView = new Uint8Array(ROWS * COLS)
+    })
+
+    it('should write and read character code at valid position', () => {
+      writeScreenChar(charView, 5, 3, 65)
+
+      expect(readScreenChar(charView, 5, 3)).toEqual(65)
+    })
+
+    it('should return space (0x20) for out-of-bounds x (negative)', () => {
+      expect(readScreenChar(charView, -1, 5)).toEqual(0x20)
+    })
+
+    it('should return space (0x20) for out-of-bounds x (too large)', () => {
+      expect(readScreenChar(charView, COLS, 5)).toEqual(0x20)
+    })
+
+    it('should return space (0x20) for out-of-bounds y (negative)', () => {
+      expect(readScreenChar(charView, 5, -1)).toEqual(0x20)
+    })
+
+    it('should return space (0x20) for out-of-bounds y (too large)', () => {
+      expect(readScreenChar(charView, 5, ROWS)).toEqual(0x20)
+    })
+
+    it('should not write for out-of-bounds coordinates', () => {
+      writeScreenChar(charView, -1, -1, 65)
+      writeScreenChar(charView, COLS, 0, 65)
+      writeScreenChar(charView, 0, ROWS, 65)
+
+      // All cells should remain 0 (default)
+      expect(charView[0]).toEqual(0)
+    })
+
+    it('should clamp char code to 0-255 range', () => {
+      writeScreenChar(charView, 0, 0, 300)
+      expect(readScreenChar(charView, 0, 0)).toEqual(255)
+
+      writeScreenChar(charView, 0, 0, -10)
+      expect(readScreenChar(charView, 0, 0)).toEqual(0)
+    })
+
+    it('should return 0 for uninitialized cell (Uint8Array defaults to 0)', () => {
+      // Uint8Array is zero-initialized, so the ?? 0x20 fallback does not trigger
+      // (it only triggers for undefined, which doesn't happen with typed arrays)
+      expect(readScreenChar(charView, 0, 0)).toEqual(0)
+    })
+  })
+
+  describe('readScreenPattern / writeScreenPattern', () => {
+    let patternView: Uint8Array
+
+    beforeEach(() => {
+      patternView = new Uint8Array(ROWS * COLS)
+    })
+
+    it('should write and read pattern at valid position', () => {
+      writeScreenPattern(patternView, 5, 3, 3)
+
+      expect(readScreenPattern(patternView, 5, 3)).toEqual(3)
+    })
+
+    it('should return 0 for out-of-bounds coordinates', () => {
+      expect(readScreenPattern(patternView, -1, 0)).toEqual(0)
+      expect(readScreenPattern(patternView, COLS, 0)).toEqual(0)
+      expect(readScreenPattern(patternView, 0, -1)).toEqual(0)
+      expect(readScreenPattern(patternView, 0, ROWS)).toEqual(0)
+    })
+
+    it('should not write for out-of-bounds coordinates', () => {
+      writeScreenPattern(patternView, -1, 0, 3)
+      expect(patternView[0]).toEqual(0)
+    })
+
+    it('should mask pattern to 2 bits (& 3)', () => {
+      writeScreenPattern(patternView, 0, 0, 7)
+      expect(readScreenPattern(patternView, 0, 0)).toEqual(3)
+
+      writeScreenPattern(patternView, 0, 0, 15)
+      expect(readScreenPattern(patternView, 0, 0)).toEqual(3)
+    })
+  })
+
+  describe('readCursor / writeCursor', () => {
+    let cursorView: Uint8Array
+
+    beforeEach(() => {
+      cursorView = new Uint8Array(2)
+    })
+
+    it('should write and read cursor position', () => {
+      writeCursor(cursorView, 10, 5)
+
+      expect(readCursor(cursorView)).toEqual({ x: 10, y: 5 })
+    })
+
+    it('should clamp x to 0..COLS-1', () => {
+      writeCursor(cursorView, -1, 0)
+      expect(readCursor(cursorView).x).toEqual(0)
+
+      writeCursor(cursorView, COLS + 5, 0)
+      expect(readCursor(cursorView).x).toEqual(COLS - 1)
+    })
+
+    it('should clamp y to 0..ROWS-1', () => {
+      writeCursor(cursorView, 0, -1)
+      expect(readCursor(cursorView).y).toEqual(0)
+
+      writeCursor(cursorView, 0, ROWS + 5)
+      expect(readCursor(cursorView).y).toEqual(ROWS - 1)
+    })
+
+    it('should return default (0,0) for empty view', () => {
+      expect(readCursor(new Uint8Array(0))).toEqual({ x: 0, y: 0 })
+    })
+  })
+
+  describe('readSequence / incrementSequence', () => {
+    let sequenceView: Int32Array
+
+    beforeEach(() => {
+      sequenceView = new Int32Array(1)
+    })
+
+    it('should return 0 initially', () => {
+      expect(readSequence(sequenceView)).toEqual(0)
+    })
+
+    it('should increment sequence', () => {
+      incrementSequence(sequenceView)
+      expect(readSequence(sequenceView)).toEqual(1)
+
+      incrementSequence(sequenceView)
+      expect(readSequence(sequenceView)).toEqual(2)
+    })
+
+    it('should return 0 for empty view', () => {
+      expect(readSequence(new Int32Array(0))).toEqual(0)
+    })
+  })
+
+  describe('writeScreenState', () => {
+    let charView: Uint8Array
+    let patternView: Uint8Array
+    let cursorView: Uint8Array
+    let scalarsView: Uint8Array
+
+    beforeEach(() => {
+      charView = new Uint8Array(ROWS * COLS)
+      patternView = new Uint8Array(ROWS * COLS)
+      cursorView = new Uint8Array(2)
+      scalarsView = new Uint8Array(4)
+    })
+
+    it('should write character and pattern data', () => {
+      const screenBuffer = Array.from({ length: ROWS }, (_, y) =>
+        Array.from({ length: COLS }, (_, x) => ({
+          character: 'A',
+          colorPattern: 1,
+          x,
+          y,
+        }))
+      )
+
+      writeScreenState(charView, patternView, cursorView, scalarsView, screenBuffer, 5, 3, 0, 0, 0, 2)
+
+      // Check that screen was written (character 'A' should produce a non-zero code)
+      expect(charView[0]).toBeGreaterThan(0)
+      expect(patternView[0]).toEqual(1)
+    })
+
+    it('should write cursor and scalar values', () => {
+      const screenBuffer = Array.from({ length: ROWS }, (_, y) =>
+        Array.from({ length: COLS }, (_, x) => ({
+          character: ' ',
+          colorPattern: 0,
+          x,
+          y,
+        }))
+      )
+
+      writeScreenState(charView, patternView, cursorView, scalarsView, screenBuffer, 10, 15, 1, 2, 30, 3)
+
+      expect(cursorView[0]).toEqual(10)
+      expect(cursorView[1]).toEqual(15)
+      expect(scalarsView[0]).toEqual(1) // bgPalette & 1
+      expect(scalarsView[1]).toEqual(2) // spritePalette & 3
+      expect(scalarsView[2]).toEqual(30) // backdropColor
+      expect(scalarsView[3]).toEqual(3) // cgenMode & 3
+    })
+
+    it('should skip when screenBuffer is null', () => {
+      expect(() =>
+        writeScreenState(charView, patternView, cursorView, scalarsView, null as never, 0, 0, 0, 0, 0, 0)
+      ).not.toThrow()
+    })
+
+    it('should clamp scalar values', () => {
+      const screenBuffer = Array.from({ length: ROWS }, (_, y) =>
+        Array.from({ length: COLS }, (_, x) => ({
+          character: ' ',
+          colorPattern: 0,
+          x,
+          y,
+        }))
+      )
+
+      writeScreenState(charView, patternView, cursorView, scalarsView, screenBuffer, 0, 0, 5, 7, 100, 9)
+
+      expect(scalarsView[0]).toEqual(1) // bgPalette & 1
+      expect(scalarsView[1]).toEqual(3) // spritePalette & 3
+      expect(scalarsView[2]).toEqual(60) // backdropColor clamped to 60
+      expect(scalarsView[3]).toEqual(1) // cgenMode & 3
+    })
+  })
+
+  describe('readScreenState', () => {
+    let charView: Uint8Array
+    let patternView: Uint8Array
+    let cursorView: Uint8Array
+    let scalarsView: Uint8Array
+
+    beforeEach(() => {
+      charView = new Uint8Array(ROWS * COLS)
+      patternView = new Uint8Array(ROWS * COLS)
+      cursorView = new Uint8Array(2)
+      scalarsView = new Uint8Array(4)
+    })
+
+    it('should read screen buffer with correct dimensions', () => {
+      const state = readScreenState(charView, patternView, cursorView, scalarsView)
+
+      expect(state.buffer.length).toEqual(ROWS)
+      expect(state.buffer[0]?.length).toEqual(COLS)
+    })
+
+    it('should read cursor and scalar values', () => {
+      cursorView[0] = 10
+      cursorView[1] = 15
+      scalarsView[0] = 1
+      scalarsView[1] = 2
+      scalarsView[2] = 30
+      scalarsView[3] = 3
+
+      const state = readScreenState(charView, patternView, cursorView, scalarsView)
+
+      expect(state.cursorX).toEqual(10)
+      expect(state.cursorY).toEqual(15)
+      expect(state.bgPalette).toEqual(1)
+      expect(state.spritePalette).toEqual(2)
+      expect(state.backdropColor).toEqual(30)
+      expect(state.cgenMode).toEqual(3)
+    })
+
+    it('should return 0 for uninitialized scalar values (Uint8Array defaults to 0)', () => {
+      const state = readScreenState(charView, patternView, cursorView, scalarsView)
+
+      // Uint8Array is zero-initialized, so ?? fallbacks do not trigger
+      expect(state.bgPalette).toEqual(0)
+      expect(state.spritePalette).toEqual(0)
+      expect(state.backdropColor).toEqual(0)
+      expect(state.cgenMode).toEqual(0)
+    })
+  })
+
+  describe('readScreenBuffer', () => {
+    let charView: Uint8Array
+    let patternView: Uint8Array
+
+    beforeEach(() => {
+      charView = new Uint8Array(ROWS * COLS)
+      patternView = new Uint8Array(ROWS * COLS)
+    })
+
+    it('should return buffer with correct dimensions', () => {
+      const buffer = readScreenBuffer(charView, patternView)
+
+      expect(buffer.length).toEqual(ROWS)
+      expect(buffer[0]?.length).toEqual(COLS)
+    })
+
+    it('should include x,y coordinates in each cell', () => {
+      const buffer = readScreenBuffer(charView, patternView)
+
+      expect(buffer[5]?.[10]?.x).toEqual(10)
+      expect(buffer[5]?.[10]?.y).toEqual(5)
+    })
+  })
+})

--- a/test/core/animation/bufferSpriteOperations.test.ts
+++ b/test/core/animation/bufferSpriteOperations.test.ts
@@ -1,0 +1,377 @@
+/**
+ * bufferSpriteOperations unit tests
+ *
+ * Covers writeSpriteStateToView, clearAllSprites, all individual sprite
+ * property readers (position, flags, animation, visual), and readAllMovementStates.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  clearAllSprites,
+  readAllMovementStates,
+  readSpriteCharacterTypeFromView,
+  readSpriteColorCombinationFromView,
+  readSpriteDirectionFromView,
+  readSpriteFrameIndexFromView,
+  readSpriteIsActiveFromView,
+  readSpriteIsVisibleFromView,
+  readSpritePositionFromView,
+  readSpritePriorityFromView,
+  readSpriteRemainingDistanceFromView,
+  readSpriteSpeedFromView,
+  readSpriteTotalDistanceFromView,
+  writeSpriteStateToView,
+} from '@/core/animation/bufferSpriteOperations'
+import { MAX_SPRITES, slotBase,SPRITE_DATA_FLOATS } from '@/core/animation/sharedDisplayBuffer'
+
+function createView(): Float64Array {
+  return new Float64Array(SPRITE_DATA_FLOATS)
+}
+
+describe('bufferSpriteOperations', () => {
+  describe('writeSpriteStateToView / readSpritePositionFromView', () => {
+    it('should write and read sprite position', () => {
+      const view = createView()
+
+      writeSpriteStateToView(view, 0, 100, 50, true, true)
+
+      expect(readSpritePositionFromView(view, 0)).toEqual({ x: 100, y: 50 })
+    })
+
+    it('should write position for multiple sprites', () => {
+      const view = createView()
+
+      writeSpriteStateToView(view, 0, 10, 20, false, false)
+      writeSpriteStateToView(view, 3, 200, 150, false, false)
+      writeSpriteStateToView(view, 7, 255, 240, false, false)
+
+      expect(readSpritePositionFromView(view, 0)).toEqual({ x: 10, y: 20 })
+      expect(readSpritePositionFromView(view, 3)).toEqual({ x: 200, y: 150 })
+      expect(readSpritePositionFromView(view, 7)).toEqual({ x: 255, y: 240 })
+    })
+  })
+
+  describe('readSpriteIsActiveFromView', () => {
+    it('should return true when active', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, true, false)
+
+      expect(readSpriteIsActiveFromView(view, 0)).toEqual(true)
+    })
+
+    it('should return false when inactive', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, false, false)
+
+      expect(readSpriteIsActiveFromView(view, 0)).toEqual(false)
+    })
+
+    it('should return false for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpriteIsActiveFromView(view, -1)).toEqual(false)
+      expect(readSpriteIsActiveFromView(view, MAX_SPRITES)).toEqual(false)
+    })
+  })
+
+  describe('readSpriteIsVisibleFromView', () => {
+    it('should return true when visible', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, false, true)
+
+      expect(readSpriteIsVisibleFromView(view, 0)).toEqual(true)
+    })
+
+    it('should return false when not visible', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, false, false)
+
+      expect(readSpriteIsVisibleFromView(view, 0)).toEqual(false)
+    })
+
+    it('should return false for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpriteIsVisibleFromView(view, -1)).toEqual(false)
+      expect(readSpriteIsVisibleFromView(view, MAX_SPRITES)).toEqual(false)
+    })
+  })
+
+  describe('readSpriteFrameIndexFromView', () => {
+    it('should read frame index', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, true, true, 5)
+
+      expect(readSpriteFrameIndexFromView(view, 0)).toEqual(5)
+    })
+
+    it('should return 0 for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpriteFrameIndexFromView(view, -1)).toEqual(0)
+    })
+  })
+
+  describe('readSpriteRemainingDistanceFromView', () => {
+    it('should read remaining distance', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, true, true, 0, 100)
+
+      expect(readSpriteRemainingDistanceFromView(view, 0)).toEqual(100)
+    })
+
+    it('should return 0 for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpriteRemainingDistanceFromView(view, MAX_SPRITES)).toEqual(0)
+    })
+  })
+
+  describe('readSpriteTotalDistanceFromView', () => {
+    it('should read total distance', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, true, true, 0, 0, 200)
+
+      expect(readSpriteTotalDistanceFromView(view, 0)).toEqual(200)
+    })
+
+    it('should return 0 for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpriteTotalDistanceFromView(view, MAX_SPRITES)).toEqual(0)
+    })
+  })
+
+  describe('readSpriteDirectionFromView', () => {
+    it('should read direction', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, true, true, 0, 0, 0, 3)
+
+      expect(readSpriteDirectionFromView(view, 0)).toEqual(3)
+    })
+
+    it('should return 0 for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpriteDirectionFromView(view, -1)).toEqual(0)
+    })
+  })
+
+  describe('readSpriteSpeedFromView', () => {
+    it('should read speed', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, true, true, 0, 0, 0, 0, 60)
+
+      expect(readSpriteSpeedFromView(view, 0)).toEqual(60)
+    })
+
+    it('should return 0 for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpriteSpeedFromView(view, -1)).toEqual(0)
+    })
+  })
+
+  describe('readSpritePriorityFromView', () => {
+    it('should read priority', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, true, true, 0, 0, 0, 0, 0, 1)
+
+      expect(readSpritePriorityFromView(view, 0)).toEqual(1)
+    })
+
+    it('should return 0 for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpritePriorityFromView(view, -1)).toEqual(0)
+    })
+  })
+
+  describe('readSpriteCharacterTypeFromView', () => {
+    it('should read character type', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, true, true, 0, 0, 0, 0, 0, 0, 5)
+
+      expect(readSpriteCharacterTypeFromView(view, 0)).toEqual(5)
+    })
+
+    it('should return 0 for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpriteCharacterTypeFromView(view, MAX_SPRITES)).toEqual(0)
+    })
+  })
+
+  describe('readSpriteColorCombinationFromView', () => {
+    it('should read color combination', () => {
+      const view = createView()
+      writeSpriteStateToView(view, 0, 0, 0, true, true, 0, 0, 0, 0, 0, 0, 0, 3)
+
+      expect(readSpriteColorCombinationFromView(view, 0)).toEqual(3)
+    })
+
+    it('should return 0 for out-of-range action number', () => {
+      const view = createView()
+
+      expect(readSpriteColorCombinationFromView(view, -1)).toEqual(0)
+    })
+  })
+
+  describe('clearAllSprites', () => {
+    it('should clear all 8 sprite slots', () => {
+      const view = createView()
+
+      // Set up some sprites
+      writeSpriteStateToView(view, 0, 100, 50, true, true, 0, 0, 0, 3, 60, 0, 5, 2)
+      writeSpriteStateToView(view, 7, 200, 150, true, true, 2, 0, 0, 5, 80, 1, 3, 1)
+
+      clearAllSprites(view)
+
+      // All sprites should be inactive, invisible, characterType = -1
+      for (let i = 0; i < 8; i++) {
+        expect(readSpriteIsActiveFromView(view, i)).toEqual(false)
+        expect(readSpriteIsVisibleFromView(view, i)).toEqual(false)
+        expect(readSpriteCharacterTypeFromView(view, i)).toEqual(-1)
+      }
+    })
+  })
+
+  describe('readAllMovementStates', () => {
+    it('should return states only for initialized sprites (characterType >= 0)', () => {
+      const view = createView()
+
+      // Sprite 0: initialized with characterType 5
+      writeSpriteStateToView(view, 0, 100, 50, true, true, 0, 0, 100, 3, 60, 0, 5, 2)
+      // Sprite 1: uninitialized (characterType stays 0 from clearAllSprites or default)
+      // Sprite 2: uninitialized
+      // Sprite 3: initialized with characterType 10
+      writeSpriteStateToView(view, 3, 200, 150, true, true, 1, 0, 200, 5, 80, 1, 10, 1)
+
+      const states = readAllMovementStates(
+        view,
+        (n) => readSpriteCharacterTypeFromView(view, n),
+        (n) => readSpriteTotalDistanceFromView(view, n),
+        (n) => readSpriteDirectionFromView(view, n),
+        (n) => readSpriteSpeedFromView(view, n),
+        (n) => readSpritePriorityFromView(view, n),
+        (n) => readSpriteColorCombinationFromView(view, n)
+      )
+
+      // Default view has characterType = 0 for all slots, so all are "initialized"
+      // Only slots with explicitly set data will have meaningful values
+      expect(states.length).toBeGreaterThanOrEqual(2)
+
+      // Find sprite 0
+      const state0 = states.find(s => s.actionNumber === 0)
+      expect(state0).toBeDefined()
+      expect(state0!.definition.characterType).toEqual(5)
+      expect(state0!.definition.direction).toEqual(3)
+      expect(state0!.definition.speed).toEqual(60)
+      expect(state0!.definition.distance).toEqual(50) // totalDistance / 2
+      expect(state0!.definition.priority).toEqual(0)
+      expect(state0!.definition.colorCombination).toEqual(2)
+    })
+
+    it('should exclude sprites with characterType = -1 (cleared)', () => {
+      const view = createView()
+      clearAllSprites(view) // Sets all characterType to -1
+
+      // Now initialize only sprite 5
+      writeSpriteStateToView(view, 5, 100, 50, true, true, 0, 0, 100, 3, 60, 0, 5, 2)
+
+      const states = readAllMovementStates(
+        view,
+        (n) => readSpriteCharacterTypeFromView(view, n),
+        (n) => readSpriteTotalDistanceFromView(view, n),
+        (n) => readSpriteDirectionFromView(view, n),
+        (n) => readSpriteSpeedFromView(view, n),
+        (n) => readSpritePriorityFromView(view, n),
+        (n) => readSpriteColorCombinationFromView(view, n)
+      )
+
+      expect(states.length).toEqual(1)
+      expect(states[0]?.actionNumber).toEqual(5)
+    })
+
+    it('should return empty array when no sprites are initialized', () => {
+      const view = createView()
+      clearAllSprites(view)
+
+      const states = readAllMovementStates(
+        view,
+        (n) => readSpriteCharacterTypeFromView(view, n),
+        (n) => readSpriteTotalDistanceFromView(view, n),
+        (n) => readSpriteDirectionFromView(view, n),
+        (n) => readSpriteSpeedFromView(view, n),
+        (n) => readSpritePriorityFromView(view, n),
+        (n) => readSpriteColorCombinationFromView(view, n)
+      )
+
+      expect(states).toEqual([])
+    })
+
+    it('should calculate distance as totalDistance / 2', () => {
+      const view = createView()
+      clearAllSprites(view)
+      writeSpriteStateToView(view, 0, 0, 0, true, true, 0, 0, 100, 0, 0, 0, 0, 0)
+
+      const states = readAllMovementStates(
+        view,
+        (n) => readSpriteCharacterTypeFromView(view, n),
+        (n) => readSpriteTotalDistanceFromView(view, n),
+        (n) => readSpriteDirectionFromView(view, n),
+        (n) => readSpriteSpeedFromView(view, n),
+        (n) => readSpritePriorityFromView(view, n),
+        (n) => readSpriteColorCombinationFromView(view, n)
+      )
+
+      expect(states[0]?.definition.distance).toEqual(50) // 100 / 2
+    })
+  })
+
+  describe('slotBase integration', () => {
+    it('should compute correct base indices for each sprite', () => {
+      for (let i = 0; i < MAX_SPRITES; i++) {
+        expect(slotBase(i)).toEqual(i * 12)
+      }
+    })
+
+    it('should throw for invalid action number', () => {
+      expect(() => slotBase(-1)).toThrow('actionNumber must be 0-7')
+      expect(() => slotBase(8)).toThrow('actionNumber must be 0-7')
+    })
+  })
+
+  describe('writeSpriteStateToView full fields', () => {
+    it('should write all 12 fields correctly', () => {
+      const view = createView()
+
+      writeSpriteStateToView(view, 2, 100, 200, true, true, 3, 50, 100, 5, 60, 1, 7, 2)
+
+      const base = slotBase(2)
+      expect(view[base + 0]).toEqual(100) // x
+      expect(view[base + 1]).toEqual(200) // y
+      expect(view[base + 2]).toEqual(1) // isActive (true -> 1)
+      expect(view[base + 3]).toEqual(1) // isVisible (true -> 1)
+      expect(view[base + 4]).toEqual(3) // frameIndex
+      expect(view[base + 5]).toEqual(50) // remainingDistance
+      expect(view[base + 6]).toEqual(100) // totalDistance
+      expect(view[base + 7]).toEqual(5) // direction
+      expect(view[base + 8]).toEqual(60) // speed
+      expect(view[base + 9]).toEqual(1) // priority
+      expect(view[base + 10]).toEqual(7) // characterType
+      expect(view[base + 11]).toEqual(2) // colorCombination
+    })
+
+    it('should convert boolean flags to 0/1', () => {
+      const view = createView()
+
+      writeSpriteStateToView(view, 0, 0, 0, false, false)
+
+      const base = slotBase(0)
+      expect(view[base + 2]).toEqual(0) // isActive false
+      expect(view[base + 3]).toEqual(0) // isVisible false
+    })
+  })
+})

--- a/test/core/animation/sharedDisplayBufferAccessor.test.ts
+++ b/test/core/animation/sharedDisplayBufferAccessor.test.ts
@@ -1,0 +1,424 @@
+/**
+ * SharedDisplayBufferAccessor unit tests
+ *
+ * Covers construction (valid/invalid buffer), screen char/pattern read/write,
+ * cursor, sequence, scalars, sprite state delegation, sync commands,
+ * and bulk screen state operations.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { SHARED_DISPLAY_BUFFER_BYTES } from '@/core/animation/sharedDisplayBuffer'
+import { SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
+import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
+import type { ScreenCell } from '@/core/interfaces'
+
+function createBuffer(): SharedArrayBuffer {
+  return new SharedArrayBuffer(SHARED_DISPLAY_BUFFER_BYTES)
+}
+
+describe('SharedDisplayBufferAccessor', () => {
+  describe('constructor', () => {
+    it('should accept a valid SharedArrayBuffer', () => {
+      const buffer = createBuffer()
+
+      expect(() => new SharedDisplayBufferAccessor(buffer)).not.toThrow()
+    })
+
+    it('should throw RangeError for buffer too small', () => {
+      const smallBuffer = new SharedArrayBuffer(100)
+
+      expect(() => new SharedDisplayBufferAccessor(smallBuffer)).toThrow(RangeError)
+      expect(() => new SharedDisplayBufferAccessor(smallBuffer)).toThrow('Buffer too small')
+    })
+  })
+
+  describe('screen char operations', () => {
+    let accessor: SharedDisplayBufferAccessor
+
+    beforeEach(() => {
+      accessor = new SharedDisplayBufferAccessor(createBuffer())
+    })
+
+    it('should write and read screen character', () => {
+      accessor.writeScreenChar(5, 3, 65)
+
+      expect(accessor.readScreenChar(5, 3)).toEqual(65)
+    })
+
+    it('should return space (0x20) for out-of-bounds', () => {
+      expect(accessor.readScreenChar(-1, 0)).toEqual(0x20)
+      expect(accessor.readScreenChar(28, 0)).toEqual(0x20)
+      expect(accessor.readScreenChar(0, -1)).toEqual(0x20)
+      expect(accessor.readScreenChar(0, 24)).toEqual(0x20)
+    })
+
+    it('should not write for out-of-bounds', () => {
+      // The accessor's buffer is zero-initialized, so (0,0) starts at 0
+      const original = accessor.readScreenChar(0, 0)
+
+      accessor.writeScreenChar(-1, -1, 65)
+      accessor.writeScreenChar(28, 0, 65)
+
+      expect(accessor.readScreenChar(0, 0)).toEqual(original)
+    })
+  })
+
+  describe('screen pattern operations', () => {
+    let accessor: SharedDisplayBufferAccessor
+
+    beforeEach(() => {
+      accessor = new SharedDisplayBufferAccessor(createBuffer())
+    })
+
+    it('should write and read screen pattern', () => {
+      accessor.writeScreenPattern(5, 3, 3)
+
+      expect(accessor.readScreenPattern(5, 3)).toEqual(3)
+    })
+
+    it('should return 0 for out-of-bounds', () => {
+      expect(accessor.readScreenPattern(-1, 0)).toEqual(0)
+      expect(accessor.readScreenPattern(28, 0)).toEqual(0)
+    })
+  })
+
+  describe('readScreenBuffer', () => {
+    it('should return buffer with correct dimensions', () => {
+      const accessor = new SharedDisplayBufferAccessor(createBuffer())
+
+      const buffer = accessor.readScreenBuffer()
+
+      expect(buffer.length).toEqual(24)
+      expect(buffer[0]?.length).toEqual(28)
+    })
+  })
+
+  describe('cursor operations', () => {
+    let accessor: SharedDisplayBufferAccessor
+
+    beforeEach(() => {
+      accessor = new SharedDisplayBufferAccessor(createBuffer())
+    })
+
+    it('should write and read cursor position', () => {
+      accessor.writeCursor(10, 5)
+
+      expect(accessor.readCursor()).toEqual({ x: 10, y: 5 })
+    })
+  })
+
+  describe('sequence operations', () => {
+    let accessor: SharedDisplayBufferAccessor
+
+    beforeEach(() => {
+      accessor = new SharedDisplayBufferAccessor(createBuffer())
+    })
+
+    it('should return 0 initially', () => {
+      expect(accessor.readSequence()).toEqual(0)
+    })
+
+    it('should increment sequence', () => {
+      accessor.incrementSequence()
+
+      expect(accessor.readSequence()).toEqual(1)
+    })
+  })
+
+  describe('scalar operations', () => {
+    let accessor: SharedDisplayBufferAccessor
+
+    beforeEach(() => {
+      accessor = new SharedDisplayBufferAccessor(createBuffer())
+    })
+
+    it('should read and write bgPalette', () => {
+      accessor.writeBgPalette(1)
+      expect(accessor.readBgPalette()).toEqual(1)
+    })
+
+    it('should mask bgPalette to 0-1', () => {
+      accessor.writeBgPalette(5)
+      expect(accessor.readBgPalette()).toEqual(1)
+    })
+
+    it('should read and write spritePalette', () => {
+      accessor.writeSpritePalette(3)
+      expect(accessor.readSpritePalette()).toEqual(3)
+    })
+
+    it('should mask spritePalette to 0-3', () => {
+      accessor.writeSpritePalette(7)
+      expect(accessor.readSpritePalette()).toEqual(3)
+    })
+
+    it('should read and write backdropColor', () => {
+      accessor.writeBackdropColor(30)
+      expect(accessor.readBackdropColor()).toEqual(30)
+    })
+
+    it('should clamp backdropColor to 0-60', () => {
+      accessor.writeBackdropColor(100)
+      expect(accessor.readBackdropColor()).toEqual(60)
+
+      accessor.writeBackdropColor(-10)
+      expect(accessor.readBackdropColor()).toEqual(0)
+    })
+
+    it('should read and write cgenMode', () => {
+      accessor.writeCgenMode(3)
+      expect(accessor.readCgenMode()).toEqual(3)
+    })
+
+    it('should mask cgenMode to 0-3', () => {
+      accessor.writeCgenMode(7)
+      expect(accessor.readCgenMode()).toEqual(3)
+    })
+
+    it('should read all scalars at once', () => {
+      accessor.writeScalars(1, 2, 30, 3)
+
+      const scalars = accessor.readScalars()
+      expect(scalars).toEqual({
+        bgPalette: 1,
+        spritePalette: 2,
+        backdropColor: 30,
+        cgenMode: 3,
+      })
+    })
+
+    it('should write all scalars at once', () => {
+      accessor.writeScalars(0, 1, 15, 2)
+
+      expect(accessor.readBgPalette()).toEqual(0)
+      expect(accessor.readSpritePalette()).toEqual(1)
+      expect(accessor.readBackdropColor()).toEqual(15)
+      expect(accessor.readCgenMode()).toEqual(2)
+    })
+  })
+
+  describe('sprite operations', () => {
+    let accessor: SharedDisplayBufferAccessor
+
+    beforeEach(() => {
+      accessor = new SharedDisplayBufferAccessor(createBuffer())
+    })
+
+    it('should write and read sprite position', () => {
+      accessor.writeSpriteState(0, 100, 50, true, true)
+
+      expect(accessor.readSpritePosition(0)).toEqual({ x: 100, y: 50 })
+    })
+
+    it('should read isActive', () => {
+      accessor.writeSpriteState(0, 0, 0, true, false)
+
+      expect(accessor.readSpriteIsActive(0)).toEqual(true)
+    })
+
+    it('should read isVisible', () => {
+      accessor.writeSpriteState(0, 0, 0, false, true)
+
+      expect(accessor.readSpriteIsVisible(0)).toEqual(true)
+    })
+
+    it('should read frameIndex', () => {
+      accessor.writeSpriteState(0, 0, 0, true, true, 5)
+
+      expect(accessor.readSpriteFrameIndex(0)).toEqual(5)
+    })
+
+    it('should read remainingDistance', () => {
+      accessor.writeSpriteState(0, 0, 0, true, true, 0, 100)
+
+      expect(accessor.readSpriteRemainingDistance(0)).toEqual(100)
+    })
+
+    it('should read totalDistance', () => {
+      accessor.writeSpriteState(0, 0, 0, true, true, 0, 0, 200)
+
+      expect(accessor.readSpriteTotalDistance(0)).toEqual(200)
+    })
+
+    it('should read direction', () => {
+      accessor.writeSpriteState(0, 0, 0, true, true, 0, 0, 0, 3)
+
+      expect(accessor.readSpriteDirection(0)).toEqual(3)
+    })
+
+    it('should read speed', () => {
+      accessor.writeSpriteState(0, 0, 0, true, true, 0, 0, 0, 0, 60)
+
+      expect(accessor.readSpriteSpeed(0)).toEqual(60)
+    })
+
+    it('should read priority', () => {
+      accessor.writeSpriteState(0, 0, 0, true, true, 0, 0, 0, 0, 0, 1)
+
+      expect(accessor.readSpritePriority(0)).toEqual(1)
+    })
+
+    it('should read characterType', () => {
+      accessor.writeSpriteState(0, 0, 0, true, true, 0, 0, 0, 0, 0, 0, 5)
+
+      expect(accessor.readSpriteCharacterType(0)).toEqual(5)
+    })
+
+    it('should read colorCombination', () => {
+      accessor.writeSpriteState(0, 0, 0, true, true, 0, 0, 0, 0, 0, 0, 0, 2)
+
+      expect(accessor.readSpriteColorCombination(0)).toEqual(2)
+    })
+
+    it('should return null position for out-of-range', () => {
+      expect(accessor.readSpritePosition(-1)).toBeNull()
+      expect(accessor.readSpritePosition(8)).toBeNull()
+    })
+
+    it('should return false for out-of-range isActive/isVisible', () => {
+      expect(accessor.readSpriteIsActive(-1)).toEqual(false)
+      expect(accessor.readSpriteIsVisible(8)).toEqual(false)
+    })
+
+    it('should return 0 for out-of-range numeric properties', () => {
+      expect(accessor.readSpriteFrameIndex(-1)).toEqual(0)
+      expect(accessor.readSpriteDirection(8)).toEqual(0)
+      expect(accessor.readSpriteSpeed(-1)).toEqual(0)
+      expect(accessor.readSpritePriority(8)).toEqual(0)
+      expect(accessor.readSpriteCharacterType(-1)).toEqual(0)
+      expect(accessor.readSpriteColorCombination(8)).toEqual(0)
+    })
+  })
+
+  describe('clearAllSprites', () => {
+    it('should clear all sprite slots', () => {
+      const accessor = new SharedDisplayBufferAccessor(createBuffer())
+
+      accessor.writeSpriteState(0, 100, 50, true, true, 0, 0, 0, 3, 60, 0, 5, 2)
+      accessor.writeSpriteState(7, 200, 150, true, true, 2, 0, 0, 5, 80, 1, 3, 1)
+
+      accessor.clearAllSprites()
+
+      for (let i = 0; i < 8; i++) {
+        expect(accessor.readSpriteIsActive(i)).toEqual(false)
+        expect(accessor.readSpriteIsVisible(i)).toEqual(false)
+        expect(accessor.readSpriteCharacterType(i)).toEqual(-1)
+      }
+    })
+  })
+
+  describe('readAllMovementStates', () => {
+    it('should return only initialized sprites', () => {
+      const accessor = new SharedDisplayBufferAccessor(createBuffer())
+      accessor.clearAllSprites()
+
+      accessor.writeSpriteState(0, 0, 0, true, true, 0, 0, 100, 3, 60, 0, 5, 2)
+      accessor.writeSpriteState(5, 0, 0, true, true, 0, 0, 200, 5, 80, 1, 10, 1)
+
+      const states = accessor.readAllMovementStates()
+
+      expect(states.length).toEqual(2)
+      expect(states[0]?.actionNumber).toEqual(0)
+      expect(states[0]?.definition.characterType).toEqual(5)
+      expect(states[0]?.definition.distance).toEqual(50) // totalDistance / 2
+      expect(states[1]?.actionNumber).toEqual(5)
+      expect(states[1]?.definition.characterType).toEqual(10)
+    })
+  })
+
+  describe('writeScreenState / readScreenState', () => {
+    let accessor: SharedDisplayBufferAccessor
+
+    beforeEach(() => {
+      accessor = new SharedDisplayBufferAccessor(createBuffer())
+    })
+
+    it('should write and read screen state', () => {
+      const screenBuffer: ScreenCell[][] = Array.from({ length: 24 }, (_, y) =>
+        Array.from({ length: 28 }, (_, x) => ({
+          character: 'A',
+          colorPattern: 1,
+          x,
+          y,
+        }))
+      )
+
+      accessor.writeScreenState(screenBuffer, 10, 5, 1, 2, 30, 3)
+
+      const state = accessor.readScreenState()
+      expect(state.cursorX).toEqual(10)
+      expect(state.cursorY).toEqual(5)
+      expect(state.bgPalette).toEqual(1)
+      expect(state.spritePalette).toEqual(2)
+      expect(state.backdropColor).toEqual(30)
+      expect(state.cgenMode).toEqual(3)
+      expect(state.buffer.length).toEqual(24)
+      expect(state.buffer[0]?.length).toEqual(28)
+    })
+  })
+
+  describe('sync command operations', () => {
+    let accessor: SharedDisplayBufferAccessor
+
+    beforeEach(() => {
+      accessor = new SharedDisplayBufferAccessor(createBuffer())
+    })
+
+    it('should write and read sync command', () => {
+      accessor.writeSyncCommand(SyncCommandType.START_MOVEMENT, 0, {
+        startX: 100,
+        startY: 50,
+        direction: 3,
+        speed: 60,
+        distance: 100,
+        priority: 0,
+      })
+
+      const cmd = accessor.readSyncCommand()
+
+      expect(cmd).not.toBeNull()
+      expect(cmd!.commandType).toEqual(SyncCommandType.START_MOVEMENT)
+      expect(cmd!.actionNumber).toEqual(0)
+      expect(cmd!.params.startX).toEqual(100)
+      expect(cmd!.params.startY).toEqual(50)
+      expect(cmd!.params.direction).toEqual(3)
+      expect(cmd!.params.speed).toEqual(60)
+      expect(cmd!.params.distance).toEqual(100)
+      expect(cmd!.params.priority).toEqual(0)
+    })
+
+    it('should return null when no command is pending (type = NONE)', () => {
+      expect(accessor.readSyncCommand()).toBeNull()
+    })
+
+    it('should clear sync command', () => {
+      accessor.writeSyncCommand(SyncCommandType.START_MOVEMENT, 0)
+      accessor.clearSyncCommand()
+
+      expect(accessor.readSyncCommand()).toBeNull()
+    })
+
+    it('should write and read ack', () => {
+      accessor.writeAck(1)
+
+      expect(accessor.readAck()).toEqual(1)
+    })
+  })
+
+  describe('notify', () => {
+    it('should not throw', () => {
+      const accessor = new SharedDisplayBufferAccessor(createBuffer())
+
+      expect(() => accessor.notify()).not.toThrow()
+    })
+  })
+
+  describe('notifyAck', () => {
+    it('should not throw', () => {
+      const accessor = new SharedDisplayBufferAccessor(createBuffer())
+
+      expect(() => accessor.notifyAck()).not.toThrow()
+    })
+  })
+})

--- a/test/core/services/DataService.test.ts
+++ b/test/core/services/DataService.test.ts
@@ -1,0 +1,331 @@
+/**
+ * DataService unit tests
+ *
+ * Covers DATA constant evaluation (number, hex, string, identifier),
+ * READ with pointer advancement, RESTORE (full and by line), preprocess,
+ * and edge cases (out-of-data, missing targets).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ERROR_TYPES } from '@/core/constants'
+import type { InterpreterConfig } from '@/core/interfaces'
+import { DataService } from '@/core/services/DataService'
+import { ExecutionContext } from '@/core/state/ExecutionContext'
+
+function createTestContext(config?: Partial<InterpreterConfig>): ExecutionContext {
+  return new ExecutionContext({
+    maxIterations: 1000,
+    maxOutputLines: 100,
+    enableDebugMode: false,
+    strictMode: false,
+    ...config,
+  })
+}
+
+function createMockEvaluator() {
+  return {
+    evaluateExpression: vi.fn(),
+  }
+}
+
+function createNumberLiteralCst(image: string) {
+  return {
+    name: 'dataConstant',
+    children: {
+      NumberLiteral: [{ image, startOffset: 0, endOffset: image.length, tokenTypeIdx: 0 }],
+    },
+  }
+}
+
+function createHexLiteralCst(image: string) {
+  return {
+    name: 'dataConstant',
+    children: {
+      HexLiteral: [{ image, startOffset: 0, endOffset: image.length, tokenTypeIdx: 0 }],
+    },
+  }
+}
+
+function createStringLiteralCst(image: string) {
+  return {
+    name: 'dataConstant',
+    children: {
+      StringLiteral: [{ image, startOffset: 0, endOffset: image.length, tokenTypeIdx: 0 }],
+    },
+  }
+}
+
+function createIdentifierCst(image: string) {
+  return {
+    name: 'dataConstant',
+    children: {
+      Identifier: [{ image, startOffset: 0, endOffset: image.length, tokenTypeIdx: 0 }],
+    },
+  }
+}
+
+describe('DataService', () => {
+  let context: ExecutionContext
+  let evaluator: ReturnType<typeof createMockEvaluator>
+  let service: DataService
+
+  beforeEach(() => {
+    context = createTestContext()
+    evaluator = createMockEvaluator()
+    service = new DataService(context, evaluator as never)
+  })
+
+  describe('addDataValuesCst', () => {
+    it('should add number literal values', () => {
+      const csts = [
+        createNumberLiteralCst('10'),
+        createNumberLiteralCst('20'),
+        createNumberLiteralCst('30'),
+      ]
+
+      service.addDataValuesCst(csts as never)
+
+      expect(context.dataValues).toEqual([10, 20, 30])
+    })
+
+    it('should add hex literal values', () => {
+      const csts = [
+        createHexLiteralCst('&HDD'),
+        createHexLiteralCst('&HFF'),
+        createHexLiteralCst('&H00'),
+      ]
+
+      service.addDataValuesCst(csts as never)
+
+      expect(context.dataValues).toEqual([0xDD, 0xFF, 0x00])
+    })
+
+    it('should add string literal values (without quotes)', () => {
+      const csts = [
+        createStringLiteralCst('"hello"'),
+        createStringLiteralCst('"world"'),
+      ]
+
+      service.addDataValuesCst(csts as never)
+
+      expect(context.dataValues).toEqual(['hello', 'world'])
+    })
+
+    it('should add identifier values as string constants', () => {
+      const csts = [
+        createIdentifierCst('HELLO'),
+        createIdentifierCst('WORLD'),
+      ]
+
+      service.addDataValuesCst(csts as never)
+
+      expect(context.dataValues).toEqual(['HELLO', 'WORLD'])
+    })
+
+    it('should add mixed types of data values', () => {
+      const csts = [
+        createNumberLiteralCst('100'),
+        createStringLiteralCst('"test"'),
+        createIdentifierCst('NAME'),
+        createHexLiteralCst('&H1A'),
+      ]
+
+      service.addDataValuesCst(csts as never)
+
+      expect(context.dataValues).toEqual([100, 'test', 'NAME', 0x1A])
+    })
+
+    it('should throw for invalid DATA constant', () => {
+      const cst = { name: 'dataConstant', children: {} }
+
+      expect(() => service.addDataValuesCst([cst as never])).toThrow('Invalid DATA constant')
+    })
+
+    it('should log debug output when debug mode is enabled', () => {
+      const debugContext = createTestContext({ enableDebugMode: true })
+      const mockAdapter = { debugOutput: vi.fn() }
+      debugContext.deviceAdapter = mockAdapter as never
+      const debugService = new DataService(debugContext, evaluator as never)
+
+      const csts = [createNumberLiteralCst('10'), createNumberLiteralCst('20')]
+      debugService.addDataValuesCst(csts as never)
+
+      expect(mockAdapter.debugOutput).toHaveBeenCalledWith('DATA: Added 2 values')
+    })
+  })
+
+  describe('readNextDataValue', () => {
+    it('should read values sequentially', () => {
+      service.addDataValuesCst([
+        createNumberLiteralCst('10'),
+        createNumberLiteralCst('20'),
+        createNumberLiteralCst('30'),
+      ] as never)
+
+      expect(service.readNextDataValue()).toEqual(10)
+      expect(service.readNextDataValue()).toEqual(20)
+      expect(service.readNextDataValue()).toEqual(30)
+    })
+
+    it('should advance dataIndex after each read', () => {
+      service.addDataValuesCst([
+        createNumberLiteralCst('10'),
+        createNumberLiteralCst('20'),
+      ] as never)
+
+      expect(service.getCurrentDataIndex()).toEqual(0)
+      service.readNextDataValue()
+      expect(service.getCurrentDataIndex()).toEqual(1)
+      service.readNextDataValue()
+      expect(service.getCurrentDataIndex()).toEqual(2)
+    })
+
+    it('should add OD ERROR when reading past end of data', () => {
+      service.addDataValuesCst([createNumberLiteralCst('10')] as never)
+      service.readNextDataValue() // read the only value
+      service.readNextDataValue() // should trigger OD ERROR
+
+      const errors = context.getErrors()
+      expect(errors.length).toEqual(1)
+      expect(errors[0]?.message).toEqual('OD ERROR')
+      expect(errors[0]?.type).toEqual(ERROR_TYPES.RUNTIME)
+    })
+
+    it('should return 0 when reading past end of data', () => {
+      service.addDataValuesCst([createNumberLiteralCst('10')] as never)
+      service.readNextDataValue()
+
+      expect(service.readNextDataValue()).toEqual(0)
+    })
+
+    it('should halt execution on OD ERROR', () => {
+      service.addDataValuesCst([createNumberLiteralCst('10')] as never)
+      service.readNextDataValue()
+      service.readNextDataValue()
+
+      expect(context.shouldStop).toEqual(true)
+      expect(context.isRunning).toEqual(false)
+    })
+  })
+
+  describe('restoreData', () => {
+    it('should reset data index to 0 with no arguments', () => {
+      service.addDataValuesCst([
+        createNumberLiteralCst('10'),
+        createNumberLiteralCst('20'),
+        createNumberLiteralCst('30'),
+      ] as never)
+      service.readNextDataValue()
+      service.readNextDataValue()
+
+      expect(service.getCurrentDataIndex()).toEqual(2)
+
+      service.restoreData()
+
+      expect(service.getCurrentDataIndex()).toEqual(0)
+    })
+
+    it('should add error for non-existent target line', () => {
+      context.statements = []
+
+      service.restoreData(100)
+
+      const errors = context.getErrors()
+      expect(errors.length).toEqual(1)
+      expect(errors[0]?.message).toEqual('RESTORE target line 100 not found')
+    })
+
+    it('should log debug output when debug mode is enabled', () => {
+      const debugContext = createTestContext({ enableDebugMode: true })
+      const mockAdapter = { debugOutput: vi.fn() }
+      debugContext.deviceAdapter = mockAdapter as never
+      const debugService = new DataService(debugContext, evaluator as never)
+
+      debugService.restoreData()
+
+      expect(mockAdapter.debugOutput).toHaveBeenCalledWith('RESTORE: Data index set to 0')
+    })
+  })
+
+  describe('getCurrentDataIndex', () => {
+    it('should return 0 initially', () => {
+      expect(service.getCurrentDataIndex()).toEqual(0)
+    })
+  })
+
+  describe('getDataValueCount', () => {
+    it('should return 0 when no data', () => {
+      expect(service.getDataValueCount()).toEqual(0)
+    })
+
+    it('should return total count of data values', () => {
+      service.addDataValuesCst([
+        createNumberLiteralCst('10'),
+        createNumberLiteralCst('20'),
+        createNumberLiteralCst('30'),
+      ] as never)
+
+      expect(service.getDataValueCount()).toEqual(3)
+    })
+  })
+
+  describe('getAllDataValues', () => {
+    it('should return copy of all data values', () => {
+      service.addDataValuesCst([
+        createNumberLiteralCst('10'),
+        createNumberLiteralCst('20'),
+      ] as never)
+
+      const values = service.getAllDataValues()
+      expect(values).toEqual([10, 20])
+
+      // Verify it is a copy
+      values.push(99)
+      expect(service.getDataValueCount()).toEqual(2)
+    })
+  })
+
+  describe('clearDataValues', () => {
+    it('should clear all data values and reset index', () => {
+      service.addDataValuesCst([
+        createNumberLiteralCst('10'),
+        createNumberLiteralCst('20'),
+      ] as never)
+      service.readNextDataValue()
+
+      service.clearDataValues()
+
+      expect(service.getDataValueCount()).toEqual(0)
+      expect(service.getCurrentDataIndex()).toEqual(0)
+    })
+  })
+
+  describe('hasMoreData', () => {
+    it('should return false when no data', () => {
+      expect(service.hasMoreData()).toEqual(false)
+    })
+
+    it('should return true when data is available', () => {
+      service.addDataValuesCst([createNumberLiteralCst('10')] as never)
+
+      expect(service.hasMoreData()).toEqual(true)
+    })
+
+    it('should return false when all data has been read', () => {
+      service.addDataValuesCst([createNumberLiteralCst('10')] as never)
+      service.readNextDataValue()
+
+      expect(service.hasMoreData()).toEqual(false)
+    })
+  })
+
+  describe('addDataValues (deprecated)', () => {
+    it('should log warning when called', () => {
+      service.addDataValues([])
+
+      // No error should be thrown
+      expect(context.getErrors().length).toEqual(0)
+    })
+  })
+})

--- a/test/core/services/VariableService.test.ts
+++ b/test/core/services/VariableService.test.ts
@@ -1,0 +1,341 @@
+/**
+ * VariableService unit tests
+ *
+ * Covers variable get/set, type handling, array operations, array creation,
+ * existence checks, and clearing.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { InterpreterConfig } from '@/core/interfaces'
+import { VariableService } from '@/core/services/VariableService'
+import { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { BasicScalarValue } from '@/core/types/BasicTypes'
+
+function createTestContext(): ExecutionContext {
+  const config: InterpreterConfig = {
+    maxIterations: 1000,
+    maxOutputLines: 100,
+    enableDebugMode: false,
+    strictMode: false,
+  }
+  return new ExecutionContext(config)
+}
+
+function createMockEvaluator() {
+  return {
+    evaluateExpression: vi.fn(),
+  }
+}
+
+describe('VariableService', () => {
+  let context: ExecutionContext
+  let evaluator: ReturnType<typeof createMockEvaluator>
+  let service: VariableService
+
+  beforeEach(() => {
+    context = createTestContext()
+    evaluator = createMockEvaluator()
+    service = new VariableService(context, evaluator as never)
+  })
+
+  describe('getVariable', () => {
+    it('should return undefined for non-existent variable', () => {
+      expect(service.getVariable('X')).toBeUndefined()
+    })
+
+    it('should return the variable value for existing variable', () => {
+      service.setVariable('X', 42)
+
+      expect(service.getVariable('X')).toEqual({ value: 42, type: 'number' })
+    })
+  })
+
+  describe('setVariable', () => {
+    it('should store a numeric variable with type number', () => {
+      service.setVariable('X', 42)
+
+      expect(context.variables.get('X')).toEqual({ value: 42, type: 'number' })
+    })
+
+    it('should store a string variable with type string', () => {
+      service.setVariable('NAME$', 'Hello')
+
+      expect(context.variables.get('NAME$')).toEqual({ value: 'Hello', type: 'string' })
+    })
+
+    it('should overwrite an existing variable', () => {
+      service.setVariable('X', 10)
+      service.setVariable('X', 20)
+
+      expect(context.variables.get('X')).toEqual({ value: 20, type: 'number' })
+    })
+  })
+
+  describe('setVariableFromExpressionCst', () => {
+    it('should evaluate expression and set variable', () => {
+      evaluator.evaluateExpression.mockReturnValue(42)
+      const cst = { name: 'expression', children: {} }
+
+      service.setVariableFromExpressionCst('X', cst as never)
+
+      expect(evaluator.evaluateExpression).toHaveBeenCalledWith(cst)
+      expect(context.variables.get('X')).toEqual({ value: 42, type: 'number' })
+    })
+
+    it('should convert boolean true to 1', () => {
+      evaluator.evaluateExpression.mockReturnValue(true)
+      const cst = { name: 'expression', children: {} }
+
+      service.setVariableFromExpressionCst('X', cst as never)
+
+      expect(context.variables.get('X')).toEqual({ value: 1, type: 'number' })
+    })
+
+    it('should convert boolean false to 0', () => {
+      evaluator.evaluateExpression.mockReturnValue(false)
+      const cst = { name: 'expression', children: {} }
+
+      service.setVariableFromExpressionCst('X', cst as never)
+
+      expect(context.variables.get('X')).toEqual({ value: 0, type: 'number' })
+    })
+
+    it('should store string values directly', () => {
+      evaluator.evaluateExpression.mockReturnValue('hello')
+      const cst = { name: 'expression', children: {} }
+
+      service.setVariableFromExpressionCst('S$', cst as never)
+
+      expect(context.variables.get('S$')).toEqual({ value: 'hello', type: 'string' })
+    })
+  })
+
+  describe('setArrayElement', () => {
+    it('should create array and set element if array does not exist', () => {
+      service.setArrayElement('A', [0], 42)
+
+      expect(context.arrays.has('A')).toEqual(true)
+      expect((context.arrays.get('A') as BasicScalarValue[])?.[0]).toEqual(42)
+    })
+
+    it('should set element in existing array', () => {
+      service.setArrayElement('A', [0], 10)
+      service.setArrayElement('A', [1], 20)
+
+      expect(context.arrays.get('A')).toEqual([10, 20])
+    })
+
+    it('should set nested array elements (2D)', () => {
+      service.setArrayElement('M', [0, 0], 1)
+      service.setArrayElement('M', [0, 1], 2)
+      service.setArrayElement('M', [1, 0], 3)
+
+      const mArray = context.arrays.get('M') as BasicScalarValue[][]
+      expect(mArray?.[0]).toEqual([1, 2])
+      expect(mArray?.[1]?.[0]).toEqual(3)
+    })
+
+    it('should handle string array elements', () => {
+      service.setArrayElement('A$', [0], 'hello')
+
+      expect((context.arrays.get('A$') as BasicScalarValue[])?.[0]).toEqual('hello')
+    })
+
+    it('should floor index values', () => {
+      service.setArrayElement('A', [2.7], 99)
+
+      expect((context.arrays.get('A') as BasicScalarValue[])?.[2]).toEqual(99)
+    })
+  })
+
+  describe('setArrayElementFromExpressionsCst', () => {
+    it('should evaluate index and value expressions then set element', () => {
+      const indexCst1 = { name: 'expr1', children: {} }
+      const indexCst2 = { name: 'expr2', children: {} }
+      const valueCst = { name: 'valueExpr', children: {} }
+
+      evaluator.evaluateExpression
+        .mockReturnValueOnce(1) // first index
+        .mockReturnValueOnce(2) // second index
+        .mockReturnValueOnce(42) // value
+
+      service.setArrayElementFromExpressionsCst('M', [indexCst1, indexCst2] as never, valueCst as never)
+
+      expect((context.arrays.get('M') as BasicScalarValue[][])?.[1]?.[2]).toEqual(42)
+    })
+
+    it('should convert boolean values to numbers', () => {
+      const indexCst = { name: 'expr1', children: {} }
+      const valueCst = { name: 'valueExpr', children: {} }
+
+      evaluator.evaluateExpression
+        .mockReturnValueOnce(0) // index
+        .mockReturnValueOnce(true) // value (boolean)
+
+      service.setArrayElementFromExpressionsCst('A', [indexCst] as never, valueCst as never)
+
+      expect((context.arrays.get('A') as BasicScalarValue[])?.[0]).toEqual(1)
+    })
+  })
+
+  describe('getArrayElement', () => {
+    it('should return 0 for non-existent array', () => {
+      expect(service.getArrayElement('NOEXIST', [0])).toEqual(0)
+    })
+
+    it('should return element value for existing 1D array', () => {
+      service.setArrayElement('A', [0], 10)
+      service.setArrayElement('A', [2], 30)
+
+      expect(service.getArrayElement('A', [0])).toEqual(10)
+      expect(service.getArrayElement('A', [2])).toEqual(30)
+    })
+
+    it('should return 0 for uninitialized element', () => {
+      service.setArrayElement('A', [0], 10)
+
+      expect(service.getArrayElement('A', [5])).toEqual(0)
+    })
+
+    it('should navigate nested arrays (2D)', () => {
+      service.setArrayElement('M', [1, 2], 99)
+
+      expect(service.getArrayElement('M', [1, 2])).toEqual(99)
+    })
+
+    it('should return 0 when navigating through undefined nesting', () => {
+      service.setArrayElement('M', [0], 5) // 1D array
+
+      expect(service.getArrayElement('M', [0, 1])).toEqual(0)
+    })
+
+    it('should floor index values when reading', () => {
+      service.setArrayElement('A', [3], 77)
+
+      expect(service.getArrayElement('A', [3.9])).toEqual(77)
+    })
+  })
+
+  describe('createArray', () => {
+    it('should create 1D numeric array initialized to 0', () => {
+      service.createArray('A', [5])
+
+      const arr = context.arrays.get('A')
+      expect(arr).toEqual([0, 0, 0, 0, 0, 0]) // size = highestIndex + 1 = 6
+    })
+
+    it('should create 1D string array initialized to empty strings', () => {
+      service.createArray('A$', [3])
+
+      const arr = context.arrays.get('A$')
+      expect(arr).toEqual(['', '', '', '']) // size = highestIndex + 1 = 4
+    })
+
+    it('should create 2D numeric array', () => {
+      service.createArray('M', [2, 3])
+
+      const arr = context.arrays.get('M')
+      expect(arr).toEqual([
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ])
+    })
+
+    it('should create 2D string array', () => {
+      service.createArray('M$', [1, 1])
+
+      const arr = context.arrays.get('M$')
+      expect(arr).toEqual([
+        ['', ''],
+        ['', ''],
+      ])
+    })
+
+    it('should overwrite existing array', () => {
+      service.setArrayElement('A', [0], 99)
+      service.createArray('A', [2])
+
+      const arr = context.arrays.get('A')
+      expect(arr).toEqual([0, 0, 0])
+    })
+  })
+
+  describe('hasVariable', () => {
+    it('should return false for non-existent variable', () => {
+      expect(service.hasVariable('X')).toEqual(false)
+    })
+
+    it('should return true for existing variable', () => {
+      service.setVariable('X', 42)
+
+      expect(service.hasVariable('X')).toEqual(true)
+    })
+  })
+
+  describe('hasArray', () => {
+    it('should return false for non-existent array', () => {
+      expect(service.hasArray('A')).toEqual(false)
+    })
+
+    it('should return true for existing array', () => {
+      service.createArray('A', [5])
+
+      expect(service.hasArray('A')).toEqual(true)
+    })
+  })
+
+  describe('getVariableNames', () => {
+    it('should return empty array when no variables', () => {
+      expect(service.getVariableNames()).toEqual([])
+    })
+
+    it('should return all variable names', () => {
+      service.setVariable('X', 1)
+      service.setVariable('Y', 2)
+      service.setVariable('NAME$', 'Test')
+
+      const names = service.getVariableNames().sort()
+      expect(names).toEqual(['NAME$', 'X', 'Y'])
+    })
+  })
+
+  describe('getArrayNames', () => {
+    it('should return empty array when no arrays', () => {
+      expect(service.getArrayNames()).toEqual([])
+    })
+
+    it('should return all array names', () => {
+      service.createArray('A', [5])
+      service.createArray('B', [3])
+
+      const names = service.getArrayNames().sort()
+      expect(names).toEqual(['A', 'B'])
+    })
+  })
+
+  describe('clearVariables', () => {
+    it('should clear all variables', () => {
+      service.setVariable('X', 1)
+      service.setVariable('Y', 2)
+
+      service.clearVariables()
+
+      expect(context.variables.size).toEqual(0)
+      expect(service.hasVariable('X')).toEqual(false)
+    })
+  })
+
+  describe('clearArrays', () => {
+    it('should clear all arrays', () => {
+      service.createArray('A', [5])
+      service.createArray('B', [3])
+
+      service.clearArrays()
+
+      expect(context.arrays.size).toEqual(0)
+      expect(service.hasArray('A')).toEqual(false)
+    })
+  })
+})

--- a/test/core/sprite/SpriteStateManager.test.ts
+++ b/test/core/sprite/SpriteStateManager.test.ts
@@ -1,0 +1,237 @@
+/**
+ * SpriteStateManager unit tests
+ *
+ * Covers sprite slot initialization, enable/disable, define, display, hide,
+ * state retrieval, visibility filtering, clear, and reset.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { SpriteStateManager } from '@/core/sprite/SpriteStateManager'
+import type { DefSpriteDefinition } from '@/core/sprite/types'
+import type { Tile } from '@/shared/data/types'
+
+function createDefinition(overrides: Partial<DefSpriteDefinition> = {}): DefSpriteDefinition {
+  return {
+    spriteNumber: 0,
+    colorCombination: 0,
+    size: 0,
+    priority: 0,
+    invertX: 0,
+    invertY: 0,
+    characterSet: '@',
+    tiles: [[]] as Tile[],
+    ...overrides,
+  }
+}
+
+describe('SpriteStateManager', () => {
+  let manager: SpriteStateManager
+
+  beforeEach(() => {
+    manager = new SpriteStateManager()
+  })
+
+  describe('constructor', () => {
+    it('should initialize 8 sprite slots with defaults', () => {
+      const states = manager.getAllSpriteStates()
+
+      expect(states.length).toEqual(8)
+
+      for (let i = 0; i < 8; i++) {
+        expect(states[i]).toEqual({
+          spriteNumber: i,
+          x: 0,
+          y: 0,
+          visible: false,
+          priority: 0,
+          definition: null,
+        })
+      }
+    })
+  })
+
+  describe('setSpriteEnabled / isSpriteEnabled', () => {
+    it('should default to disabled', () => {
+      expect(manager.isSpriteEnabled()).toEqual(false)
+    })
+
+    it('should enable sprite display', () => {
+      manager.setSpriteEnabled(true)
+
+      expect(manager.isSpriteEnabled()).toEqual(true)
+    })
+
+    it('should disable sprite display', () => {
+      manager.setSpriteEnabled(true)
+      manager.setSpriteEnabled(false)
+
+      expect(manager.isSpriteEnabled()).toEqual(false)
+    })
+  })
+
+  describe('defineSprite', () => {
+    it('should store sprite definition', () => {
+      const def = createDefinition({ spriteNumber: 0, priority: 1 })
+
+      manager.defineSprite(def)
+
+      const state = manager.getSpriteState(0)
+      expect(state?.definition).toEqual(def)
+      expect(state?.priority).toEqual(1)
+    })
+
+    it('should throw for invalid sprite number', () => {
+      const def = createDefinition({ spriteNumber: 99 })
+
+      expect(() => manager.defineSprite(def)).toThrow('Invalid sprite number: 99')
+    })
+
+    it('should not make sprite visible', () => {
+      const def = createDefinition()
+
+      manager.defineSprite(def)
+
+      expect(manager.getSpriteState(0)?.visible).toEqual(false)
+    })
+
+    it('should define multiple sprites', () => {
+      manager.defineSprite(createDefinition({ spriteNumber: 0 }))
+      manager.defineSprite(createDefinition({ spriteNumber: 3, priority: 1 }))
+      manager.defineSprite(createDefinition({ spriteNumber: 7, colorCombination: 2 }))
+
+      expect(manager.getSpriteState(0)?.definition?.spriteNumber).toEqual(0)
+      expect(manager.getSpriteState(3)?.priority).toEqual(1)
+      expect(manager.getSpriteState(7)?.definition?.colorCombination).toEqual(2)
+    })
+  })
+
+  describe('displaySprite', () => {
+    it('should make sprite visible and set position', () => {
+      manager.defineSprite(createDefinition({ spriteNumber: 0 }))
+
+      manager.displaySprite(0, 100, 50)
+
+      const state = manager.getSpriteState(0)
+      expect(state?.visible).toEqual(true)
+      expect(state?.x).toEqual(100)
+      expect(state?.y).toEqual(50)
+    })
+
+    it('should throw if sprite has no definition', () => {
+      expect(() => manager.displaySprite(0, 100, 50)).toThrow('Sprite 0 has no definition')
+    })
+
+    it('should throw for invalid sprite number', () => {
+      expect(() => manager.displaySprite(99, 100, 50)).toThrow('Invalid sprite number: 99')
+    })
+  })
+
+  describe('hideSprite', () => {
+    it('should hide a visible sprite', () => {
+      manager.defineSprite(createDefinition())
+      manager.displaySprite(0, 100, 50)
+
+      manager.hideSprite(0)
+
+      expect(manager.getSpriteState(0)?.visible).toEqual(false)
+    })
+
+    it('should do nothing for non-existent sprite number', () => {
+      expect(() => manager.hideSprite(99)).not.toThrow()
+    })
+  })
+
+  describe('getSpriteState', () => {
+    it('should return state for valid sprite number', () => {
+      const state = manager.getSpriteState(3)
+
+      expect(state).toBeDefined()
+      expect(state?.spriteNumber).toEqual(3)
+    })
+
+    it('should return undefined for invalid sprite number', () => {
+      expect(manager.getSpriteState(-1)).toBeUndefined()
+      expect(manager.getSpriteState(8)).toBeUndefined()
+      expect(manager.getSpriteState(99)).toBeUndefined()
+    })
+  })
+
+  describe('getAllSpriteStates', () => {
+    it('should return all 8 sprite states', () => {
+      const states = manager.getAllSpriteStates()
+
+      expect(states.length).toEqual(8)
+      expect(states.map(s => s.spriteNumber)).toEqual([0, 1, 2, 3, 4, 5, 6, 7])
+    })
+  })
+
+  describe('getVisibleSprites', () => {
+    it('should return empty array when no sprites visible', () => {
+      expect(manager.getVisibleSprites()).toEqual([])
+    })
+
+    it('should return only visible sprites', () => {
+      manager.defineSprite(createDefinition({ spriteNumber: 0 }))
+      manager.defineSprite(createDefinition({ spriteNumber: 2 }))
+      manager.defineSprite(createDefinition({ spriteNumber: 5 }))
+
+      manager.displaySprite(0, 10, 10)
+      manager.displaySprite(5, 50, 50)
+
+      const visible = manager.getVisibleSprites()
+      expect(visible.length).toEqual(2)
+      expect(visible.map(s => s.spriteNumber)).toEqual([0, 5])
+    })
+  })
+
+  describe('clear', () => {
+    it('should reset all sprite slots to defaults', () => {
+      manager.defineSprite(createDefinition({ spriteNumber: 0 }))
+      manager.displaySprite(0, 100, 50)
+      manager.defineSprite(createDefinition({ spriteNumber: 3, priority: 1 }))
+      manager.displaySprite(3, 200, 100)
+
+      manager.clear()
+
+      const states = manager.getAllSpriteStates()
+      expect(states.length).toEqual(8)
+      for (const state of states) {
+        expect(state.x).toEqual(0)
+        expect(state.y).toEqual(0)
+        expect(state.visible).toEqual(false)
+        expect(state.priority).toEqual(0)
+        expect(state.definition).toBeNull()
+      }
+    })
+  })
+
+  describe('resetSprite', () => {
+    it('should reset a specific sprite slot', () => {
+      manager.defineSprite(createDefinition({ spriteNumber: 2, priority: 1 }))
+      manager.displaySprite(2, 100, 50)
+
+      manager.resetSprite(2)
+
+      const state = manager.getSpriteState(2)
+      expect(state).toEqual({
+        spriteNumber: 2,
+        x: 0,
+        y: 0,
+        visible: false,
+        priority: 0,
+        definition: null,
+      })
+    })
+
+    it('should not affect other sprite slots', () => {
+      manager.defineSprite(createDefinition({ spriteNumber: 0 }))
+      manager.displaySprite(0, 10, 10)
+
+      manager.resetSprite(0)
+
+      expect(manager.getSpriteState(1)?.definition).toBeNull()
+      expect(manager.getSpriteState(2)?.definition).toBeNull()
+    })
+  })
+})

--- a/test/core/sprite/characterSetConverter.test.ts
+++ b/test/core/sprite/characterSetConverter.test.ts
@@ -1,0 +1,114 @@
+/**
+ * characterSetConverter unit tests
+ *
+ * Covers convertCharacterSetToTiles (string and number input, 8x8 and 16x16,
+ * Table A vs Table B) and stringToCharCodes.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { convertCharacterSetToTiles, stringToCharCodes } from '@/core/sprite/characterSetConverter'
+
+describe('characterSetConverter', () => {
+  describe('convertCharacterSetToTiles', () => {
+    describe('8x8 sprites (size=0)', () => {
+      it('should accept a single-character string', () => {
+        // '@' is character code 64, a common sprite character
+        const tiles = convertCharacterSetToTiles('@', 0)
+
+        expect(tiles.length).toEqual(1)
+        expect(tiles[0]).toBeDefined()
+      })
+
+      it('should accept a single-element number array', () => {
+        const tiles = convertCharacterSetToTiles([64], 0)
+
+        expect(tiles.length).toEqual(1)
+        expect(tiles[0]).toBeDefined()
+      })
+    })
+
+    describe('16x16 sprites (size=1)', () => {
+      it('should accept a 4-character string', () => {
+        const tiles = convertCharacterSetToTiles('@ABC', 1)
+
+        expect(tiles.length).toEqual(4)
+      })
+
+      it('should accept a 4-element number array', () => {
+        const tiles = convertCharacterSetToTiles([64, 65, 66, 67], 1)
+
+        expect(tiles.length).toEqual(4)
+      })
+    })
+
+    describe('Table A vs Table B', () => {
+      it('should use Table A by default (useTableB=false)', () => {
+        // Should not throw for valid sprite character code
+        expect(() => convertCharacterSetToTiles([64], 0, false)).not.toThrow()
+      })
+
+      it('should use Table B when useTableB=true', () => {
+        // Should not throw for valid background character code
+        expect(() => convertCharacterSetToTiles([64], 0, true)).not.toThrow()
+      })
+    })
+
+    describe('error cases', () => {
+      it('should throw for wrong character count with 8x8 (size=0)', () => {
+        expect(() => convertCharacterSetToTiles('@ABC', 0)).toThrow(
+          'Invalid character set length: expected 1 for 8\u00d78 sprite, got 4'
+        )
+      })
+
+      it('should throw for wrong character count with 16x16 (size=1)', () => {
+        expect(() => convertCharacterSetToTiles('@', 1)).toThrow(
+          'Invalid character set length: expected 4 for 16\u00d716 sprite, got 1'
+        )
+      })
+
+      it('should throw for empty string with 8x8', () => {
+        expect(() => convertCharacterSetToTiles('', 0)).toThrow(
+          'Invalid character set length: expected 1 for 8\u00d78 sprite, got 0'
+        )
+      })
+
+      it('should throw for empty array with 16x16', () => {
+        expect(() => convertCharacterSetToTiles([], 1)).toThrow(
+          'Invalid character set length: expected 4 for 16\u00d716 sprite, got 0'
+        )
+      })
+
+      it('should wrap lookup errors with DEF SPRITE prefix for Table A', () => {
+        // Use an invalid code that the lookup table cannot resolve
+        expect(() => convertCharacterSetToTiles([99999], 0)).toThrow('DEF SPRITE')
+      })
+    })
+  })
+
+  describe('stringToCharCodes', () => {
+    it('should convert plain string to char codes', () => {
+      expect(stringToCharCodes('ABC')).toEqual([65, 66, 67])
+    })
+
+    it('should remove surrounding quotes', () => {
+      expect(stringToCharCodes('"ABC"')).toEqual([65, 66, 67])
+    })
+
+    it('should handle single character', () => {
+      expect(stringToCharCodes('@')).toEqual([64])
+    })
+
+    it('should handle quoted single character', () => {
+      expect(stringToCharCodes('"@"')).toEqual([64])
+    })
+
+    it('should handle empty string', () => {
+      expect(stringToCharCodes('')).toEqual([])
+    })
+
+    it('should handle only quotes (empty quoted string)', () => {
+      expect(stringToCharCodes('""')).toEqual([])
+    })
+  })
+})

--- a/test/core/state/ExecutionContext.test.ts
+++ b/test/core/state/ExecutionContext.test.ts
@@ -1,0 +1,522 @@
+/**
+ * ExecutionContext unit tests
+ *
+ * Covers construction, reset, control flow (loop/gosub stacks), data management,
+ * statement navigation, error handling, line tracking, and iteration limits.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { ERROR_TYPES } from '@/core/constants'
+import type { ExpandedStatement } from '@/core/execution/statement-expander'
+import type { InterpreterConfig } from '@/core/interfaces'
+import { ExecutionContext } from '@/core/state/ExecutionContext'
+
+function createConfig(overrides: Partial<InterpreterConfig> = {}): InterpreterConfig {
+  return {
+    maxIterations: 1000,
+    maxOutputLines: 100,
+    enableDebugMode: false,
+    strictMode: false,
+    ...overrides,
+  }
+}
+
+function createStatement(lineNumber: number, index: number): ExpandedStatement {
+  return {
+    command: { name: 'command', children: {} },
+    lineNumber,
+    statementIndex: index,
+  }
+}
+
+describe('ExecutionContext', () => {
+  describe('constructor', () => {
+    it('should initialize with default state values', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      expect(ctx.isRunning).toEqual(false)
+      expect(ctx.shouldStop).toEqual(false)
+      expect(ctx.currentStatementIndex).toEqual(0)
+      expect(ctx.statements).toEqual([])
+      expect(ctx.labelMap.size).toEqual(0)
+      expect(ctx.iterationCount).toEqual(0)
+      expect(ctx.loopStack).toEqual([])
+      expect(ctx.gosubStack).toEqual([])
+      expect(ctx.dataValues).toEqual([])
+      expect(ctx.dataIndex).toEqual(0)
+      expect(ctx.variables.size).toEqual(0)
+      expect(ctx.arrays.size).toEqual(0)
+      expect(ctx.getErrors()).toEqual([])
+      expect(ctx.getCurrentLineNumber()).toEqual(0)
+    })
+
+    it('should store the provided config', () => {
+      const ctx = new ExecutionContext(createConfig({ maxIterations: 500, enableDebugMode: true }))
+
+      expect(ctx.config.maxIterations).toEqual(500)
+      expect(ctx.config.enableDebugMode).toEqual(true)
+    })
+  })
+
+  describe('reset', () => {
+    it('should clear all state to initial values', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.isRunning = true
+      ctx.shouldStop = true
+      ctx.currentStatementIndex = 5
+      ctx.iterationCount = 100
+      ctx.variables.set('X', { value: 42, type: 'number' })
+      ctx.arrays.set('A', [1, 2, 3])
+      ctx.dataValues = [10, 20, 30]
+      ctx.dataIndex = 2
+      ctx.loopStack.push({ variableName: 'I', startValue: 1, endValue: 10, stepValue: 1, currentValue: 5, statementIndex: 3 })
+      ctx.gosubStack.push(10)
+      ctx.setCurrentLineNumber(50)
+      ctx.addError({ line: 5, message: 'test error', type: ERROR_TYPES.RUNTIME })
+
+      ctx.reset()
+
+      expect(ctx.isRunning).toEqual(false)
+      expect(ctx.shouldStop).toEqual(false)
+      expect(ctx.currentStatementIndex).toEqual(0)
+      expect(ctx.iterationCount).toEqual(0)
+      expect(ctx.variables.size).toEqual(0)
+      expect(ctx.arrays.size).toEqual(0)
+      expect(ctx.dataValues).toEqual([])
+      expect(ctx.dataIndex).toEqual(0)
+      expect(ctx.loopStack).toEqual([])
+      expect(ctx.gosubStack).toEqual([])
+      expect(ctx.statements).toEqual([])
+      expect(ctx.labelMap.size).toEqual(0)
+      expect(ctx.getErrors()).toEqual([])
+      expect(ctx.getCurrentLineNumber()).toEqual(0)
+    })
+
+    it('should reset spriteStateManager if present', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const mockSpriteManager = { clear: vi.fn() }
+      ctx.spriteStateManager = mockSpriteManager as never
+
+      ctx.reset()
+
+      expect(mockSpriteManager.clear).toHaveBeenCalledTimes(1)
+    })
+
+    it('should reset animationManager if present', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const mockAnimManager = { reset: vi.fn() }
+      ctx.animationManager = mockAnimManager as never
+
+      ctx.reset()
+
+      expect(mockAnimManager.reset).toHaveBeenCalledTimes(1)
+    })
+
+    it('should reset soundService if present', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const mockSoundService = { reset: vi.fn() }
+      ctx.soundService = mockSoundService as never
+
+      ctx.reset()
+
+      expect(mockSoundService.reset).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('clearDisplay', () => {
+    it('should clear sprite and animation state only', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.variables.set('X', { value: 42, type: 'number' })
+      ctx.isRunning = true
+      ctx.currentStatementIndex = 5
+
+      const mockSpriteManager = { clear: vi.fn() }
+      const mockAnimManager = { reset: vi.fn() }
+      ctx.spriteStateManager = mockSpriteManager as never
+      ctx.animationManager = mockAnimManager as never
+
+      ctx.clearDisplay()
+
+      // Other state is preserved
+      expect(ctx.variables.size).toEqual(1)
+      expect(ctx.isRunning).toEqual(true)
+      expect(ctx.currentStatementIndex).toEqual(5)
+
+      // Display state is cleared
+      expect(mockSpriteManager.clear).toHaveBeenCalledTimes(1)
+      expect(mockAnimManager.reset).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('addOutput', () => {
+    it('should delegate to deviceAdapter.printOutput', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const mockAdapter = { printOutput: vi.fn() }
+      ctx.deviceAdapter = mockAdapter as never
+
+      ctx.addOutput('Hello')
+
+      expect(mockAdapter.printOutput).toHaveBeenCalledWith('Hello')
+    })
+
+    it('should not throw if no deviceAdapter', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      expect(() => ctx.addOutput('Hello')).not.toThrow()
+    })
+  })
+
+  describe('addError', () => {
+    it('should store the error and delegate to deviceAdapter', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const mockAdapter = { errorOutput: vi.fn() }
+      ctx.deviceAdapter = mockAdapter as never
+
+      const error = { line: 10, message: 'Out of data', type: ERROR_TYPES.RUNTIME }
+      ctx.addError(error)
+
+      expect(ctx.getErrors()).toEqual([error])
+      expect(mockAdapter.errorOutput).toHaveBeenCalledWith('Out of data')
+    })
+
+    it('should halt execution on RUNTIME errors', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.isRunning = true
+
+      ctx.addError({ line: 0, message: 'Runtime error', type: ERROR_TYPES.RUNTIME })
+
+      expect(ctx.shouldStop).toEqual(true)
+      expect(ctx.isRunning).toEqual(false)
+    })
+
+    it('should not halt execution on SYNTAX errors', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.isRunning = true
+
+      ctx.addError({ line: 0, message: 'Syntax error', type: ERROR_TYPES.SYNTAX })
+
+      expect(ctx.shouldStop).toEqual(false)
+      expect(ctx.isRunning).toEqual(true)
+    })
+  })
+
+  describe('addDebugOutput', () => {
+    it('should delegate to deviceAdapter when debug mode is enabled', () => {
+      const ctx = new ExecutionContext(createConfig({ enableDebugMode: true }))
+      const mockAdapter = { debugOutput: vi.fn() }
+      ctx.deviceAdapter = mockAdapter as never
+
+      ctx.addDebugOutput('debug message')
+
+      expect(mockAdapter.debugOutput).toHaveBeenCalledWith('debug message')
+    })
+
+    it('should not call deviceAdapter when debug mode is disabled', () => {
+      const ctx = new ExecutionContext(createConfig({ enableDebugMode: false }))
+      const mockAdapter = { debugOutput: vi.fn() }
+      ctx.deviceAdapter = mockAdapter as never
+
+      ctx.addDebugOutput('debug message')
+
+      expect(mockAdapter.debugOutput).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('shouldContinue', () => {
+    it('should return true when all conditions are met', () => {
+      const ctx = new ExecutionContext(createConfig({ maxIterations: 1000 }))
+      ctx.isRunning = true
+      ctx.statements = [createStatement(10, 0), createStatement(20, 1)]
+
+      expect(ctx.shouldContinue()).toEqual(true)
+    })
+
+    it('should return false when not running', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.isRunning = false
+
+      expect(ctx.shouldContinue()).toEqual(false)
+    })
+
+    it('should return false when shouldStop is true', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.isRunning = true
+      ctx.shouldStop = true
+
+      expect(ctx.shouldContinue()).toEqual(false)
+    })
+
+    it('should return false when max iterations exceeded', () => {
+      const ctx = new ExecutionContext(createConfig({ maxIterations: 10 }))
+      ctx.isRunning = true
+      ctx.iterationCount = 10
+      ctx.statements = [createStatement(10, 0)]
+
+      expect(ctx.shouldContinue()).toEqual(false)
+    })
+
+    it('should return false when all statements executed', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.isRunning = true
+      ctx.statements = [createStatement(10, 0)]
+      ctx.currentStatementIndex = 1
+
+      expect(ctx.shouldContinue()).toEqual(false)
+    })
+
+    it('should not enforce iteration limit when maxIterations is Infinity', () => {
+      const ctx = new ExecutionContext(createConfig({ maxIterations: Infinity }))
+      ctx.isRunning = true
+      ctx.iterationCount = 999999
+      ctx.statements = [createStatement(10, 0)]
+
+      expect(ctx.shouldContinue()).toEqual(true)
+    })
+  })
+
+  describe('incrementIteration', () => {
+    it('should increment iteration count', () => {
+      const ctx = new ExecutionContext(createConfig({ maxIterations: 1000 }))
+
+      ctx.incrementIteration()
+
+      expect(ctx.iterationCount).toEqual(1)
+    })
+
+    it('should add error and stop when max iterations reached', () => {
+      const ctx = new ExecutionContext(createConfig({ maxIterations: 3 }))
+
+      ctx.incrementIteration()
+      ctx.incrementIteration()
+      ctx.incrementIteration()
+
+      expect(ctx.iterationCount).toEqual(3)
+      expect(ctx.shouldStop).toEqual(true)
+      expect(ctx.getErrors().length).toEqual(1)
+      expect(ctx.getErrors()[0]?.message).toEqual('Maximum iterations exceeded')
+    })
+
+    it('should not enforce limit when maxIterations is Infinity', () => {
+      const ctx = new ExecutionContext(createConfig({ maxIterations: Infinity }))
+
+      for (let i = 0; i < 10000; i++) {
+        ctx.incrementIteration()
+      }
+
+      expect(ctx.shouldStop).toEqual(false)
+      expect(ctx.getErrors().length).toEqual(0)
+    })
+  })
+
+  describe('statement navigation', () => {
+    it('getCurrentStatement should return current statement', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const stmt = createStatement(10, 0)
+      ctx.statements = [stmt, createStatement(20, 1)]
+
+      expect(ctx.getCurrentStatement()).toEqual(stmt)
+    })
+
+    it('getCurrentStatement should return undefined when out of bounds', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      expect(ctx.getCurrentStatement()).toBeUndefined()
+    })
+
+    it('nextStatement should advance index', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.statements = [createStatement(10, 0), createStatement(20, 1)]
+
+      ctx.nextStatement()
+
+      expect(ctx.currentStatementIndex).toEqual(1)
+    })
+
+    it('jumpToStatement should set index', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.statements = [createStatement(10, 0), createStatement(20, 1), createStatement(30, 2)]
+
+      ctx.jumpToStatement(2)
+
+      expect(ctx.currentStatementIndex).toEqual(2)
+    })
+  })
+
+  describe('findStatementIndicesByLine', () => {
+    it('should return indices for a mapped line number', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.labelMap.set(10, [0, 1])
+      ctx.labelMap.set(20, [2])
+
+      expect(ctx.findStatementIndicesByLine(10)).toEqual([0, 1])
+      expect(ctx.findStatementIndicesByLine(20)).toEqual([2])
+    })
+
+    it('should return empty array for unmapped line number', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      expect(ctx.findStatementIndicesByLine(999)).toEqual([])
+    })
+  })
+
+  describe('findStatementIndexByLine', () => {
+    it('should return first index for a mapped line number', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.labelMap.set(10, [3, 5, 7])
+
+      expect(ctx.findStatementIndexByLine(10)).toEqual(3)
+    })
+
+    it('should return -1 for unmapped line number', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      expect(ctx.findStatementIndexByLine(999)).toEqual(-1)
+    })
+  })
+
+  describe('line number tracking', () => {
+    it('should get and set current line number', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      ctx.setCurrentLineNumber(42)
+
+      expect(ctx.getCurrentLineNumber()).toEqual(42)
+    })
+  })
+
+  describe('loop stack (control flow)', () => {
+    it('should support push/pop operations on loopStack', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const loopState = {
+        variableName: 'I',
+        startValue: 1,
+        endValue: 10,
+        stepValue: 1,
+        currentValue: 1,
+        statementIndex: 5,
+      }
+
+      ctx.loopStack.push(loopState)
+
+      expect(ctx.loopStack.length).toEqual(1)
+      expect(ctx.loopStack[0]).toEqual(loopState)
+
+      const popped = ctx.loopStack.pop()
+      expect(popped).toEqual(loopState)
+      expect(ctx.loopStack.length).toEqual(0)
+    })
+  })
+
+  describe('gosub stack (control flow)', () => {
+    it('should support push/pop operations on gosubStack', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      ctx.gosubStack.push(10)
+      ctx.gosubStack.push(20)
+
+      expect(ctx.gosubStack).toEqual([10, 20])
+
+      expect(ctx.gosubStack.pop()).toEqual(20)
+      expect(ctx.gosubStack.pop()).toEqual(10)
+      expect(ctx.gosubStack.length).toEqual(0)
+    })
+  })
+
+  describe('data management', () => {
+    it('should store and track data values', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.dataValues = [10, 20, 'hello', 30]
+
+      expect(ctx.dataValues.length).toEqual(4)
+      expect(ctx.dataValues[0]).toEqual(10)
+      expect(ctx.dataValues[2]).toEqual('hello')
+    })
+
+    it('should track data index', () => {
+      const ctx = new ExecutionContext(createConfig())
+      ctx.dataValues = [10, 20, 30]
+
+      ctx.dataIndex = 0
+      expect(ctx.dataIndex).toEqual(0)
+
+      ctx.dataIndex = 2
+      expect(ctx.dataIndex).toEqual(2)
+    })
+  })
+
+  describe('variable management', () => {
+    it('should store variables in the map', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      ctx.variables.set('X', { value: 42, type: 'number' })
+      ctx.variables.set('NAME$', { value: 'Test', type: 'string' })
+
+      expect(ctx.variables.size).toEqual(2)
+      expect(ctx.variables.get('X')).toEqual({ value: 42, type: 'number' })
+      expect(ctx.variables.get('NAME$')).toEqual({ value: 'Test', type: 'string' })
+    })
+  })
+
+  describe('array management', () => {
+    it('should store arrays in the map', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      ctx.arrays.set('A', [1, 2, 3])
+
+      expect(ctx.arrays.size).toEqual(1)
+      expect(ctx.arrays.get('A')).toEqual([1, 2, 3])
+    })
+  })
+
+  describe('getStickState', () => {
+    it('should delegate to deviceAdapter', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const mockAdapter = { getStickState: vi.fn().mockReturnValue(5) }
+      ctx.deviceAdapter = mockAdapter as never
+
+      expect(ctx.getStickState(0)).toEqual(5)
+      expect(mockAdapter.getStickState).toHaveBeenCalledWith(0)
+    })
+
+    it('should return 0 when no deviceAdapter', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      expect(ctx.getStickState(0)).toEqual(0)
+    })
+  })
+
+  describe('consumeStrigState', () => {
+    it('should delegate to deviceAdapter and return consumed value', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const mockAdapter = { consumeStrigState: vi.fn().mockReturnValue(1) }
+      ctx.deviceAdapter = mockAdapter as never
+
+      expect(ctx.consumeStrigState(0)).toEqual(1)
+      expect(mockAdapter.consumeStrigState).toHaveBeenCalledWith(0)
+    })
+
+    it('should return 0 when no deviceAdapter', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      expect(ctx.consumeStrigState(0)).toEqual(0)
+    })
+  })
+
+  describe('getSpritePosition', () => {
+    it('should delegate to deviceAdapter', () => {
+      const ctx = new ExecutionContext(createConfig())
+      const mockAdapter = { getSpritePosition: vi.fn().mockReturnValue({ x: 100, y: 50 }) }
+      ctx.deviceAdapter = mockAdapter as never
+
+      expect(ctx.getSpritePosition(0)).toEqual({ x: 100, y: 50 })
+      expect(mockAdapter.getSpritePosition).toHaveBeenCalledWith(0)
+    })
+
+    it('should return null when no deviceAdapter', () => {
+      const ctx = new ExecutionContext(createConfig())
+
+      expect(ctx.getSpritePosition(0)).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #158

## Changes
- **8 new test files**, 251 tests covering all previously untested core modules:
  - `ExecutionContext.test.ts` (44 tests): execution state, variable management, flow control (loop/gosub stacks), statement navigation, error handling
  - `VariableService.test.ts` (37 tests): variable get/set, type handling (string/number/boolean), array operations, DIM semantics
  - `DataService.test.ts` (24 tests): DATA constant evaluation, READ pointer advancement, RESTORE, OD ERROR
  - `SpriteStateManager.test.ts` (21 tests): 8-slot initialization, enable/disable, DEF SPRITE, SPRITE display
  - `characterSetConverter.test.ts` (17 tests): 8x8/16x16 conversion, Table A/B selection
  - `bufferScreenOperations.test.ts` (31 tests): screen buffer read/write, cursor, sequence, bulk ops
  - `bufferSpriteOperations.test.ts` (33 tests): sprite state write/read, all property readers
  - `sharedDisplayBufferAccessor.test.ts` (44 tests): unified buffer accessor, scalar masking, sync commands

## Test plan
- [x] All 251 new tests pass
- [x] TypeScript type-check passes (0 errors)
- [x] ESLint passes (0 errors)
- [ ] CI passes