### PR TITLE
fix: resolve #180 #181 #182 - fix review findings from PRs #174 and #178

### DIFF
--- a/src/core/samples/programs/control/conditionals.bas
+++ b/src/core/samples/programs/control/conditionals.bas
@@ -6,6 +6,8 @@
 60 IF I < 3 THEN PRINT I;" < 3"
 70 IF I > 3 THEN PRINT I;" > 3"
 80 IF I <> 3 THEN PRINT I;" <> 3"
+85 IF I <= 2 THEN PRINT I;" <= 2"
+86 IF I >= 4 THEN PRINT I;" >= 4"
 90 NEXT
 100 REM Show AND/OR logic
 110 PRINT "=== LOGIC ==="

--- a/src/core/samples/programs/music/play-demo.bas
+++ b/src/core/samples/programs/music/play-demo.bas
@@ -9,7 +9,7 @@
 90 PAUSE 30
 100 REM Eighth-note scale (faster)
 110 PRINT "Eighth notes:"
-120 PLAY "T120O2CDEFGABO3C"
+120 PLAY "T120L8O2CDEFGABO3C"
 130 PAUSE 30
 140 REM Half notes (slow)
 150 PRINT "Half notes:"

--- a/test/core/animation/bufferSpriteOperations.test.ts
+++ b/test/core/animation/bufferSpriteOperations.test.ts
@@ -23,7 +23,7 @@ import {
   readSpriteTotalDistanceFromView,
   writeSpriteStateToView,
 } from '@/core/animation/bufferSpriteOperations'
-import { MAX_SPRITES, slotBase,SPRITE_DATA_FLOATS } from '@/core/animation/sharedDisplayBuffer'
+import { MAX_SPRITES, slotBase, SPRITE_DATA_FLOATS } from '@/core/animation/sharedDisplayBuffer'
 
 function createView(): Float64Array {
   return new Float64Array(SPRITE_DATA_FLOATS)


### PR DESCRIPTION
## Summary
- Fixes #180, #181, #182

## Changes
- **play-demo.bas**: Added `L8` prefix to eighth-note section so it actually plays eighth notes instead of quarter notes
- **conditionals.bas**: Added `<=` and `>=` operator demonstrations
- **bufferSpriteOperations.test.ts**: Fixed missing space in import (`slotBase,SPRITE_DATA_FLOATS` → `slotBase, SPRITE_DATA_FLOATS`)

## Test plan
- [ ] All tests pass
- [ ] CI passes