### PR TITLE
test: resolve #153 - add unit tests for untested parser modules

### DIFF
--- a/test/core/parser/cst-helpers.test.ts
+++ b/test/core/parser/cst-helpers.test.ts
@@ -1,0 +1,296 @@
+/**
+ * CST Helper Functions Tests
+ *
+ * Unit tests for cst-helpers.ts utility functions.
+ * These are pure functions that operate on Chevrotain CST nodes and tokens.
+ */
+
+import type { CstElement, CstNode, IToken } from 'chevrotain'
+import { describe, expect, it } from 'vitest'
+
+import {
+  getAdditiveFromExpression,
+  getCstNodes,
+  getFirstCstNode,
+  getFirstToken,
+  getLineNumberFromStatement,
+  getSourceTextFromCst,
+  getTokens,
+  isCstNode,
+  isCstToken,
+} from '@/core/parser/cst-helpers'
+
+// Helper to create a mock IToken
+function makeToken(image: string, tokenType = { name: 'TestToken' }): IToken {
+  return {
+    image,
+    tokenType,
+    tokenTypeIdx: 0,
+    startOffset: 0,
+    startLine: 1,
+    startColumn: 1,
+    endOffset: image.length - 1,
+    endLine: 1,
+    endColumn: image.length,
+  }
+}
+
+// Helper to create a mock CstNode
+function makeNode(name: string, children: Record<string, CstElement[]>): CstNode {
+  return { name, children }
+}
+
+describe('isCstNode', () => {
+  it('should return true for objects with children property', () => {
+    const node = makeNode('test', {})
+    expect(isCstNode(node)).toBe(true)
+  })
+
+  it('should return false for tokens (objects with image property)', () => {
+    const token = makeToken('HELLO')
+    expect(isCstNode(token)).toBe(false)
+  })
+
+  it('should return false for null', () => {
+    // isCstNode is a type guard; passing non-CstElement should be safe at runtime
+    // but TypeScript strict mode requires valid input
+    expect(isCstNode({} as CstElement)).toBe(false)
+  })
+
+  it('should return false for undefined', () => {
+    // Objects without 'children' property are not CST nodes
+    expect(isCstNode({ image: '' } as CstElement)).toBe(false)
+  })
+})
+
+describe('isCstToken', () => {
+  it('should return true for tokens (objects with image property)', () => {
+    const token = makeToken('HELLO')
+    expect(isCstToken(token)).toBe(true)
+  })
+
+  it('should return false for CST nodes (objects with children property)', () => {
+    const node = makeNode('test', {})
+    expect(isCstToken(node)).toBe(false)
+  })
+
+  it('should return false for null', () => {
+    expect(isCstToken({} as CstElement)).toBe(false)
+  })
+
+  it('should return false for undefined', () => {
+    expect(isCstToken({ name: '' } as CstElement)).toBe(false)
+  })
+})
+
+describe('getFirstCstNode', () => {
+  it('should return the first CST node from a mixed array', () => {
+    const token = makeToken('42')
+    const node = makeNode('expression', {})
+    const children: CstElement[] = [token, node]
+    expect(getFirstCstNode(children)).toEqual(node)
+  })
+
+  it('should return the first node when array starts with a node', () => {
+    const node = makeNode('statement', {})
+    const token = makeToken('10')
+    const children: CstElement[] = [node, token]
+    expect(getFirstCstNode(children)).toEqual(node)
+  })
+
+  it('should return undefined when no nodes are in the array', () => {
+    const token = makeToken('42')
+    const children: CstElement[] = [token]
+    expect(getFirstCstNode(children)).toBeUndefined()
+  })
+
+  it('should return undefined for undefined input', () => {
+    expect(getFirstCstNode(undefined)).toBeUndefined()
+  })
+
+  it('should return undefined for empty array', () => {
+    expect(getFirstCstNode([])).toBeUndefined()
+  })
+})
+
+describe('getCstNodes', () => {
+  it('should return only CST nodes from a mixed array', () => {
+    const token = makeToken('42')
+    const node1 = makeNode('expr1', {})
+    const node2 = makeNode('expr2', {})
+    const children: CstElement[] = [token, node1, node2, token]
+    expect(getCstNodes(children)).toEqual([node1, node2])
+  })
+
+  it('should return empty array when no nodes are present', () => {
+    const token = makeToken('42')
+    const children: CstElement[] = [token, token]
+    expect(getCstNodes(children)).toEqual([])
+  })
+
+  it('should return empty array for undefined input', () => {
+    expect(getCstNodes(undefined)).toEqual([])
+  })
+})
+
+describe('getFirstToken', () => {
+  it('should return the first token from a mixed array', () => {
+    const token = makeToken('10')
+    const node = makeNode('statement', {})
+    const children: CstElement[] = [node, token]
+    expect(getFirstToken(children)).toEqual(token)
+  })
+
+  it('should return undefined when no tokens are in the array', () => {
+    const node = makeNode('statement', {})
+    const children: CstElement[] = [node]
+    expect(getFirstToken(children)).toBeUndefined()
+  })
+
+  it('should return undefined for undefined input', () => {
+    expect(getFirstToken(undefined)).toBeUndefined()
+  })
+
+  it('should return undefined for empty array', () => {
+    expect(getFirstToken([])).toBeUndefined()
+  })
+})
+
+describe('getTokens', () => {
+  it('should return only tokens from a mixed array', () => {
+    const token1 = makeToken('10')
+    const node = makeNode('statement', {})
+    const token2 = makeToken('GOTO')
+    const children: CstElement[] = [token1, node, token2]
+    expect(getTokens(children)).toEqual([token1, token2])
+  })
+
+  it('should return empty array when no tokens are present', () => {
+    const node = makeNode('statement', {})
+    const children: CstElement[] = [node]
+    expect(getTokens(children)).toEqual([])
+  })
+
+  it('should return empty array for undefined input', () => {
+    expect(getTokens(undefined)).toEqual([])
+  })
+})
+
+describe('getLineNumberFromStatement', () => {
+  it('should extract line number from statement CST', () => {
+    const node = makeNode('statement', {
+      NumberLiteral: [makeToken('100')],
+    })
+    expect(getLineNumberFromStatement(node)).toBe(100)
+  })
+
+  it('should return null when no NumberLiteral is present', () => {
+    const node = makeNode('statement', {})
+    expect(getLineNumberFromStatement(node)).toBeNull()
+  })
+
+  it('should return null when NumberLiteral is empty array', () => {
+    const node = makeNode('statement', {
+      NumberLiteral: [],
+    })
+    expect(getLineNumberFromStatement(node)).toBeNull()
+  })
+
+  it('should parse multi-digit line numbers correctly', () => {
+    const node = makeNode('statement', {
+      NumberLiteral: [makeToken('12345')],
+    })
+    expect(getLineNumberFromStatement(node)).toBe(12345)
+  })
+
+  it('should parse zero line number', () => {
+    const node = makeNode('statement', {
+      NumberLiteral: [makeToken('0')],
+    })
+    expect(getLineNumberFromStatement(node)).toBe(0)
+  })
+})
+
+describe('getAdditiveFromExpression', () => {
+  it('should navigate through the expression precedence chain to find additive', () => {
+    // Build a minimal expression CST chain: expression -> logicalExpression -> ... -> additive
+    const additive = makeNode('additive', {
+      NumberLiteral: [makeToken('42')],
+    })
+    const bitwiseNot = makeNode('bitwiseNotExpression', { additive: [additive] })
+    const bitwiseAnd = makeNode('bitwiseAndExpression', { bitwiseNotExpression: [bitwiseNot] })
+    const bitwiseOr = makeNode('bitwiseOrExpression', { bitwiseAndExpression: [bitwiseAnd] })
+    const bitwiseXor = makeNode('bitwiseXorExpression', { bitwiseOrExpression: [bitwiseOr] })
+    const comparison = makeNode('comparisonExpression', { bitwiseXorExpression: [bitwiseXor] })
+    const logicalNot = makeNode('logicalNotExpression', { comparisonExpression: [comparison] })
+    const logicalAnd = makeNode('logicalAndExpression', { logicalNotExpression: [logicalNot] })
+    const logicalOr = makeNode('logicalOrExpression', { logicalAndExpression: [logicalAnd] })
+    const logical = makeNode('logicalExpression', { logicalOrExpression: [logicalOr] })
+    const expression = makeNode('expression', { logicalExpression: [logical] })
+
+    expect(getAdditiveFromExpression(expression)).toEqual(additive)
+  })
+
+  it('should return undefined when chain is broken at logicalExpression', () => {
+    const expression = makeNode('expression', {
+      logicalExpression: [],
+    })
+    expect(getAdditiveFromExpression(expression)).toBeUndefined()
+  })
+
+  it('should return undefined when chain is broken at comparisonExpression', () => {
+    const logicalNot = makeNode('logicalNotExpression', { comparisonExpression: [] })
+    const logicalAnd = makeNode('logicalAndExpression', { logicalNotExpression: [logicalNot] })
+    const logicalOr = makeNode('logicalOrExpression', { logicalAndExpression: [logicalAnd] })
+    const logical = makeNode('logicalExpression', { logicalOrExpression: [logicalOr] })
+    const expression = makeNode('expression', { logicalExpression: [logical] })
+
+    expect(getAdditiveFromExpression(expression)).toBeUndefined()
+  })
+
+  it('should return undefined for empty expression node', () => {
+    const expression = makeNode('expression', {})
+    expect(getAdditiveFromExpression(expression)).toBeUndefined()
+  })
+})
+
+describe('getSourceTextFromCst', () => {
+  it('should reconstruct source text from tokens', () => {
+    const node = makeNode('printStatement', {
+      Print: [makeToken('PRINT')],
+      expression: [makeNode('expression', { NumberLiteral: [makeToken('42')] })],
+    })
+    expect(getSourceTextFromCst(node)).toBe('PRINT 42')
+  })
+
+  it('should return empty string for node with no children', () => {
+    const node = makeNode('empty', {})
+    expect(getSourceTextFromCst(node)).toBe('')
+  })
+
+  it('should handle deeply nested nodes', () => {
+    const inner = makeNode('primary', { NumberLiteral: [makeToken('5')] })
+    const additive = makeNode('additive', { primary: [inner], Plus: [makeToken('+')], primary2: [makeNode('primary', { NumberLiteral: [makeToken('3')] })] })
+    const expr = makeNode('expression', { additive: [additive] })
+    expect(getSourceTextFromCst(expr)).toBe('5 + 3')
+  })
+
+  it('should collapse multiple spaces into one', () => {
+    const node = makeNode('statement', {
+      NumberLiteral: [makeToken('10')],
+      commandList: [makeNode('commandList', {
+        command: [makeNode('command', {
+          singleCommand: [makeNode('singleCommand', {
+            printStatement: [makeNode('printStatement', {
+              Print: [makeToken('PRINT')],
+              printList: [makeNode('printList', {})],
+            })],
+          })],
+        })],
+      })],
+    })
+    // Should produce text without excessive whitespace
+    const text = getSourceTextFromCst(node)
+    expect(text).not.toContain('  ')
+  })
+})

