### PR TITLE
refactor: resolve #183 - replace null as never with proper nullable typing

### DIFF
--- a/src/core/animation/bufferScreenOperations.ts
+++ b/src/core/animation/bufferScreenOperations.ts
@@ -126,7 +126,7 @@ export function writeScreenState(
   patternView: Uint8Array,
   cursorView: Uint8Array,
   scalarsView: Uint8Array,
-  screenBuffer: ScreenCell[][],
+  screenBuffer: ScreenCell[][] | null,
   cursorX: number,
   cursorY: number,
   bgPalette: number,

--- a/test/core/animation/bufferScreenOperations.test.ts
+++ b/test/core/animation/bufferScreenOperations.test.ts
@@ -235,7 +235,7 @@ describe('bufferScreenOperations', () => {
 
     it('should skip when screenBuffer is null', () => {
       expect(() =>
-        writeScreenState(charView, patternView, cursorView, scalarsView, null as never, 0, 0, 0, 0, 0, 0)
+        writeScreenState(charView, patternView, cursorView, scalarsView, null, 0, 0, 0, 0, 0, 0)
       ).not.toThrow()
     })
 


### PR DESCRIPTION
## Summary
- Fixes #183

## Changes
- **bufferScreenOperations.ts**: Changed `screenBuffer` parameter type from `ScreenCell[][]` to `ScreenCell[][] | null` to match existing null check at line 137
- **bufferScreenOperations.test.ts**: Removed `as never` cast, now passes `null` directly with proper typing

## Test plan
- [ ] All 2404 tests pass
- [ ] CI passes