### PR TITLE
test: resolve #161 - add Vue component tests for core IDE panels

### DIFF
--- a/test/ide/DebugTab.test.ts
+++ b/test/ide/DebugTab.test.ts
@@ -1,0 +1,113 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import DebugTab from '@/features/ide/components/DebugTab.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const gameTabPaneStub = defineComponent({
+  props: ['name', 'disabled'],
+  template: '<div class="game-tab-pane-stub" :data-name="name" :data-disabled="disabled"><slot /><slot name="label" /></div>',
+})
+
+const gameIconStub = defineComponent({
+  props: ['icon', 'size'],
+  template: '<span class="game-icon-stub" />',
+})
+
+describe('DebugTab', () => {
+  it('renders debug tab container', () => {
+    const wrapper = mount(DebugTab, {
+      props: { debugOutput: '', debugMode: true },
+      global: {
+        stubs: { GameTabPane: gameTabPaneStub, GameIcon: gameIconStub },
+      },
+    })
+
+    expect(wrapper.find('.tab-content').exists()).toBe(true)
+    expect(wrapper.find('.debug-content').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('disables tab pane when debugMode is false', () => {
+    const wrapper = mount(DebugTab, {
+      props: { debugOutput: 'some output', debugMode: false },
+      global: {
+        stubs: { GameTabPane: gameTabPaneStub, GameIcon: gameIconStub },
+      },
+    })
+
+    const tabPane = wrapper.find('.game-tab-pane-stub')
+    expect(tabPane.attributes('data-disabled')).toEqual('true')
+    wrapper.unmount()
+  })
+
+  it('disables tab pane when debugMode is true but no output', () => {
+    const wrapper = mount(DebugTab, {
+      props: { debugOutput: '', debugMode: true },
+      global: {
+        stubs: { GameTabPane: gameTabPaneStub, GameIcon: gameIconStub },
+      },
+    })
+
+    const tabPane = wrapper.find('.game-tab-pane-stub')
+    expect(tabPane.attributes('data-disabled')).toEqual('true')
+    wrapper.unmount()
+  })
+
+  it('enables tab pane when debugMode is true and has output', () => {
+    const wrapper = mount(DebugTab, {
+      props: { debugOutput: 'debug info here', debugMode: true },
+      global: {
+        stubs: { GameTabPane: gameTabPaneStub, GameIcon: gameIconStub },
+      },
+    })
+
+    const tabPane = wrapper.find('.game-tab-pane-stub')
+    expect(tabPane.attributes('data-disabled')).toEqual('false')
+    wrapper.unmount()
+  })
+
+  it('displays debug output text in pre element', () => {
+    const wrapper = mount(DebugTab, {
+      props: { debugOutput: 'line 1\nline 2', debugMode: true },
+      global: {
+        stubs: { GameTabPane: gameTabPaneStub, GameIcon: gameIconStub },
+      },
+    })
+
+    expect(wrapper.find('pre.debug-text').text()).toEqual('line 1\nline 2')
+    wrapper.unmount()
+  })
+
+  it('passes correct name prop to GameTabPane', () => {
+    const wrapper = mount(DebugTab, {
+      props: { debugOutput: '', debugMode: false },
+      global: {
+        stubs: { GameTabPane: gameTabPaneStub, GameIcon: gameIconStub },
+      },
+    })
+
+    const tabPane = wrapper.find('.game-tab-pane-stub')
+    expect(tabPane.attributes('data-name')).toEqual('debug')
+    wrapper.unmount()
+  })
+
+  it('uses default props when none provided', () => {
+    const wrapper = mount(DebugTab, {
+      props: {},
+      global: {
+        stubs: { GameTabPane: gameTabPaneStub, GameIcon: gameIconStub },
+      },
+    })
+
+    expect(wrapper.find('pre.debug-text').text()).toEqual('')
+    expect(wrapper.find('.game-tab-pane-stub').attributes('data-disabled')).toEqual('true')
+    wrapper.unmount()
+  })
+})

--- a/test/ide/EditorViewToggle.test.ts
+++ b/test/ide/EditorViewToggle.test.ts
@@ -1,0 +1,135 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import EditorViewToggle from '@/features/ide/components/EditorViewToggle.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const gameButtonStub = defineComponent({
+  props: ['variant', 'type', 'icon', 'size', 'selected'],
+  template: '<button :data-icon="icon" :data-selected="selected" :data-variant="variant"><slot /></button>',
+})
+
+const gameIconButtonStub = defineComponent({
+  props: ['variant', 'type', 'icon', 'size', 'title', 'selected'],
+  template: '<button :data-icon="icon" :data-selected="selected" :title="title" :data-variant="variant" />',
+})
+
+describe('EditorViewToggle', () => {
+  it('renders two buttons for code and bg views', () => {
+    const wrapper = mount(EditorViewToggle, {
+      props: { modelValue: 'code' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toEqual(2)
+    wrapper.unmount()
+  })
+
+  it('highlights code button when modelValue is code', () => {
+    const wrapper = mount(EditorViewToggle, {
+      props: { modelValue: 'code' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const codeButton = buttons.find(b => b.attributes('data-icon') === 'mdi:code-tags')!
+    const bgButton = buttons.find(b => b.attributes('data-icon') === 'mdi:view-grid')!
+
+    expect(codeButton.attributes('data-selected')).toEqual('true')
+    expect(bgButton.attributes('data-selected')).toEqual('false')
+    wrapper.unmount()
+  })
+
+  it('highlights bg button when modelValue is bg', () => {
+    const wrapper = mount(EditorViewToggle, {
+      props: { modelValue: 'bg' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const codeButton = buttons.find(b => b.attributes('data-icon') === 'mdi:code-tags')!
+    const bgButton = buttons.find(b => b.attributes('data-icon') === 'mdi:view-grid')!
+
+    expect(codeButton.attributes('data-selected')).toEqual('false')
+    expect(bgButton.attributes('data-selected')).toEqual('true')
+    wrapper.unmount()
+  })
+
+  it('emits update:modelValue with code when code button is clicked', async () => {
+    const wrapper = mount(EditorViewToggle, {
+      props: { modelValue: 'bg' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const codeButton = buttons.find(b => b.attributes('data-icon') === 'mdi:code-tags')!
+    await codeButton.trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['code'])
+    wrapper.unmount()
+  })
+
+  it('emits update:modelValue with bg when bg button is clicked', async () => {
+    const wrapper = mount(EditorViewToggle, {
+      props: { modelValue: 'code' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const bgButton = buttons.find(b => b.attributes('data-icon') === 'mdi:view-grid')!
+    await bgButton.trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['bg'])
+    wrapper.unmount()
+  })
+
+  it('uses GameButton (non-compact) by default', () => {
+    const wrapper = mount(EditorViewToggle, {
+      props: { modelValue: 'code', isCompact: false },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    // Non-compact mode uses GameButton which has slots (text content)
+    const buttons = wrapper.findAll('button')
+    // In non-compact mode, buttons have text labels
+    expect(buttons.length).toEqual(2)
+    wrapper.unmount()
+  })
+
+  it('uses GameIconButton in compact mode', () => {
+    const wrapper = mount(EditorViewToggle, {
+      props: { modelValue: 'code', isCompact: true },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    // Compact mode uses GameIconButton (no text, just icons)
+    const buttons = wrapper.findAll('button')
+    // Both buttons should have title attributes (from GameIconButton)
+    expect(buttons[0]!.attributes('title')).toEqual('ide.editorViewToggle.codeTitle')
+    expect(buttons[1]!.attributes('title')).toEqual('ide.editorViewToggle.bgTitle')
+    wrapper.unmount()
+  })
+})

--- a/test/ide/ErrorPanel.test.ts
+++ b/test/ide/ErrorPanel.test.ts
@@ -1,0 +1,183 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import ErrorPanel from '@/features/ide/components/ErrorPanel.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const gameIconStub = defineComponent({
+  props: ['icon', 'size'],
+  template: '<span class="game-icon-stub" :data-icon="icon" :data-size="size" />',
+})
+
+function createError(overrides: Partial<{
+  line: number
+  message: string
+  type: string
+  stack?: string
+  sourceLine?: string
+}> = {}) {
+  return {
+    line: 10,
+    message: 'Syntax error',
+    type: 'ParseError',
+    ...overrides,
+  }
+}
+
+describe('ErrorPanel', () => {
+  it('renders nothing when errors is undefined', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: { errors: undefined },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    expect(wrapper.find('.error-panel').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders nothing when errors array is empty', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: { errors: [] },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    expect(wrapper.find('.error-panel').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders error panel with single error', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: { errors: [createError()] },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    expect(wrapper.find('.error-panel').exists()).toBe(true)
+    expect(wrapper.findAll('.error-block').length).toEqual(1)
+    expect(wrapper.find('.error-type').text()).toEqual('ParseError:')
+    expect(wrapper.find('.error-message').text()).toEqual('Syntax error')
+    wrapper.unmount()
+  })
+
+  it('renders multiple errors', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: {
+        errors: [
+          createError({ type: 'ParseError', message: 'Bad syntax' }),
+          createError({ type: 'RuntimeError', message: 'Division by zero' }),
+        ],
+      },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    expect(wrapper.findAll('.error-block').length).toEqual(2)
+    wrapper.unmount()
+  })
+
+  it('shows line number when line is greater than 0', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: { errors: [createError({ line: 42 })] },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    const lineSpan = wrapper.find('.error-line-number')
+    expect(lineSpan.exists()).toBe(true)
+    expect(lineSpan.text()).toEqual('(ide.output.errorLine)')
+    wrapper.unmount()
+  })
+
+  it('hides line number when line is 0', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: { errors: [createError({ line: 0 })] },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    expect(wrapper.find('.error-line-number').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('hides line number when line is negative', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: { errors: [createError({ line: -1 })] },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    expect(wrapper.find('.error-line-number').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows source line when provided', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: {
+        errors: [createError({
+          sourceLine: '10 PRINT "Hello"',
+        })],
+      },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    const sourceDiv = wrapper.find('.error-source-line')
+    expect(sourceDiv.exists()).toBe(true)
+    expect(sourceDiv.find('code').text()).toEqual('10 PRINT "Hello"')
+    expect(sourceDiv.find('.error-source-label').text()).toEqual('ide.errorPanel.sourceLabel')
+    wrapper.unmount()
+  })
+
+  it('hides source line section when sourceLine is not provided', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: { errors: [createError({ sourceLine: undefined })] },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    expect(wrapper.find('.error-source-line').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows stack trace in collapsible details when provided', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: {
+        errors: [createError({
+          stack: 'at line 10\nat line 5',
+        })],
+      },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    const details = wrapper.find('details.error-stack-details')
+    expect(details.exists()).toBe(true)
+    expect(details.find('summary').text()).toEqual('ide.errorPanel.stackTrace')
+    expect(details.find('pre.error-stack').text()).toEqual('at line 10\nat line 5')
+    wrapper.unmount()
+  })
+
+  it('hides stack trace section when stack is not provided', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: { errors: [createError({ stack: undefined })] },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    expect(wrapper.find('details.error-stack-details').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders GameIcon for each error', () => {
+    const wrapper = mount(ErrorPanel, {
+      props: {
+        errors: [
+          createError({ type: 'Error1' }),
+          createError({ type: 'Error2' }),
+        ],
+      },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+
+    const icons = wrapper.findAll('.game-icon-stub')
+    expect(icons.length).toEqual(2)
+    wrapper.unmount()
+  })
+})

--- a/test/ide/IdeControls.test.ts
+++ b/test/ide/IdeControls.test.ts
@@ -1,0 +1,247 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import IdeControls from '@/features/ide/components/IdeControls.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const gameIconButtonStub = defineComponent({
+  props: ['type', 'disabled', 'icon', 'size', 'title', 'variant', 'selected'],
+  template: '<button :disabled="disabled" :data-testid="$attrs[\'data-testid\']" :data-type="type" :data-icon="icon" :data-variant="variant" :data-selected="selected" :title="title"><slot /></button>',
+})
+
+const inputModeToggleStub = defineComponent({
+  props: ['modelValue', 'isCompact'],
+  emits: ['update:modelValue'],
+  template: '<div class="input-mode-toggle-stub" :data-value="modelValue" :data-compact="isCompact" />',
+})
+
+describe('IdeControls', () => {
+  it('renders all control buttons', () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toEqual(5) // run, stop, clear, debug, debugBuffer
+    wrapper.unmount()
+  })
+
+  it('renders input mode toggle', () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const toggle = wrapper.find('.input-mode-toggle-stub')
+    expect(toggle.exists()).toBe(true)
+    expect(toggle.attributes('data-compact')).toEqual('')
+    wrapper.unmount()
+  })
+
+  it('emits run event when run button is clicked', async () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false, canRun: true },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const runButton = wrapper.find('[data-testid="ide-run-button"]')
+    await runButton.trigger('click')
+
+    expect(wrapper.emitted('run')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('emits stop event when stop button is clicked', async () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: true, canStop: true },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const stopButton = wrapper.find('[data-testid="ide-stop-button"]')
+    await stopButton.trigger('click')
+
+    expect(wrapper.emitted('stop')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('disables run button when canRun is false', () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: true, canRun: false },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const runButton = wrapper.find('[data-testid="ide-run-button"]')
+    expect((runButton.element as HTMLButtonElement).disabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('enables run button when canRun is true', () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false, canRun: true },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const runButton = wrapper.find('[data-testid="ide-run-button"]')
+    expect((runButton.element as HTMLButtonElement).disabled).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('disables stop button when canStop is false', () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false, canStop: false },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const stopButton = wrapper.find('[data-testid="ide-stop-button"]')
+    expect((stopButton.element as HTMLButtonElement).disabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('emits clear event when clear button is clicked', async () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    await buttons[2]!.trigger('click') // clear button (3rd button)
+
+    expect(wrapper.emitted('clear')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('emits toggleDebug event when debug button is clicked', async () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false, debugMode: false },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    await buttons[3]!.trigger('click') // debug toggle button
+
+    expect(wrapper.emitted('toggleDebug')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('emits debugBuffer event when debug buffer button is clicked', async () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    await buttons[4]!.trigger('click') // debug buffer button (5th button)
+
+    expect(wrapper.emitted('debugBuffer')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('passes debugMode selected state to debug toggle button', () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false, debugMode: true },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const debugButton = buttons[3]!
+    expect(debugButton.attributes('data-selected')).toEqual('true')
+    wrapper.unmount()
+  })
+
+  it('emits update:inputMode when InputModeToggle changes', async () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false, inputMode: 'joystick' },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const toggle = wrapper.findComponent(inputModeToggleStub)
+    toggle.vm.$emit('update:modelValue', 'keyboard')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('update:inputMode')).toHaveLength(1)
+    expect(wrapper.emitted('update:inputMode')![0]).toEqual(['keyboard'])
+    wrapper.unmount()
+  })
+
+  it('renders control divider between toggle and buttons', () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.control-divider').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})

--- a/test/ide/InputModal.test.ts
+++ b/test/ide/InputModal.test.ts
@@ -1,0 +1,193 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+
+import InputModal from '@/features/ide/components/InputModal.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const gameInputStub = defineComponent({
+  props: ['modelValue', 'type', 'placeholder'],
+  emits: ['update:modelValue'],
+  template: '<input :value="modelValue" :type="type" :placeholder="placeholder" @input="$emit(\'update:modelValue\', $event.target.value)" data-testid="game-input" />',
+})
+
+const gameButtonStub = defineComponent({
+  props: ['type', 'size'],
+  template: '<button :data-type="type" :data-size="size"><slot /></button>',
+})
+
+function createPendingRequest(overrides: Partial<{
+  requestId: string
+  prompt: string
+  isLinput: boolean
+}> = {}) {
+  return {
+    requestId: 'req-1',
+    executionId: 'exec-1',
+    prompt: '? ',
+    variableCount: 1,
+    isLinput: false,
+    ...overrides,
+  }
+}
+
+describe('InputModal', () => {
+  it('renders nothing when pendingRequest is null', () => {
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: null },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    expect(wrapper.find('.input-modal-overlay').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders dialog when pendingRequest is provided', () => {
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: createPendingRequest() },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    expect(wrapper.find('.input-modal-overlay').exists()).toBe(true)
+    expect(wrapper.find('.input-modal-prompt').text()).toEqual('?')
+    expect(wrapper.find('[data-testid="game-input"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('shows INPUT placeholder for non-LINPUT request', () => {
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: createPendingRequest({ isLinput: false }) },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    const input = wrapper.find('[data-testid="game-input"]')
+    expect(input.attributes('placeholder')).toEqual('ide.inputModal.inputPlaceholder')
+    wrapper.unmount()
+  })
+
+  it('shows LINPUT placeholder for LINPUT request', () => {
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: createPendingRequest({ isLinput: true }) },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    const input = wrapper.find('[data-testid="game-input"]')
+    expect(input.attributes('placeholder')).toEqual('ide.inputModal.linputPlaceholder')
+    wrapper.unmount()
+  })
+
+  it('emits respond with split values on submit for INPUT', async () => {
+    const request = createPendingRequest({ isLinput: false })
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: request },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    await wrapper.find('[data-testid="game-input"]').setValue('hello, world')
+    const buttons = wrapper.findAll('button')
+    await buttons[0]!.trigger('click') // Submit button
+
+    expect(wrapper.emitted('respond')).toHaveLength(1)
+    expect(wrapper.emitted('respond')![0]).toEqual([
+      'req-1',
+      ['hello', 'world'],
+      false,
+    ])
+    wrapper.unmount()
+  })
+
+  it('emits respond with single raw value on submit for LINPUT', async () => {
+    const request = createPendingRequest({ isLinput: true })
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: request },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    await wrapper.find('[data-testid="game-input"]').setValue('hello, world')
+    const buttons = wrapper.findAll('button')
+    await buttons[0]!.trigger('click') // Submit button
+
+    expect(wrapper.emitted('respond')).toHaveLength(1)
+    expect(wrapper.emitted('respond')![0]).toEqual([
+      'req-1',
+      ['hello, world'],
+      false,
+    ])
+    wrapper.unmount()
+  })
+
+  it('emits respond with cancelled true on cancel', async () => {
+    const request = createPendingRequest()
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: request },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    const buttons = wrapper.findAll('button')
+    await buttons[1]!.trigger('click') // Cancel button
+
+    expect(wrapper.emitted('respond')).toHaveLength(1)
+    expect(wrapper.emitted('respond')![0]).toEqual([
+      'req-1',
+      [],
+      true,
+    ])
+    wrapper.unmount()
+  })
+
+  it('does not emit when submit with no pending request', async () => {
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: null },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    // Component is not rendered, so no buttons exist
+    expect(wrapper.find('button').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('clears input value when pendingRequest changes', async () => {
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: createPendingRequest({ requestId: 'req-1' }) },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    await wrapper.find('[data-testid="game-input"]').setValue('typed value')
+    expect((wrapper.find('[data-testid="game-input"]').element as HTMLInputElement).value).toEqual('typed value')
+
+    await wrapper.setProps({ pendingRequest: createPendingRequest({ requestId: 'req-2' }) })
+    await nextTick()
+
+    expect((wrapper.find('[data-testid="game-input"]').element as HTMLInputElement).value).toEqual('')
+    wrapper.unmount()
+  })
+
+  it('has proper dialog ARIA attributes', () => {
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: createPendingRequest() },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    const overlay = wrapper.find('.input-modal-overlay')
+    expect(overlay.attributes('role')).toEqual('dialog')
+    expect(overlay.attributes('aria-modal')).toEqual('true')
+    expect(overlay.attributes('aria-labelledby')).toEqual('input-modal-prompt')
+    wrapper.unmount()
+  })
+
+  it('has form with submit.prevent', () => {
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: createPendingRequest() },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    const form = wrapper.find('form')
+    expect(form.exists()).toBe(true)
+    wrapper.unmount()
+  })
+})

--- a/test/ide/InputModeToggle.test.ts
+++ b/test/ide/InputModeToggle.test.ts
@@ -1,0 +1,131 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import InputModeToggle from '@/features/ide/components/InputModeToggle.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const gameButtonStub = defineComponent({
+  props: ['variant', 'type', 'icon', 'size', 'selected'],
+  template: '<button :data-icon="icon" :data-selected="selected" :data-variant="variant"><slot /></button>',
+})
+
+const gameIconButtonStub = defineComponent({
+  props: ['variant', 'type', 'icon', 'size', 'title', 'selected'],
+  template: '<button :data-icon="icon" :data-selected="selected" :title="title" :data-variant="variant" />',
+})
+
+describe('InputModeToggle', () => {
+  it('renders two buttons for joystick and keyboard modes', () => {
+    const wrapper = mount(InputModeToggle, {
+      props: { modelValue: 'joystick' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toEqual(2)
+    wrapper.unmount()
+  })
+
+  it('highlights joystick button when modelValue is joystick', () => {
+    const wrapper = mount(InputModeToggle, {
+      props: { modelValue: 'joystick' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const joystickButton = buttons.find(b => b.attributes('data-icon') === 'mdi:gamepad-variant')!
+    const keyboardButton = buttons.find(b => b.attributes('data-icon') === 'mdi:keyboard')!
+
+    expect(joystickButton.attributes('data-selected')).toEqual('true')
+    expect(keyboardButton.attributes('data-selected')).toEqual('false')
+    wrapper.unmount()
+  })
+
+  it('highlights keyboard button when modelValue is keyboard', () => {
+    const wrapper = mount(InputModeToggle, {
+      props: { modelValue: 'keyboard' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const joystickButton = buttons.find(b => b.attributes('data-icon') === 'mdi:gamepad-variant')!
+    const keyboardButton = buttons.find(b => b.attributes('data-icon') === 'mdi:keyboard')!
+
+    expect(joystickButton.attributes('data-selected')).toEqual('false')
+    expect(keyboardButton.attributes('data-selected')).toEqual('true')
+    wrapper.unmount()
+  })
+
+  it('emits update:modelValue with joystick when joystick button is clicked', async () => {
+    const wrapper = mount(InputModeToggle, {
+      props: { modelValue: 'keyboard' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const joystickButton = buttons.find(b => b.attributes('data-icon') === 'mdi:gamepad-variant')!
+    await joystickButton.trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['joystick'])
+    wrapper.unmount()
+  })
+
+  it('emits update:modelValue with keyboard when keyboard button is clicked', async () => {
+    const wrapper = mount(InputModeToggle, {
+      props: { modelValue: 'joystick' },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const keyboardButton = buttons.find(b => b.attributes('data-icon') === 'mdi:keyboard')!
+    await keyboardButton.trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['keyboard'])
+    wrapper.unmount()
+  })
+
+  it('uses GameIconButton in compact mode', () => {
+    const wrapper = mount(InputModeToggle, {
+      props: { modelValue: 'joystick', isCompact: true },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons[0]!.attributes('title')).toEqual('ide.inputModeToggle.joystickTitle')
+    expect(buttons[1]!.attributes('title')).toEqual('ide.inputModeToggle.keyboardTitle')
+    wrapper.unmount()
+  })
+
+  it('uses GameButton (non-compact) by default', () => {
+    const wrapper = mount(InputModeToggle, {
+      props: { modelValue: 'joystick', isCompact: false },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toEqual(2)
+    wrapper.unmount()
+  })
+})

--- a/test/ide/JoystickControl.test.ts
+++ b/test/ide/JoystickControl.test.ts
@@ -1,0 +1,270 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, reactive, ref } from 'vue'
+
+import JoystickControl from '@/features/ide/components/JoystickControl.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const mockStartDpadHold = vi.fn()
+const mockStopDpadHold = vi.fn()
+const mockToggleActionButton = vi.fn()
+const mockUpdateKeyBindings = vi.fn()
+const mockResetToDefaults = vi.fn()
+
+const mockHeldButtons = reactive<Record<string, boolean>>({})
+const mockFlashingCells = ref(new Set<string>())
+const mockKeyBindings = ref({
+  joystick0: {
+    up: { key: 'KeyW', displayName: 'W' },
+    down: { key: 'KeyS', displayName: 'S' },
+    left: { key: 'KeyA', displayName: 'A' },
+    right: { key: 'KeyD', displayName: 'D' },
+    select: { key: 'ShiftRight', displayName: 'RShift' },
+    start: { key: 'Enter', displayName: 'Enter' },
+    a: { key: 'KeyJ', displayName: 'J' },
+    b: { key: 'KeyK', displayName: 'K' },
+  },
+  joystick1: {
+    up: { key: 'ArrowUp', displayName: 'Up' },
+    down: { key: 'ArrowDown', displayName: 'Down' },
+    left: { key: 'ArrowLeft', displayName: 'Left' },
+    right: { key: 'ArrowRight', displayName: 'Right' },
+    select: { key: 'Numpad0', displayName: 'Num0' },
+    start: { key: 'NumpadEnter', displayName: 'NumEnter' },
+    a: { key: 'Numpad1', displayName: 'Num1' },
+    b: { key: 'Numpad2', displayName: 'Num2' },
+  },
+})
+
+vi.mock('@/core/devices', () => ({
+  createViewsFromJoystickBuffer: vi.fn(() => null),
+}))
+
+vi.mock('@/features/ide/composables/useJoystickEvents', () => ({
+  useJoystickEvents: () => ({
+    heldButtons: mockHeldButtons,
+    flashingCells: mockFlashingCells,
+    startDpadHold: mockStartDpadHold,
+    stopDpadHold: mockStopDpadHold,
+    toggleActionButton: mockToggleActionButton,
+  }),
+}))
+
+vi.mock('@/features/ide/composables/useKeyboardJoystick', () => ({
+  useKeyboardJoystick: () => ({
+    keyBindings: mockKeyBindings,
+    updateKeyBindings: mockUpdateKeyBindings,
+    resetToDefaults: mockResetToDefaults,
+  }),
+}))
+
+const gameBlockStub = defineComponent({
+  props: ['title', 'titleIcon'],
+  template: '<div class="game-block-stub"><slot /></div>',
+})
+
+const gameSubBlockStub = defineComponent({
+  props: ['title'],
+  template: '<div class="game-sub-block-stub" :data-title="title"><slot /></div>',
+})
+
+const gameButtonStub = defineComponent({
+  props: ['size'],
+  template: '<button class="game-button-stub"><slot /></button>',
+})
+
+const nintendoControllerStub = defineComponent({
+  props: ['joystickId', 'heldButtons'],
+  emits: ['dpadStart', 'dpadStop', 'actionButton'],
+  template: '<div class="nintendo-controller-stub" :data-joystick-id="joystickId" />',
+})
+
+const joystickStatusTableStub = defineComponent({
+  props: ['statusData', 'flashingCells'],
+  template: '<div class="joystick-status-table-stub" :data-count="statusData.length" />',
+})
+
+const joystickKeybindingPanelStub = defineComponent({
+  props: ['modelValue', 'keyBindings'],
+  emits: ['update:modelValue', 'update:keyBindings', 'reset'],
+  template: '<div class="joystick-keybinding-panel-stub" :data-visible="modelValue" />',
+})
+
+describe('JoystickControl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders control panel with GameBlock', () => {
+    const wrapper = mount(JoystickControl, {
+      props: {},
+      global: {
+        stubs: {
+          GameBlock: gameBlockStub,
+          GameSubBlock: gameSubBlockStub,
+          GameButton: gameButtonStub,
+          NintendoController: nintendoControllerStub,
+          JoystickStatusTable: joystickStatusTableStub,
+          JoystickKeybindingPanel: joystickKeybindingPanelStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.game-block-stub').exists()).toBe(true)
+    expect(wrapper.find('.joystick-control').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders two NintendoController instances for joysticks 0 and 1', () => {
+    const wrapper = mount(JoystickControl, {
+      props: {},
+      global: {
+        stubs: {
+          GameBlock: gameBlockStub,
+          GameSubBlock: gameSubBlockStub,
+          GameButton: gameButtonStub,
+          NintendoController: nintendoControllerStub,
+          JoystickStatusTable: joystickStatusTableStub,
+          JoystickKeybindingPanel: joystickKeybindingPanelStub,
+        },
+      },
+    })
+
+    const controllers = wrapper.findAll('.nintendo-controller-stub')
+    expect(controllers.length).toEqual(2)
+    expect(controllers[0]!.attributes('data-joystick-id')).toEqual('0')
+    expect(controllers[1]!.attributes('data-joystick-id')).toEqual('1')
+    wrapper.unmount()
+  })
+
+  it('renders JoystickStatusTable with status data', () => {
+    const wrapper = mount(JoystickControl, {
+      props: {},
+      global: {
+        stubs: {
+          GameBlock: gameBlockStub,
+          GameSubBlock: gameSubBlockStub,
+          GameButton: gameButtonStub,
+          NintendoController: nintendoControllerStub,
+          JoystickStatusTable: joystickStatusTableStub,
+          JoystickKeybindingPanel: joystickKeybindingPanelStub,
+        },
+      },
+    })
+
+    const table = wrapper.find('.joystick-status-table-stub')
+    expect(table.exists()).toBe(true)
+    expect(table.attributes('data-count')).toEqual('2')
+    wrapper.unmount()
+  })
+
+  it('renders keyboard hint text', () => {
+    const wrapper = mount(JoystickControl, {
+      props: {},
+      global: {
+        stubs: {
+          GameBlock: gameBlockStub,
+          GameSubBlock: gameSubBlockStub,
+          GameButton: gameButtonStub,
+          NintendoController: nintendoControllerStub,
+          JoystickStatusTable: joystickStatusTableStub,
+          JoystickKeybindingPanel: joystickKeybindingPanelStub,
+        },
+      },
+    })
+
+    const hint = wrapper.find('.keyboard-hint')
+    expect(hint.exists()).toBe(true)
+    expect(hint.find('.hint-text').exists()).toBe(true)
+    expect(hint.find('.key-bindings').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('shows keybinding panel as hidden by default', () => {
+    const wrapper = mount(JoystickControl, {
+      props: {},
+      global: {
+        stubs: {
+          GameBlock: gameBlockStub,
+          GameSubBlock: gameSubBlockStub,
+          GameButton: gameButtonStub,
+          NintendoController: nintendoControllerStub,
+          JoystickStatusTable: joystickStatusTableStub,
+          JoystickKeybindingPanel: joystickKeybindingPanelStub,
+        },
+      },
+    })
+
+    const panel = wrapper.find('.joystick-keybinding-panel-stub')
+    expect(panel.attributes('data-visible')).toEqual('false')
+    wrapper.unmount()
+  })
+
+  it('shows keybinding panel when configure button is clicked', async () => {
+    const wrapper = mount(JoystickControl, {
+      props: {},
+      global: {
+        stubs: {
+          GameBlock: gameBlockStub,
+          GameSubBlock: gameSubBlockStub,
+          GameButton: gameButtonStub,
+          NintendoController: nintendoControllerStub,
+          JoystickStatusTable: joystickStatusTableStub,
+          JoystickKeybindingPanel: joystickKeybindingPanelStub,
+        },
+      },
+    })
+
+    const configureButton = wrapper.findAll('.game-button-stub').find(b => b.text() === 'ide.joystick.configureKeys')!
+    await configureButton.trigger('click')
+
+    const panel = wrapper.find('.joystick-keybinding-panel-stub')
+    expect(panel.attributes('data-visible')).toEqual('true')
+    wrapper.unmount()
+  })
+
+  it('renders two GameSubBlock instances for joystick panels', () => {
+    const wrapper = mount(JoystickControl, {
+      props: {},
+      global: {
+        stubs: {
+          GameBlock: gameBlockStub,
+          GameSubBlock: gameSubBlockStub,
+          GameButton: gameButtonStub,
+          NintendoController: nintendoControllerStub,
+          JoystickStatusTable: joystickStatusTableStub,
+          JoystickKeybindingPanel: joystickKeybindingPanelStub,
+        },
+      },
+    })
+
+    const subBlocks = wrapper.findAll('.game-sub-block-stub')
+    expect(subBlocks.length).toEqual(2)
+    wrapper.unmount()
+  })
+
+  it('renders control grid layout', () => {
+    const wrapper = mount(JoystickControl, {
+      props: {},
+      global: {
+        stubs: {
+          GameBlock: gameBlockStub,
+          GameSubBlock: gameSubBlockStub,
+          GameButton: gameButtonStub,
+          NintendoController: nintendoControllerStub,
+          JoystickStatusTable: joystickStatusTableStub,
+          JoystickKeybindingPanel: joystickKeybindingPanelStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.control-grid').exists()).toBe(true)
+    expect(wrapper.find('.joystick-panels-row').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})

--- a/test/ide/LogLevelPanel.test.ts
+++ b/test/ide/LogLevelPanel.test.ts
@@ -1,0 +1,196 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+
+import LogLevelPanel from '@/features/ide/components/LogLevelPanel.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const { mockSetLogLevelByName, mockGetLogLevelName, mockLoggerRegistry } = vi.hoisted(() => ({
+  mockSetLogLevelByName: vi.fn(),
+  mockGetLogLevelName: vi.fn((_key: string) => 'warn'),
+  mockLoggerRegistry: [
+    { key: 'screen', name: 'Screen', description: 'Screen rendering', getLevel: () => 3, setLevel: vi.fn() },
+    { key: 'worker', name: 'Worker', description: 'Web worker', getLevel: () => 2, setLevel: vi.fn() },
+  ],
+}))
+
+vi.mock('@/shared/logger', () => ({
+  LOGGER_REGISTRY: mockLoggerRegistry,
+  LOG_LEVEL_NAMES: ['trace', 'debug', 'info', 'warn', 'error', 'silent'] as const,
+  getLogLevelName: (...args: unknown[]) => mockGetLogLevelName(...args as [string]),
+  setLogLevelByName: (...args: unknown[]) => mockSetLogLevelByName(...args as [string, string]),
+}))
+
+const gameBlockStub = defineComponent({
+  props: ['title', 'titleIcon'],
+  template: '<div class="game-block-stub" :data-title="title"><slot /><slot name="right" /></div>',
+})
+
+const gameIconStub = defineComponent({
+  props: ['icon', 'size'],
+  template: '<span class="game-icon-stub" />',
+})
+
+describe('LogLevelPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetLogLevelName.mockReturnValue('warn')
+  })
+
+  it('renders panel container', () => {
+    const wrapper = mount(LogLevelPanel, {
+      props: { open: false },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    expect(wrapper.find('.log-level-panel').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders a logger row for each entry in LOGGER_REGISTRY', () => {
+    const wrapper = mount(LogLevelPanel, {
+      props: { open: false },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    const rows = wrapper.findAll('.logger-row')
+    expect(rows.length).toEqual(mockLoggerRegistry.length)
+    wrapper.unmount()
+  })
+
+  it('displays logger name and description', () => {
+    const wrapper = mount(LogLevelPanel, {
+      props: { open: false },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    expect(wrapper.find('.logger-name').text()).toEqual('Screen')
+    expect(wrapper.find('.logger-desc').text()).toEqual('Screen rendering')
+    wrapper.unmount()
+  })
+
+  it('renders select element for each logger', () => {
+    const wrapper = mount(LogLevelPanel, {
+      props: { open: false },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    const selects = wrapper.findAll('select')
+    expect(selects.length).toEqual(mockLoggerRegistry.length)
+    wrapper.unmount()
+  })
+
+  it('renders all log level options in each select', () => {
+    const wrapper = mount(LogLevelPanel, {
+      props: { open: false },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    const firstSelect = wrapper.find('select')
+    const options = firstSelect.findAll('option')
+    expect(options.length).toEqual(6) // trace, debug, info, warn, error, silent
+    expect(options[0]!.text()).toEqual('trace')
+    expect(options[5]!.text()).toEqual('silent')
+    wrapper.unmount()
+  })
+
+  it('initializes levels from getLogLevelName on mount', () => {
+    mockGetLogLevelName.mockReturnValue('info')
+
+    mount(LogLevelPanel, {
+      props: { open: false },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    expect(mockGetLogLevelName).toHaveBeenCalledWith('screen')
+    expect(mockGetLogLevelName).toHaveBeenCalledWith('worker')
+  })
+
+  it('calls setLogLevelByName when select changes', async () => {
+    const wrapper = mount(LogLevelPanel, {
+      props: { open: false },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    const firstSelect = wrapper.find('select')
+    const selectElement = firstSelect.element as HTMLSelectElement
+    selectElement.value = 'error'
+    await firstSelect.trigger('change')
+
+    expect(mockSetLogLevelByName).toHaveBeenCalledWith('screen', 'error')
+    wrapper.unmount()
+  })
+
+  it('refreshes levels when open prop changes to true', async () => {
+    mockGetLogLevelName
+      .mockReturnValueOnce('warn')
+      .mockReturnValueOnce('warn')
+
+    const wrapper = mount(LogLevelPanel, {
+      props: { open: false },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    vi.clearAllMocks()
+
+    await wrapper.setProps({ open: true })
+    await nextTick()
+
+    expect(mockGetLogLevelName).toHaveBeenCalledWith('screen')
+    expect(mockGetLogLevelName).toHaveBeenCalledWith('worker')
+    wrapper.unmount()
+  })
+
+  it('does not refresh levels when open prop changes to false', async () => {
+    mockGetLogLevelName.mockReturnValue('warn')
+
+    const wrapper = mount(LogLevelPanel, {
+      props: { open: true },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    vi.clearAllMocks()
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+
+    expect(mockGetLogLevelName).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('has correct aria-label on select elements', () => {
+    const wrapper = mount(LogLevelPanel, {
+      props: { open: false },
+      global: {
+        stubs: { GameBlock: gameBlockStub, GameIcon: gameIconStub },
+      },
+    })
+
+    const firstSelect = wrapper.find('select')
+    expect(firstSelect.attributes('aria-label')).toEqual('ide.logLevels.ariaLabelFor')
+    wrapper.unmount()
+  })
+})

--- a/test/ide/NintendoController.test.ts
+++ b/test/ide/NintendoController.test.ts
@@ -1,0 +1,158 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+
+import NintendoController from '@/features/ide/components/NintendoController.vue'
+
+const dpadStub = defineComponent({
+  template: '<div class="dpad-stub" />',
+})
+
+const manualActionButtonStub = defineComponent({
+  props: ['button', 'active'],
+  emits: ['click'],
+  template: '<button class="action-button-stub" :data-button="button" :data-active="active" @mousedown="$emit(\'click\', button)" />',
+})
+
+describe('NintendoController', () => {
+  function createWrapper(heldButtons: Record<string, boolean> = {}) {
+    return mount(NintendoController, {
+      props: {
+        joystickId: 0,
+        heldButtons,
+      },
+      global: {
+        stubs: {
+          Dpad: dpadStub,
+          ManualActionButton: manualActionButtonStub,
+        },
+      },
+    })
+  }
+
+  it('renders controller container', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('.nintendo-controller').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders Dpad component', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('.dpad-stub').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders select and start buttons', () => {
+    const wrapper = createWrapper()
+    const buttons = wrapper.findAll('.action-button-stub')
+    const selectButton = buttons.find(b => b.attributes('data-button') === 'select')
+    const startButton = buttons.find(b => b.attributes('data-button') === 'start')
+    expect(selectButton).toBeDefined()
+    expect(startButton).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('renders A and B action buttons', () => {
+    const wrapper = createWrapper()
+    const buttons = wrapper.findAll('.action-button-stub')
+    const buttonA = buttons.find(b => b.attributes('data-button') === 'a')
+    const buttonB = buttons.find(b => b.attributes('data-button') === 'b')
+    expect(buttonA).toBeDefined()
+    expect(buttonB).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('passes active state from heldButtons to action buttons', () => {
+    const wrapper = createWrapper({
+      '0-select': true,
+      '0-start': false,
+      '0-a': true,
+      '0-b': false,
+    })
+    const buttons = wrapper.findAll('.action-button-stub')
+    const selectButton = buttons.find(b => b.attributes('data-button') === 'select')!
+    const startButton = buttons.find(b => b.attributes('data-button') === 'start')!
+    const buttonA = buttons.find(b => b.attributes('data-button') === 'a')!
+    const buttonB = buttons.find(b => b.attributes('data-button') === 'b')!
+
+    expect(selectButton.attributes('data-active')).toEqual('true')
+    expect(startButton.attributes('data-active')).toEqual('false')
+    expect(buttonA.attributes('data-active')).toEqual('true')
+    expect(buttonB.attributes('data-active')).toEqual('false')
+    wrapper.unmount()
+  })
+
+  it('emits dpadStart event from Dpad', async () => {
+    const wrapper = createWrapper()
+    const dpad = wrapper.findComponent(dpadStub)
+    dpad.vm.$emit('dpadStart', 'up')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('dpadStart')).toHaveLength(1)
+    expect(wrapper.emitted('dpadStart')![0]).toEqual(['up'])
+    wrapper.unmount()
+  })
+
+  it('emits dpadStop event from Dpad', async () => {
+    const wrapper = createWrapper()
+    const dpad = wrapper.findComponent(dpadStub)
+    dpad.vm.$emit('dpadStop', 'down')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('dpadStop')).toHaveLength(1)
+    expect(wrapper.emitted('dpadStop')![0]).toEqual(['down'])
+    wrapper.unmount()
+  })
+
+  it('emits actionButton event when action button is clicked', async () => {
+    const wrapper = createWrapper()
+    const buttons = wrapper.findAll('.action-button-stub')
+    const buttonA = buttons.find(b => b.attributes('data-button') === 'a')!
+    await buttonA.trigger('mousedown')
+
+    expect(wrapper.emitted('actionButton')).toHaveLength(1)
+    expect(wrapper.emitted('actionButton')![0]).toEqual(['a'])
+    wrapper.unmount()
+  })
+
+  it('emits actionButton event for select button', async () => {
+    const wrapper = createWrapper()
+    const buttons = wrapper.findAll('.action-button-stub')
+    const selectButton = buttons.find(b => b.attributes('data-button') === 'select')!
+    await selectButton.trigger('mousedown')
+
+    expect(wrapper.emitted('actionButton')).toHaveLength(1)
+    expect(wrapper.emitted('actionButton')![0]).toEqual(['select'])
+    wrapper.unmount()
+  })
+
+  it('uses correct joystickId for held button keys', () => {
+    const wrapper = mount(NintendoController, {
+      props: {
+        joystickId: 1,
+        heldButtons: { '1-a': true, '1-b': false },
+      },
+      global: {
+        stubs: {
+          Dpad: dpadStub,
+          ManualActionButton: manualActionButtonStub,
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('.action-button-stub')
+    const buttonA = buttons.find(b => b.attributes('data-button') === 'a')!
+    const buttonB = buttons.find(b => b.attributes('data-button') === 'b')!
+
+    expect(buttonA.attributes('data-active')).toEqual('true')
+    expect(buttonB.attributes('data-active')).toEqual('false')
+    wrapper.unmount()
+  })
+
+  it('renders select-start and action-buttons sections', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('.select-start-buttons').exists()).toBe(true)
+    expect(wrapper.find('.action-buttons').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})

--- a/test/ide/RuntimeOutput.test.ts
+++ b/test/ide/RuntimeOutput.test.ts
@@ -1,0 +1,206 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import RuntimeOutput from '@/features/ide/components/RuntimeOutput.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const gameTabsStub = defineComponent({
+  props: ['modelValue', 'type'],
+  emits: ['update:modelValue'],
+  template: '<div class="game-tabs-stub" data-testid="game-tabs"><slot /></div>',
+})
+
+const screenTabStub = defineComponent({
+  props: ['errors'],
+  template: '<div class="screen-tab-stub" data-testid="screen-tab" />',
+})
+
+const debugTabStub = defineComponent({
+  props: ['debugOutput', 'debugMode'],
+  template: '<div class="debug-tab-stub" data-testid="debug-tab" />',
+})
+
+const variablesTabStub = defineComponent({
+  props: ['variables'],
+  template: '<div class="variables-tab-stub" data-testid="variables-tab" />',
+})
+
+describe('RuntimeOutput', () => {
+  it('renders runtime output container', () => {
+    const wrapper = mount(RuntimeOutput, {
+      props: {
+        output: [],
+        isRunning: false,
+      },
+      global: {
+        stubs: {
+          GameTabs: gameTabsStub,
+          ScreenTab: screenTabStub,
+          DebugTab: debugTabStub,
+          VariablesTab: variablesTabStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.runtime-output').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders GameTabs with output-tabs class', () => {
+    const wrapper = mount(RuntimeOutput, {
+      props: {
+        output: [],
+        isRunning: false,
+      },
+      global: {
+        stubs: {
+          GameTabs: gameTabsStub,
+          ScreenTab: screenTabStub,
+          DebugTab: debugTabStub,
+          VariablesTab: variablesTabStub,
+        },
+      },
+    })
+
+    const tabs = wrapper.find('[data-testid="game-tabs"]')
+    expect(tabs.exists()).toBe(true)
+    expect(tabs.classes()).toContain('output-tabs')
+    wrapper.unmount()
+  })
+
+  it('renders ScreenTab component', () => {
+    const wrapper = mount(RuntimeOutput, {
+      props: {
+        output: [],
+        isRunning: false,
+      },
+      global: {
+        stubs: {
+          GameTabs: gameTabsStub,
+          ScreenTab: screenTabStub,
+          DebugTab: debugTabStub,
+          VariablesTab: variablesTabStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="screen-tab"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders DebugTab component', () => {
+    const wrapper = mount(RuntimeOutput, {
+      props: {
+        output: [],
+        isRunning: false,
+      },
+      global: {
+        stubs: {
+          GameTabs: gameTabsStub,
+          ScreenTab: screenTabStub,
+          DebugTab: debugTabStub,
+          VariablesTab: variablesTabStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="debug-tab"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders VariablesTab component', () => {
+    const wrapper = mount(RuntimeOutput, {
+      props: {
+        output: [],
+        isRunning: false,
+      },
+      global: {
+        stubs: {
+          GameTabs: gameTabsStub,
+          ScreenTab: screenTabStub,
+          DebugTab: debugTabStub,
+          VariablesTab: variablesTabStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="variables-tab"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('passes errors to ScreenTab', () => {
+    const errors = [{ line: 5, message: 'error', type: 'Error' }]
+    const wrapper = mount(RuntimeOutput, {
+      props: {
+        output: [],
+        isRunning: false,
+        errors,
+      },
+      global: {
+        stubs: {
+          GameTabs: gameTabsStub,
+          ScreenTab: screenTabStub,
+          DebugTab: debugTabStub,
+          VariablesTab: variablesTabStub,
+        },
+      },
+    })
+
+    const screenTab = wrapper.findComponent(screenTabStub)
+    expect(screenTab.props('errors')).toEqual(errors)
+    wrapper.unmount()
+  })
+
+  it('passes debugOutput and debugMode to DebugTab', () => {
+    const wrapper = mount(RuntimeOutput, {
+      props: {
+        output: [],
+        isRunning: false,
+        debugOutput: 'debug info',
+        debugMode: true,
+      },
+      global: {
+        stubs: {
+          GameTabs: gameTabsStub,
+          ScreenTab: screenTabStub,
+          DebugTab: debugTabStub,
+          VariablesTab: variablesTabStub,
+        },
+      },
+    })
+
+    const debugTab = wrapper.findComponent(debugTabStub)
+    expect(debugTab.props('debugOutput')).toEqual('debug info')
+    expect(debugTab.props('debugMode')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('passes variables to VariablesTab', () => {
+    const variables = { A: { value: 42, type: 0 }, B$: { value: 'hello', type: 1 } }
+    const wrapper = mount(RuntimeOutput, {
+      props: {
+        output: [],
+        isRunning: false,
+        variables: variables as never,
+      },
+      global: {
+        stubs: {
+          GameTabs: gameTabsStub,
+          ScreenTab: screenTabStub,
+          DebugTab: debugTabStub,
+          VariablesTab: variablesTabStub,
+        },
+      },
+    })
+
+    const variablesTab = wrapper.findComponent(variablesTabStub)
+    expect(variablesTab.props('variables')).toEqual(variables)
+    wrapper.unmount()
+  })
+})

--- a/test/ide/VariablesTab.test.ts
+++ b/test/ide/VariablesTab.test.ts
@@ -1,0 +1,214 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import VariablesTab from '@/features/ide/components/VariablesTab.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const gameTabPaneStub = defineComponent({
+  props: ['name', 'disabled'],
+  template: '<div class="game-tab-pane-stub" :data-name="name" :data-disabled="disabled"><slot /><slot name="label" /></div>',
+})
+
+const gameIconStub = defineComponent({
+  props: ['icon', 'size'],
+  template: '<span class="game-icon-stub" />',
+})
+
+const gameTagStub = defineComponent({
+  props: ['type', 'size'],
+  template: '<span class="game-tag-stub" :data-type="type" :data-size="size"><slot /></span>',
+})
+
+describe('VariablesTab', () => {
+  it('renders with empty variables object', () => {
+    const wrapper = mount(VariablesTab, {
+      props: { variables: {} },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.variable-list').exists()).toBe(true)
+    expect(wrapper.findAll('.variable-item').length).toEqual(0)
+    wrapper.unmount()
+  })
+
+  it('renders variable items from variables prop', () => {
+    const variables = {
+      A: { value: 42, type: 0 },
+      B$: { value: 'hello', type: 1 },
+    }
+    const wrapper = mount(VariablesTab, {
+      props: { variables: variables as never },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    const items = wrapper.findAll('.variable-item')
+    expect(items.length).toEqual(2)
+    wrapper.unmount()
+  })
+
+  it('displays variable name and value for each variable', () => {
+    const variables = {
+      X: { value: 100, type: 0 },
+      NAME$: { value: 'Test', type: 1 },
+    }
+    const wrapper = mount(VariablesTab, {
+      props: { variables: variables as never },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    const items = wrapper.findAll('.variable-item')
+    expect(items[0]!.find('.variable-name').text()).toEqual('X')
+    expect(items[0]!.find('.variable-value').text()).toEqual('100')
+    expect(items[1]!.find('.variable-name').text()).toEqual('NAME$')
+    expect(items[1]!.find('.variable-value').text()).toEqual('Test')
+    wrapper.unmount()
+  })
+
+  it('disables tab pane when no variables are present', () => {
+    const wrapper = mount(VariablesTab, {
+      props: { variables: {} },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    const tabPane = wrapper.find('.game-tab-pane-stub')
+    expect(tabPane.attributes('data-disabled')).toEqual('true')
+    wrapper.unmount()
+  })
+
+  it('enables tab pane when variables are present', () => {
+    const wrapper = mount(VariablesTab, {
+      props: { variables: { A: { value: 1, type: 0 } } as never },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    const tabPane = wrapper.find('.game-tab-pane-stub')
+    expect(tabPane.attributes('data-disabled')).toEqual('false')
+    wrapper.unmount()
+  })
+
+  it('shows correct variable count in GameTag', () => {
+    const variables = {
+      A: { value: 1, type: 0 },
+      B: { value: 2, type: 0 },
+      C: { value: 3, type: 0 },
+    }
+    const wrapper = mount(VariablesTab, {
+      props: { variables: variables as never },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    const tag = wrapper.find('.game-tag-stub')
+    expect(tag.text()).toEqual('3')
+    wrapper.unmount()
+  })
+
+  it('shows zero count in GameTag when no variables', () => {
+    const wrapper = mount(VariablesTab, {
+      props: { variables: {} },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    const tag = wrapper.find('.game-tag-stub')
+    expect(tag.text()).toEqual('0')
+    wrapper.unmount()
+  })
+
+  it('hides GameTag when no variables (tag-hidden class)', () => {
+    const wrapper = mount(VariablesTab, {
+      props: { variables: {} },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    const tag = wrapper.find('.game-tag-stub')
+    expect(tag.classes()).toContain('tag-hidden')
+    wrapper.unmount()
+  })
+
+  it('does not add tag-hidden class when variables exist', () => {
+    const wrapper = mount(VariablesTab, {
+      props: { variables: { A: { value: 1, type: 0 } } as never },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    const tag = wrapper.find('.game-tag-stub')
+    expect(tag.classes()).not.toContain('tag-hidden')
+    wrapper.unmount()
+  })
+
+  it('passes correct name prop to GameTabPane', () => {
+    const wrapper = mount(VariablesTab, {
+      props: { variables: {} },
+      global: {
+        stubs: {
+          GameTabPane: gameTabPaneStub,
+          GameIcon: gameIconStub,
+          GameTag: gameTagStub,
+        },
+      },
+    })
+
+    const tabPane = wrapper.find('.game-tab-pane-stub')
+    expect(tabPane.attributes('data-name')).toEqual('variables')
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #161

## Changes
- **11 new test files**, 104 tests covering previously untested IDE components:
  - `InputModal.test.ts` (11): dialog rendering, INPUT/LINPUT, form submission, cancel
  - `ErrorPanel.test.ts` (12): conditional rendering, line numbers, stack trace
  - `IdeControls.test.ts` (13): buttons, events, disabled states, input mode
  - `NintendoController.test.ts` (11): Dpad, action buttons, held states
  - `VariablesTab.test.ts` (10): variable rendering, computed counts, tab logic
  - `LogLevelPanel.test.ts` (10): logger rows, selects, level changes
  - `JoystickControl.test.ts` (8): panel rendering, controller instances
  - `RuntimeOutput.test.ts` (8): container rendering, tab integration
  - `DebugTab.test.ts` (7): disable logic, text rendering
  - `EditorViewToggle.test.ts` (7): toggle selection, compact mode
  - `InputModeToggle.test.ts` (7): toggle selection, compact mode

## Test plan
- [x] All 104 new tests pass
- [x] TypeScript type-check passes (0 errors)
- [x] ESLint passes (0 errors)
- [ ] CI passes

## Notes
- `Screen.vue` excluded — deep Konva/animation worker dependencies make unit testing impractical