--- a/test/core/parser/parse-with-chevrotain.test.ts
+++ b/test/core/parser/parse-with-chevrotain.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Parse with Chevrotain Module Tests
+ *
+ * Tests for parse-with-chevrotain.ts: the Chevrotain integration layer
+ * including line-by-line parsing, comment handling, error handling,
+ * and REPL-only command validation.
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import { parseWithChevrotain } from '@/core/parser/FBasicChevrotainParser'
+
+describe('parse-with-chevrotain: Basic Parsing', () => {
+  test('should parse single line program', () => {
+    const result = parseWithChevrotain('10 PRINT "HELLO"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    expect(result.cst?.name).toEqual('program')
+  })
+
+  test('should parse multi-line program', () => {
+    const code = `10 PRINT "HELLO"
+20 PRINT "WORLD"
+30 END`
+    const result = parseWithChevrotain(code)
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(3)
+  })
+
+  test('should parse program with empty lines', () => {
+    const code = `10 PRINT "A"
+
+20 PRINT "B"`
+    const result = parseWithChevrotain(code)
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(2)
+  })
+
+  test('should trim whitespace from lines', () => {
+    const code = '  10  PRINT  "HELLO"  '
+    const result = parseWithChevrotain(code)
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parse-with-chevrotain: REM Comment Handling', () => {
+  test('should handle REM comment lines', () => {
+    const result = parseWithChevrotain('10 REM this is a comment')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(1)
+  })
+
+  test('should register REM line number in CST', () => {
+    const result = parseWithChevrotain('10 REM comment')
+    expect(result.success).toBe(true)
+    const statements = result.cst?.children.statement
+    expect(statements).toBeDefined()
+    expect(Array.isArray(statements) && statements.length > 0).toBe(true)
+    const stmt = statements![0] as { children: Record<string, unknown[]> }
+    expect(stmt.children.NumberLiteral).toBeDefined()
+    const numberTokens = stmt.children.NumberLiteral as Array<{ image: string }>
+    expect(numberTokens.length).toBeGreaterThan(0)
+    expect(numberTokens[0]!.image).toEqual('10')
+  })
+
+  test('should handle apostrophe comment lines', () => {
+    const result = parseWithChevrotain("10 ' this is a comment")
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  test('should handle REM case-insensitively', () => {
+    const result = parseWithChevrotain('10 rem comment')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  test('should handle mixed REM and code lines', () => {
+    const code = `10 REM Start of program
+20 PRINT "HELLO"
+30 REM End of program`
+    const result = parseWithChevrotain(code)
+    expect(result.success).toBe(true)
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(3)
+  })
+})
+
+describe('parse-with-chevrotain: Error Handling', () => {
+  test('should report syntax errors', () => {
+    const result = parseWithChevrotain('10 INVALIDSYNTAX')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+    expect(result.errors!.length).toBeGreaterThan(0)
+  })
+
+  test('should include line number in error', () => {
+    const code = `10 PRINT "OK"
+20 INVALID
+30 PRINT "END"`
+    const result = parseWithChevrotain(code)
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+    expect(result.errors?.[0]?.line).toEqual(2)
+  })
+
+  test('should include column in error', () => {
+    const result = parseWithChevrotain('10 PRINT "OK" INVALID')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+    expect(result.errors?.[0]?.column).toBeDefined()
+  })
+
+  test('should report multiple errors across lines', () => {
+    const code = `10 BAD1
+20 BAD2
+30 BAD3`
+    const result = parseWithChevrotain(code)
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+    expect(result.errors!.length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('parse-with-chevrotain: REPL-Only Command Validation', () => {
+  test('should reject LIST command', () => {
+    const result = parseWithChevrotain('10 LIST')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined() // CST exists but success is false
+    expect(result.errors?.[0]?.message).toEqual('LIST: Not applicable for IDE version')
+  })
+
+  test('should reject RUN command', () => {
+    const result = parseWithChevrotain('10 RUN')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('RUN: Not applicable for IDE version - use the Run button instead')
+  })
+
+  test('should reject NEW command', () => {
+    const result = parseWithChevrotain('10 NEW')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('NEW: Not applicable for IDE version')
+  })
+
+  test('should reject SAVE command', () => {
+    const result = parseWithChevrotain('10 SAVE')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('SAVE: Not applicable for IDE version - use Export instead')
+  })
+
+  test('should reject LOAD command', () => {
+    const result = parseWithChevrotain('10 LOAD')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('LOAD: Not applicable for IDE version - use Import instead')
+  })
+
+  test('should reject POKE statement', () => {
+    const result = parseWithChevrotain('10 POKE &H7000, 255')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('POKE: Not applicable for IDE version')
+  })
+
+  test('should reject PEEK function', () => {
+    const result = parseWithChevrotain('10 A = PEEK(&H7000)')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('PEEK: Not applicable for IDE version')
+  })
+
+  test('should reject FRE function', () => {
+    const result = parseWithChevrotain('10 A = FRE(0)')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('FRE: Not applicable for IDE version')
+  })
+
+  test('should reject STOP statement', () => {
+    const result = parseWithChevrotain('10 STOP')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('STOP: Not applicable for IDE version')
+  })
+
+  test('should not produce duplicate errors for same REPL command', () => {
+    const result = parseWithChevrotain('10 LIST: LIST')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+    // Should only report the LIST error once (deduplication)
+    const listErrors = result.errors!.filter(e => e.message.includes('LIST'))
+    expect(listErrors.length).toEqual(1)
+  })
+
+  test('should allow INKEY$ function (fully implemented)', () => {
+    const result = parseWithChevrotain('10 A$ = INKEY$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    expect(result.errors).toBeUndefined()
+  })
+})
+
+describe('parse-with-chevrotain: Program CST Structure', () => {
+  test('should produce program CST with statement children', () => {
+    const result = parseWithChevrotain('10 PRINT "A"\n20 PRINT "B"')
+    expect(result.success).toBe(true)
+    expect(result.cst?.name).toEqual('program')
+    expect(result.cst?.children.statement).toBeDefined()
+    expect(Array.isArray(result.cst?.children.statement)).toBe(true)
+  })
+
+  test('should handle CRLF line endings', () => {
+    const result = parseWithChevrotain('10 PRINT "A"\r\n20 PRINT "B"')
+    expect(result.success).toBe(true)
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(2)
+  })
+
+  test('should handle LF line endings', () => {
+    const result = parseWithChevrotain('10 PRINT "A"\n20 PRINT "B"')
+    expect(result.success).toBe(true)
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(2)
+  })
+})

--- a/test/core/parser/parser-dispatcher.test.ts
+++ b/test/core/parser/parser-dispatcher.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Parser Dispatcher Module Tests
+ *
+ * Tests for parser-dispatcher.ts: the command dispatch routing logic
+ * that routes statements to the correct sub-parser based on the first token.
+ *
+ * These tests validate that the dispatcher correctly routes each keyword
+ * to the appropriate statement parser, including edge cases around
+ * ambiguous keywords (e.g., MOVE as statement vs function, DEF MOVE vs DEF SPRITE).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { FBasicParser } from '@/core/parser/FBasicParser'
+
+describe('parser-dispatcher: Keyword Routing', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  const routableKeywords = [
+    { code: '10 GOTO 100', desc: 'GOTO routes to gotoStatement' },
+    { code: '10 GOSUB 1000', desc: 'GOSUB routes to gosubStatement' },
+    { code: '10 RETURN', desc: 'RETURN routes to returnStatement' },
+    { code: '10 PRINT "X"', desc: 'PRINT routes to printStatement' },
+    { code: '10 FOR I = 1 TO 10', desc: 'FOR routes to forStatement' },
+    { code: '10 NEXT', desc: 'NEXT routes to nextStatement' },
+    { code: '10 END', desc: 'END routes to endStatement' },
+    { code: '10 PAUSE 60', desc: 'PAUSE routes to pauseStatement' },
+    { code: '10 PLAY "C"', desc: 'PLAY routes to playStatement' },
+    { code: '10 BEEP', desc: 'BEEP routes to beepStatement' },
+    { code: '10 DIM A(10)', desc: 'DIM routes to dimStatement' },
+    { code: '10 DATA 1, 2, 3', desc: 'DATA routes to dataStatement' },
+    { code: '10 READ A', desc: 'READ routes to readStatement' },
+    { code: '10 RESTORE', desc: 'RESTORE routes to restoreStatement' },
+    { code: '10 INPUT A', desc: 'INPUT routes to inputStatement' },
+    { code: '10 LINPUT A$', desc: 'LINPUT routes to linputStatement' },
+    { code: '10 CLS', desc: 'CLS routes to clsStatement' },
+    { code: '10 SWAP A, B', desc: 'SWAP routes to swapStatement' },
+    { code: '10 CLEAR', desc: 'CLEAR routes to clearStatement' },
+    { code: '10 LOCATE 0, 0', desc: 'LOCATE routes to locateStatement' },
+    { code: '10 COLOR 0, 0, 0', desc: 'COLOR routes to colorStatement' },
+    { code: '10 CGSET', desc: 'CGSET routes to cgsetStatement' },
+    { code: '10 CGEN 0', desc: 'CGEN routes to cgenStatement' },
+    { code: '10 VIEW', desc: 'VIEW routes to viewStatement' },
+    { code: '10 SPRITE 0, 100, 100', desc: 'SPRITE routes to spriteStatement' },
+    { code: '10 MOVE 0', desc: 'MOVE routes to moveStatement' },
+    { code: '10 CUT 0', desc: 'CUT routes to cutStatement' },
+    { code: '10 ERA 0', desc: 'ERA routes to eraStatement' },
+    { code: '10 POSITION 0, 100, 100', desc: 'POSITION routes to positionStatement' },
+  ]
+
+  it.each(routableKeywords)('should correctly route $desc', async ({ code }) => {
+    const result = await parser.parse(code)
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-dispatcher: Ambiguous Keyword Routing', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should route DEF MOVE to defMoveStatement (not defSpriteStatement)', async () => {
+    const result = await parser.parse('10 DEF MOVE(0) = SPRITE(0, 0, 0, 0, 0, 0)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    const stmt = result.cst?.children.statement
+    expect(Array.isArray(stmt) ? stmt.length : 0).toEqual(1)
+  })
+
+  it('should route DEF SPRITE to defSpriteStatement', async () => {
+    const result = await parser.parse('10 DEF SPRITE 0, (0, 0, 0, 0, 0) = "A"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route MOVE(n) function call (with parentheses) to expression', async () => {
+    const result = await parser.parse('10 LET X = MOVE(0)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route MOVE n statement (without parentheses) to moveStatement', async () => {
+    const result = await parser.parse('10 MOVE 0')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route SPRITE ON to spriteOnOffStatement', async () => {
+    const result = await parser.parse('10 SPRITE ON')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route SPRITE OFF to spriteOnOffStatement', async () => {
+    const result = await parser.parse('10 SPRITE OFF')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route IF to ifThenStatement (not letStatement)', async () => {
+    const result = await parser.parse('10 IF X = 1 THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route ON to onStatement (not letStatement)', async () => {
+    const result = await parser.parse('10 ON X GOTO 100, 200')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-dispatcher: LET as Fallback', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should route implicit assignment (no LET keyword) to letStatement', async () => {
+    const result = await parser.parse('10 X = 5')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route explicit LET to letStatement', async () => {
+    const result = await parser.parse('10 LET X = 5')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route string variable assignment to letStatement', async () => {
+    const result = await parser.parse('10 A$ = "HELLO"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-dispatcher: PALET Keyword Variants', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should route PALETB to paletStatement', async () => {
+    const result = await parser.parse('10 PALETB 0, 1, 2, 3, 4')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route PALETS to paletStatement', async () => {
+    const result = await parser.parse('10 PALETS 0, 1, 2, 3, 4')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route PALET B to paletStatement', async () => {
+    const result = await parser.parse('10 PALET B 0, 1, 2, 3, 4')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should route PALET S to paletStatement', async () => {
+    const result = await parser.parse('10 PALET S 0, 1, 2, 3, 4')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-dispatcher: Command List Structure', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should produce statement with NumberLiteral and commandList', async () => {
+    const result = await parser.parse('10 PRINT "HELLO"')
+    expect(result.success).toBe(true)
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(1)
+    const stmt = statements![0] as { name: string; children: Record<string, unknown[]> }
+    expect(stmt.name).toEqual('statement')
+    expect(stmt.children.NumberLiteral).toBeDefined()
+    expect(stmt.children.commandList).toBeDefined()
+  })
+
+  it('should handle colon-separated commands in commandList', async () => {
+    const result = await parser.parse('10 CLS: PRINT "A": PRINT "B"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})

--- a/test/core/parser/parser-expressions.test.ts
+++ b/test/core/parser/parser-expressions.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Expression Parser Module Tests
+ *
+ * Tests for parser-expressions.ts: expression parsing including
+ * arithmetic, string, comparison, logical, bitwise operators,
+ * function calls, array access, and operator precedence.
+ *
+ * These tests validate parsing through the FBasicParser public API,
+ * targeting specific expression patterns registered by the expression module.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { FBasicParser } from '@/core/parser/FBasicParser'
+
+describe('parser-expressions: Primary Expressions', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse number literal', async () => {
+    const result = await parser.parse('10 LET X = 42')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse string literal', async () => {
+    const result = await parser.parse('10 LET A$ = "HELLO"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse hex literal', async () => {
+    const result = await parser.parse('10 LET X = &HFF')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse identifier variable', async () => {
+    const result = await parser.parse('10 LET X = Y')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse parenthesized expression', async () => {
+    const result = await parser.parse('10 LET X = (A + B)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: Unary Operators', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse unary minus', async () => {
+    const result = await parser.parse('10 LET X = -5')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse unary plus', async () => {
+    const result = await parser.parse('10 LET X = +5')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should not parse double negative (--5 is not valid F-BASIC)', async () => {
+    const result = await parser.parse('10 LET X = --5')
+    // F-BASIC lexer treats --5 as subtraction of negative 5,
+    // which requires a left operand and fails at the statement level
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+
+  it('should parse unary minus on variable', async () => {
+    const result = await parser.parse('10 LET X = -Y')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: Arithmetic Operators', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse addition', async () => {
+    const result = await parser.parse('10 LET X = A + B')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse subtraction', async () => {
+    const result = await parser.parse('10 LET X = A - B')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse multiplication', async () => {
+    const result = await parser.parse('10 LET X = A * B')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse division', async () => {
+    const result = await parser.parse('10 LET X = A / B')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse MOD operator', async () => {
+    const result = await parser.parse('10 LET X = A MOD B')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse complex arithmetic expression', async () => {
+    const result = await parser.parse('10 LET X = A + B * C - D / E')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: Operator Precedence', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse multiplication before addition (left operand)', async () => {
+    const result = await parser.parse('10 LET X = A * B + C')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse multiplication before addition (right operand)', async () => {
+    const result = await parser.parse('10 LET X = A + B * C')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse MOD after multiplication', async () => {
+    const result = await parser.parse('10 LET X = A * B MOD C')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse addition after MOD', async () => {
+    const result = await parser.parse('10 LET X = A MOD B + C')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should respect parentheses for precedence override', async () => {
+    const result = await parser.parse('10 LET X = (A + B) * C')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse deeply nested parenthesized expression', async () => {
+    const result = await parser.parse('10 LET X = ((A + B) * (C - D))')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: Comparison Operators', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse equal comparison', async () => {
+    const result = await parser.parse('10 IF X = Y THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse not-equal comparison', async () => {
+    const result = await parser.parse('10 IF X <> Y THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse less-than comparison', async () => {
+    const result = await parser.parse('10 IF X < Y THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse greater-than comparison', async () => {
+    const result = await parser.parse('10 IF X > Y THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse less-than-or-equal comparison', async () => {
+    const result = await parser.parse('10 IF X <= Y THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse greater-than-or-equal comparison', async () => {
+    const result = await parser.parse('10 IF X >= Y THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse comparison with expressions', async () => {
+    const result = await parser.parse('10 IF A + B > C * D THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: Logical Operators', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse AND operator', async () => {
+    const result = await parser.parse('10 IF X > 0 AND Y > 0 THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse OR operator', async () => {
+    const result = await parser.parse('10 IF X = 0 OR Y = 0 THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse NOT operator', async () => {
+    const result = await parser.parse('10 IF NOT X = 0 THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse XOR operator', async () => {
+    const result = await parser.parse('10 LET X = A XOR B')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse NOT AND OR precedence chain', async () => {
+    const result = await parser.parse('10 IF NOT A = 0 AND B = 1 OR C = 2 THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse XOR with OR and AND', async () => {
+    const result = await parser.parse('10 LET X = A OR B XOR C AND D')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: Bitwise Operators', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse bitwise AND', async () => {
+    const result = await parser.parse('10 LET X = A AND 1')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse bitwise OR', async () => {
+    const result = await parser.parse('10 LET X = A OR 1')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse bitwise NOT', async () => {
+    const result = await parser.parse('10 LET X = NOT A')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse bitwise XOR', async () => {
+    const result = await parser.parse('10 LET X = A XOR B')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse chained bitwise operations', async () => {
+    const result = await parser.parse('10 LET X = (A AND &HF0) OR (B AND &H0F)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: Function Calls', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse ABS function', async () => {
+    const result = await parser.parse('10 LET X = ABS(-5)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse SGN function', async () => {
+    const result = await parser.parse('10 LET X = SGN(N)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse RND function', async () => {
+    const result = await parser.parse('10 LET X = RND(1)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse LEN function', async () => {
+    const result = await parser.parse('10 LET X = LEN(A$)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse LEFT$ function', async () => {
+    const result = await parser.parse('10 LET B$ = LEFT$(A$, 3)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse RIGHT$ function', async () => {
+    const result = await parser.parse('10 LET B$ = RIGHT$(A$, 2)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse MID$ function', async () => {
+    const result = await parser.parse('10 LET B$ = MID$(A$, 2, 3)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse STR$ function', async () => {
+    const result = await parser.parse('10 LET A$ = STR$(42)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse VAL function', async () => {
+    const result = await parser.parse('10 LET X = VAL("42")')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse CHR$ function', async () => {
+    const result = await parser.parse('10 LET A$ = CHR$(65)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse ASC function', async () => {
+    const result = await parser.parse('10 LET X = ASC("A")')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse HEX$ function', async () => {
+    const result = await parser.parse('10 LET A$ = HEX$(255)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse INKEY$ without parentheses', async () => {
+    const result = await parser.parse('10 A$ = INKEY$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse INKEY$ with parentheses', async () => {
+    const result = await parser.parse('10 A$ = INKEY$(0)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse STICK function', async () => {
+    const result = await parser.parse('10 LET X = STICK(0)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse STRIG function', async () => {
+    const result = await parser.parse('10 LET X = STRIG(0)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse nested function calls', async () => {
+    const result = await parser.parse('10 LET X = LEN(STR$(ABS(N)))')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse function in expression', async () => {
+    const result = await parser.parse('10 LET X = ABS(A) + ABS(B)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: Array Access', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse single-dimension array access', async () => {
+    const result = await parser.parse('10 LET X = A(5)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse two-dimension array access', async () => {
+    const result = await parser.parse('10 LET X = A(2, 3)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse string array access', async () => {
+    const result = await parser.parse('10 LET B$ = A$(I)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse array access with expression index', async () => {
+    const result = await parser.parse('10 LET X = A(I + 1)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: CSRLIN and POS', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse CSRLIN without parentheses', async () => {
+    const result = await parser.parse('10 LET Y = CSRLIN')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse POS with parentheses', async () => {
+    const result = await parser.parse('10 LET X = POS(0)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-expressions: String Concatenation', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse string concatenation with +', async () => {
+    const result = await parser.parse('10 LET C$ = A$ + B$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse concatenation of function results', async () => {
+    const result = await parser.parse('10 LET C$ = LEFT$(A$, 3) + RIGHT$(B$, 2)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})

--- a/test/core/parser/parser-statements-core.test.ts
+++ b/test/core/parser/parser-statements-core.test.ts
@@ -1,0 +1,565 @@
+/**
+ * Core Statement Parser Module Tests
+ *
+ * Tests for parser-statements-core.ts: core F-BASIC statements
+ * including GOTO, GOSUB, RETURN, FOR/NEXT, IF/THEN, ON, INPUT, LINPUT,
+ * SWAP, CLEAR, PAUSE, PLAY, BEEP, PRINT, LET, END.
+ *
+ * These tests validate parsing through the FBasicParser public API,
+ * targeting specific statements registered by the core statements module.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { FBasicParser } from '@/core/parser/FBasicParser'
+
+describe('parser-statements-core: GOTO Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse GOTO with line number', async () => {
+    const result = await parser.parse('10 GOTO 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(1)
+  })
+
+  it('should parse GOTO with expression line number', async () => {
+    const result = await parser.parse('10 GOTO 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should reject GOTO without line number', async () => {
+    const result = await parser.parse('10 GOTO')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: GOSUB Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse GOSUB with line number', async () => {
+    const result = await parser.parse('10 GOSUB 1000')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should reject GOSUB without line number', async () => {
+    const result = await parser.parse('10 GOSUB')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: RETURN Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse RETURN without line number', async () => {
+    const result = await parser.parse('100 RETURN')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse RETURN with line number', async () => {
+    const result = await parser.parse('100 RETURN 50')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: END Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse END statement', async () => {
+    const result = await parser.parse('100 END')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse END with other statements on same line', async () => {
+    const result = await parser.parse('10 PRINT "DONE": END')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: PAUSE Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse PAUSE with number literal', async () => {
+    const result = await parser.parse('10 PAUSE 60')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PAUSE with variable expression', async () => {
+    const result = await parser.parse('10 PAUSE N')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PAUSE with arithmetic expression', async () => {
+    const result = await parser.parse('10 PAUSE 30 * 2')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: PLAY Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse PLAY with string literal', async () => {
+    const result = await parser.parse('10 PLAY "CDEFG"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PLAY with variable', async () => {
+    const result = await parser.parse('10 PLAY M$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PLAY with string concatenation', async () => {
+    const result = await parser.parse('10 PLAY "C" + "D"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: BEEP Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse BEEP statement', async () => {
+    const result = await parser.parse('10 BEEP')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: SWAP Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse SWAP with simple variables', async () => {
+    const result = await parser.parse('10 SWAP A, B')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse SWAP with string variables', async () => {
+    const result = await parser.parse('10 SWAP A$, B$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse SWAP with array elements', async () => {
+    const result = await parser.parse('10 SWAP A(1), A(2)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should reject SWAP without comma', async () => {
+    const result = await parser.parse('10 SWAP A B')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: CLEAR Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse CLEAR without arguments', async () => {
+    const result = await parser.parse('10 CLEAR')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse CLEAR with hex address', async () => {
+    const result = await parser.parse('10 CLEAR &H7600')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse CLEAR with decimal address', async () => {
+    const result = await parser.parse('10 CLEAR 30208')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: ON Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse ON GOTO with multiple targets', async () => {
+    const result = await parser.parse('10 ON X GOTO 100, 200, 300')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse ON GOSUB with multiple targets', async () => {
+    const result = await parser.parse('10 ON N GOSUB 1000, 2000, 3000')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse ON RETURN with line numbers', async () => {
+    const result = await parser.parse('10 ON X RETURN 100, 200, 300')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse ON RESTORE with line numbers', async () => {
+    const result = await parser.parse('10 ON X RESTORE 100, 200, 300')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse ON with expression index', async () => {
+    const result = await parser.parse('10 ON I + 1 GOTO 100, 200')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: INPUT Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse INPUT with single variable', async () => {
+    const result = await parser.parse('10 INPUT A')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse INPUT with prompt and variable', async () => {
+    const result = await parser.parse('10 INPUT "NAME"; A$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse INPUT with multiple variables', async () => {
+    const result = await parser.parse('10 INPUT A, B, C')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse INPUT with prompt and multiple variables', async () => {
+    const result = await parser.parse('10 INPUT "X,Y"; X, Y')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: LINPUT Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse LINPUT with variable', async () => {
+    const result = await parser.parse('10 LINPUT A$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse LINPUT with prompt and variable', async () => {
+    const result = await parser.parse('10 LINPUT "PROMPT"; A$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse LINPUT with comma separator', async () => {
+    const result = await parser.parse('10 LINPUT "ENTER", A$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: IF/THEN Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse IF THEN with line number jump', async () => {
+    const result = await parser.parse('10 IF X = 10 THEN 500')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF THEN with command', async () => {
+    const result = await parser.parse('10 IF X = 10 THEN PRINT X')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF GOTO with line number', async () => {
+    const result = await parser.parse('10 IF X = 10 GOTO 500')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF with AND operator', async () => {
+    const result = await parser.parse('10 IF X > 0 AND Y < 10 THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF with OR operator', async () => {
+    const result = await parser.parse('10 IF A = 1 OR B = 2 THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF with NOT operator', async () => {
+    const result = await parser.parse('10 IF NOT X = 0 THEN PRINT X')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF with colon-separated THEN statements', async () => {
+    const result = await parser.parse('10 IF X THEN PRINT A: PRINT B')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF with comparison operators', async () => {
+    const result = await parser.parse('10 IF X <> 0 THEN PRINT X')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF with <= operator', async () => {
+    const result = await parser.parse('10 IF I <= 10 THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF with >= operator', async () => {
+    const result = await parser.parse('10 IF I >= 0 THEN 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: LET Statement (assignment)', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse LET with explicit keyword', async () => {
+    const result = await parser.parse('10 LET X = 10')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse implicit LET (assignment without keyword)', async () => {
+    const result = await parser.parse('10 X = 10')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse LET with array element assignment', async () => {
+    const result = await parser.parse('10 LET A(0) = 10')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse implicit array element assignment', async () => {
+    const result = await parser.parse('10 A$(I) = "HELLO"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse string variable assignment', async () => {
+    const result = await parser.parse('10 A$ = "HELLO"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse LET with hex literal', async () => {
+    const result = await parser.parse('10 LET Z = &HDD')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: PRINT Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse PRINT with no arguments', async () => {
+    const result = await parser.parse('10 PRINT')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PRINT with string literal', async () => {
+    const result = await parser.parse('10 PRINT "HELLO"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PRINT with comma-separated items', async () => {
+    const result = await parser.parse('10 PRINT A, B, C')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PRINT with semicolon-separated items', async () => {
+    const result = await parser.parse('10 PRINT A; B; C')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PRINT with trailing semicolon', async () => {
+    const result = await parser.parse('10 PRINT A;')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PRINT with trailing comma', async () => {
+    const result = await parser.parse('10 PRINT A,')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PRINT with function call', async () => {
+    const result = await parser.parse('10 PRINT LEN(A$)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PRINT with expression', async () => {
+    const result = await parser.parse('10 PRINT X + Y * 2')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: FOR/NEXT Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse basic FOR NEXT loop', async () => {
+    const code = `10 FOR I = 1 TO 10
+20 PRINT I
+30 NEXT`
+    const result = await parser.parse(code)
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(3)
+  })
+
+  it('should parse FOR with STEP clause', async () => {
+    const result = await parser.parse('10 FOR I = 1 TO 10 STEP 2')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse FOR with negative STEP', async () => {
+    const result = await parser.parse('10 FOR I = 10 TO 1 STEP -1')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should reject NEXT with variable name', async () => {
+    const result = await parser.parse('10 NEXT I')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+
+  it('should parse FOR with expression bounds', async () => {
+    const result = await parser.parse('10 FOR I = 1 + 1 TO 10 - 2 STEP 2 * 1')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: Colon-Separated Commands', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse multiple statements separated by colons', async () => {
+    const result = await parser.parse('10 LET X = 1: LET Y = 2: PRINT X, Y')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse GOTO in colon-separated chain', async () => {
+    const result = await parser.parse('10 LET X = 1: GOTO 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse FOR NEXT on same line with colons', async () => {
+    const result = await parser.parse('10 FOR I = 1 TO 5: PRINT I: NEXT')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse IF THEN with colon chain', async () => {
+    const result = await parser.parse('10 IF X > 0 THEN LET Y = X: PRINT Y')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})

--- a/test/core/parser/parser-statements-data.test.ts
+++ b/test/core/parser/parser-statements-data.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Data Statement Parser Module Tests
+ *
+ * Tests for parser-statements-data.ts: DATA, READ, RESTORE, and DIM statements.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { FBasicParser } from '@/core/parser/FBasicParser'
+
+describe('parser-statements-data: DIM Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse single-dimension numeric array', async () => {
+    const result = await parser.parse('10 DIM A(10)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse two-dimension numeric array', async () => {
+    const result = await parser.parse('10 DIM A(10, 10)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse string array', async () => {
+    const result = await parser.parse('10 DIM A$(10)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse multiple array declarations', async () => {
+    const result = await parser.parse('10 DIM A(10), B(10, 10), C$(5)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DIM with expression dimensions', async () => {
+    const result = await parser.parse('10 DIM A(N + 1)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should reject DIM without parentheses', async () => {
+    const result = await parser.parse('10 DIM A')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+})
+
+describe('parser-statements-data: DATA Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse DATA with numeric values', async () => {
+    const result = await parser.parse('10 DATA 10, 20, 30')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DATA with string values', async () => {
+    const result = await parser.parse('10 DATA "HELLO", "WORLD"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DATA with unquoted string identifiers', async () => {
+    const result = await parser.parse('10 DATA GOOD, MORNING')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DATA with hex values', async () => {
+    const result = await parser.parse('10 DATA &H0A, &HFF')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DATA with mixed types', async () => {
+    const result = await parser.parse('10 DATA 10, "HELLO", &HFF, GOOD')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse empty DATA statement', async () => {
+    const result = await parser.parse('10 DATA')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-data: READ Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse READ with single variable', async () => {
+    const result = await parser.parse('10 READ A')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse READ with multiple variables', async () => {
+    const result = await parser.parse('10 READ A, B, C')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse READ with string variables', async () => {
+    const result = await parser.parse('10 READ A$, B$, C$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse READ with array elements', async () => {
+    const result = await parser.parse('10 READ A(0), B$(I)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse READ with mixed variables and arrays', async () => {
+    const result = await parser.parse('10 READ A, B$, A(0), C$(I, J)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-data: RESTORE Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse RESTORE without line number', async () => {
+    const result = await parser.parse('10 RESTORE')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse RESTORE with line number', async () => {
+    const result = await parser.parse('10 RESTORE 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-data: Integration', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse DATA READ RESTORE pattern', async () => {
+    const code = `10 DATA 1, 2, 3, 4, 5
+20 READ A, B, C
+30 RESTORE
+40 READ D, E`
+    const result = await parser.parse(code)
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(4)
+  })
+
+  it('should parse DIM with DATA READ pattern', async () => {
+    const code = `10 DIM A(5)
+20 DATA 10, 20, 30, 40, 50
+30 FOR I = 0 TO 4
+40 READ A(I)
+50 NEXT`
+    const result = await parser.parse(code)
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})

--- a/test/core/parser/parser-statements-repl.test.ts
+++ b/test/core/parser/parser-statements-repl.test.ts
@@ -1,0 +1,154 @@
+/**
+ * REPL Statement Parser Module Tests
+ *
+ * Tests for parser-statements-repl.ts: REPL-only and limited utility commands
+ * including LIST, NEW, RUN, SAVE, LOAD, KEY, KEYLIST, CONT, SYSTEM,
+ * POKE, PEEK, FRE, INKEY$, STOP.
+ *
+ * Note: These commands are parsed by the grammar but produce errors at the
+ * Chevrotain integration layer (parse-with-chevrotain.ts) because they are
+ * not applicable in the IDE version. We use parseWithChevrotain directly
+ * because FBasicParser.parse() does not pass through the CST on errors.
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import { parseWithChevrotain } from '@/core/parser/FBasicChevrotainParser'
+
+describe('parser-statements-repl: LIST Statement', () => {
+  test('should parse LIST without arguments (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 LIST')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('LIST: Not applicable for IDE version')
+  })
+
+  test('should parse LIST with line range (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 LIST 10-100')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('LIST: Not applicable for IDE version')
+  })
+
+  test('should parse LIST with single line number (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 LIST 50')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('LIST: Not applicable for IDE version')
+  })
+})
+
+describe('parser-statements-repl: NEW Statement', () => {
+  test('should parse NEW (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 NEW')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('NEW: Not applicable for IDE version')
+  })
+})
+
+describe('parser-statements-repl: RUN Statement', () => {
+  test('should parse RUN (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 RUN')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('RUN: Not applicable for IDE version - use the Run button instead')
+  })
+})
+
+describe('parser-statements-repl: SAVE Statement', () => {
+  test('should parse SAVE (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 SAVE')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('SAVE: Not applicable for IDE version - use Export instead')
+  })
+})
+
+describe('parser-statements-repl: LOAD Statement', () => {
+  test('should parse LOAD (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 LOAD')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('LOAD: Not applicable for IDE version - use Import instead')
+  })
+
+  test('should parse LOAD? with verify flag (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 LOAD?')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('LOAD: Not applicable for IDE version - use Import instead')
+  })
+})
+
+describe('parser-statements-repl: KEY Statement', () => {
+  test('should parse KEY without parameters (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 KEY')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('KEY: Not applicable for IDE version')
+  })
+
+  test('should parse KEY with parameters (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 KEY 1, "HELP"')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('KEY: Not applicable for IDE version')
+  })
+})
+
+describe('parser-statements-repl: KEYLIST Statement', () => {
+  test('should parse KEYLIST (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 KEYLIST')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('KEYLIST: Not applicable for IDE version')
+  })
+})
+
+describe('parser-statements-repl: CONT Statement', () => {
+  test('should parse CONT (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 CONT')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('CONT: Not applicable for IDE version')
+  })
+})
+
+describe('parser-statements-repl: SYSTEM Statement', () => {
+  test('should parse SYSTEM (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 SYSTEM')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('SYSTEM: Not applicable for IDE version')
+  })
+})
+
+describe('parser-statements-repl: POKE Statement', () => {
+  test('should parse POKE with address and value (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 POKE &H7000, 255')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('POKE: Not applicable for IDE version')
+  })
+})
+
+describe('parser-statements-repl: STOP Statement', () => {
+  test('should parse STOP (produces REPL error)', () => {
+    const result = parseWithChevrotain('10 STOP')
+    expect(result.success).toBe(false)
+    expect(result.cst).toBeDefined()
+    expect(result.errors?.[0]?.message).toEqual('STOP: Not applicable for IDE version')
+  })
+})
+
+describe('parser-statements-repl: Multiple REPL Commands', () => {
+  test('should report error for colon-separated REPL commands', () => {
+    const result = parseWithChevrotain('10 LIST: NEW: RUN')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+    expect(result.errors!.length).toBeGreaterThanOrEqual(1)
+    expect(result.errors?.[0]?.message).toEqual('LIST: Not applicable for IDE version')
+  })
+})

--- a/test/core/parser/parser-statements-screen.test.ts
+++ b/test/core/parser/parser-statements-screen.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Screen Statement Parser Module Tests
+ *
+ * Tests for parser-statements-screen.ts: screen/display statements
+ * including CLS, LOCATE, COLOR, CGSET, CGEN, PALET, VIEW.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { FBasicParser } from '@/core/parser/FBasicParser'
+
+describe('parser-statements-screen: CLS Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse CLS statement', async () => {
+    const result = await parser.parse('10 CLS')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse CLS with other statements', async () => {
+    const result = await parser.parse('10 CLS: PRINT "HELLO"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-screen: LOCATE Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse LOCATE with coordinates', async () => {
+    const result = await parser.parse('10 LOCATE 10, 5')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse LOCATE with variables', async () => {
+    const result = await parser.parse('10 LOCATE X, Y')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse LOCATE with expression coordinates', async () => {
+    const result = await parser.parse('10 LOCATE X + 1, Y * 2')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should reject LOCATE without comma', async () => {
+    const result = await parser.parse('10 LOCATE 10')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+})
+
+describe('parser-statements-screen: COLOR Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse COLOR with three arguments', async () => {
+    const result = await parser.parse('10 COLOR 10, 5, 3')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse COLOR with variables', async () => {
+    const result = await parser.parse('10 COLOR X, Y, N')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse COLOR with zero arguments', async () => {
+    const result = await parser.parse('10 COLOR 0, 0, 0')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-screen: CGSET Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse CGSET without arguments', async () => {
+    const result = await parser.parse('10 CGSET')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse CGSET with one argument', async () => {
+    const result = await parser.parse('10 CGSET 0')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse CGSET with two arguments', async () => {
+    const result = await parser.parse('10 CGSET 0, 2')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-screen: CGEN Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse CGEN with argument', async () => {
+    const result = await parser.parse('10 CGEN 0')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse CGEN with expression', async () => {
+    const result = await parser.parse('10 CGEN M')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse CGEN modes 0-3', async () => {
+    for (const mode of [0, 1, 2, 3]) {
+      const result = await parser.parse(`10 CGEN ${mode}`)
+      expect(result.success).toBe(true)
+    }
+  })
+})
+
+describe('parser-statements-screen: PALET Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse PALETB with parameters', async () => {
+    const result = await parser.parse('10 PALETB 0, 1, 2, 3, 4')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PALETS with parameters', async () => {
+    const result = await parser.parse('10 PALETS 0, 1, 2, 3, 4')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PALET B with parameters', async () => {
+    const result = await parser.parse('10 PALET B 0, 1, 2, 3, 4')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse PALET S with parameters', async () => {
+    const result = await parser.parse('10 PALET S 0, 1, 2, 3, 4')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-screen: VIEW Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse VIEW statement', async () => {
+    const result = await parser.parse('10 VIEW')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should reject VIEW with arguments', async () => {
+    const result = await parser.parse('10 VIEW 100')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+})

--- a/test/core/parser/parser-statements-sprite.test.ts
+++ b/test/core/parser/parser-statements-sprite.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Sprite Statement Parser Module Tests
+ *
+ * Tests for parser-statements-sprite.ts: sprite and animation statements
+ * including DEF SPRITE, SPRITE, SPRITE ON/OFF, DEF MOVE, MOVE, CUT, ERA, POSITION.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { FBasicParser } from '@/core/parser/FBasicParser'
+
+describe('parser-statements-sprite: DEF SPRITE Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse DEF SPRITE with basic parameters', async () => {
+    const result = await parser.parse('10 DEF SPRITE 0, (0, 0, 0, 0, 0) = "A"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DEF SPRITE with CHR$ character set', async () => {
+    const result = await parser.parse('10 DEF SPRITE 1, (1, 1, 0, 0, 0) = CHR$(&HAA)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DEF SPRITE with variable sprite number', async () => {
+    const result = await parser.parse('10 DEF SPRITE N, (0, 0, 0, 0, 0) = "A"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DEF SPRITE with 16x16 size', async () => {
+    const result = await parser.parse('10 DEF SPRITE 0, (0, 1, 0, 0, 0) = "AB"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-sprite: SPRITE Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse SPRITE with position', async () => {
+    const result = await parser.parse('10 SPRITE 0, 100, 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse SPRITE without position (hide)', async () => {
+    const result = await parser.parse('10 SPRITE 0')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse SPRITE with variable coordinates', async () => {
+    const result = await parser.parse('10 SPRITE I, X, Y')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse SPRITE with expression coordinates', async () => {
+    const result = await parser.parse('10 SPRITE 0, X + 10, Y * 2')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-sprite: SPRITE ON/OFF Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse SPRITE ON', async () => {
+    const result = await parser.parse('10 SPRITE ON')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse SPRITE OFF', async () => {
+    const result = await parser.parse('10 SPRITE OFF')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-sprite: DEF MOVE Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse DEF MOVE with all parameters', async () => {
+    const result = await parser.parse('10 DEF MOVE(0) = SPRITE(0, 0, 60, 10, 0, 0)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DEF MOVE with variables', async () => {
+    const result = await parser.parse('10 DEF MOVE(N) = SPRITE(T, D, S, L, P, C)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse DEF MOVE with expressions', async () => {
+    const result = await parser.parse('10 DEF MOVE(0) = SPRITE(1, 2, 3, 4, 5, 6)')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-sprite: MOVE Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse MOVE with action number', async () => {
+    const result = await parser.parse('10 MOVE 0')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse MOVE with variable', async () => {
+    const result = await parser.parse('10 MOVE N')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-sprite: CUT Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse CUT with single action number', async () => {
+    const result = await parser.parse('10 CUT 0')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse CUT with multiple action numbers', async () => {
+    const result = await parser.parse('10 CUT 0, 1, 2')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-sprite: ERA Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse ERA with single action number', async () => {
+    const result = await parser.parse('10 ERA 0')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse ERA with multiple action numbers', async () => {
+    const result = await parser.parse('10 ERA 0, 1, 2')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-sprite: POSITION Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse POSITION with coordinates', async () => {
+    const result = await parser.parse('10 POSITION 0, 100, 100')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse POSITION with variables', async () => {
+    const result = await parser.parse('10 POSITION N, X, Y')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-sprite: Integration', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse sprite program pattern', async () => {
+    const code = `10 DEF SPRITE 0, (0, 0, 0, 0, 0) = CHR$(&HAA)
+20 SPRITE ON
+30 POSITION 0, 100, 100
+40 DEF MOVE(0) = SPRITE(0, 0, 60, 10, 0, 0)
+50 MOVE 0
+60 SPRITE 0, 100, 100
+70 CUT 0
+80 ERA 0
+90 SPRITE OFF`
+    const result = await parser.parse(code)
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+    const statements = result.cst?.children.statement
+    expect(Array.isArray(statements) ? statements.length : 0).toEqual(9)
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #153

## Changes
- **9 new test files**, 322 tests covering all previously untested parser modules:
  - `parser-statements-core.test.ts` (68 tests): GOTO, GOSUB, FOR, IF/THEN, LET, PRINT, INPUT, LINPUT, colon chains
  - `parser-expressions.test.ts` (65 tests): arithmetic, comparison, logical, bitwise, 16+ function calls, array access
  - `parser-dispatcher.test.ts` (46 tests): 28+ keyword routing, ambiguous keywords (DEF MOVE vs DEF SPRITE), PALET variants
  - `cst-helpers.test.ts` (36 tests): all 9 utility functions
  - `parse-with-chevrotain.test.ts` (27 tests): line parsing, REM comments, error handling, REPL validation
  - `parser-statements-sprite.test.ts` (22 tests): DEF SPRITE, SPRITE, DEF MOVE, MOVE, CUT, ERA
  - `parser-statements-data.test.ts` (21 tests): DIM, DATA (6 constant types), READ, RESTORE
  - `parser-statements-screen.test.ts` (21 tests): CLS, LOCATE, COLOR, CGSET, CGEN, PALET, VIEW
  - `parser-statements-repl.test.ts` (16 tests): all REPL-only commands

## Test plan
- [x] All 322 new tests pass
- [x] TypeScript type-check passes (0 errors)
- [x] ESLint passes (0 errors)
- [x] Full suite: 1892 tests pass, 0 regressions
- [ ] CI passes