### PR TITLE
feat: resolve #186 - add BGPLAY parser statement (grammar only)

### DIFF
--- a/src/core/parser/FBasicChevrotainParser.ts
+++ b/src/core/parser/FBasicChevrotainParser.ts
@@ -68,6 +68,7 @@ class FBasicChevrotainParser extends CstParser {
   declare nextStatement: () => CstNode
   declare endStatement: () => CstNode
   declare pauseStatement: () => CstNode
+  declare bgplayStatement: () => CstNode
   declare playStatement: () => CstNode
   declare beepStatement: () => CstNode
   declare ifThenStatement: () => CstNode

--- a/src/core/parser/parser-dispatcher.ts
+++ b/src/core/parser/parser-dispatcher.ts
@@ -10,6 +10,7 @@ import type { CstNode } from 'chevrotain'
 
 import {
   Beep,
+  Bgplay,
   Cgen,
   Cgset,
   Clear,
@@ -100,6 +101,7 @@ export interface DispatcherRuleDeclarations {
   nextStatement: () => CstNode
   endStatement: () => CstNode
   pauseStatement: () => CstNode
+  bgplayStatement: () => CstNode
   playStatement: () => CstNode
   beepStatement: () => CstNode
   dimStatement: () => CstNode
@@ -203,6 +205,10 @@ export function registerDispatcherRules(
       {
         GATE: () => p.LA(1).tokenType === Play,
         ALT: () => p.SUBRULE(p.playStatement),
+      },
+      {
+        GATE: () => p.LA(1).tokenType === Bgplay,
+        ALT: () => p.SUBRULE(p.bgplayStatement),
       },
       {
         GATE: () => p.LA(1).tokenType === Beep,

--- a/src/core/parser/parser-statements-core.ts
+++ b/src/core/parser/parser-statements-core.ts
@@ -2,7 +2,7 @@
  * Core Statement Parsing Rules
  *
  * Registers core F-BASIC statement grammar rules on the parser instance.
- * Includes: print, let, for/next, end, pause, play, beep, goto, gosub, return,
+ * Includes: print, let, for/next, end, pause, play, bgplay, beep, goto, gosub, return,
  * on, input, linput, swap, clear, and if/then.
  */
 
@@ -10,6 +10,7 @@ import type { CstNode } from 'chevrotain'
 
 import {
   Beep,
+  Bgplay,
   Clear,
   Comma,
   End,
@@ -73,6 +74,7 @@ export interface CoreStatementRuleDeclarations {
   nextStatement: () => CstNode
   endStatement: () => CstNode
   pauseStatement: () => CstNode
+  bgplayStatement: () => CstNode
   playStatement: () => CstNode
   beepStatement: () => CstNode
   gotoStatement: () => CstNode
@@ -187,6 +189,13 @@ export function registerCoreStatementRules(
   // Plays back music according to the sound specified by the string data
   p.playStatement = p.RULE('playStatement', () => {
     p.CONSUME(Play)
+    p.SUBRULE(p.expression) // String expression with music data
+  })
+
+  // BGPLAY StringExpression
+  // Background music playback (identical grammar to PLAY)
+  p.bgplayStatement = p.RULE('bgplayStatement', () => {
+    p.CONSUME(Bgplay)
     p.SUBRULE(p.expression) // String expression with music data
   })
 

--- a/src/core/parser/parser-tokens.ts
+++ b/src/core/parser/parser-tokens.ts
@@ -22,6 +22,8 @@ export const Next = createToken({ name: 'Next', pattern: /\bNEXT\b/i })
 export const End = createToken({ name: 'End', pattern: /\bEND\b/i })
 export const Rem = createToken({ name: 'Rem', pattern: /\bREM\b/i })
 export const Pause = createToken({ name: 'Pause', pattern: /\bPAUSE\b/i })
+// BGPLAY must come before PLAY to match the longer form first
+export const Bgplay = createToken({ name: 'Bgplay', pattern: /\bBGPLAY\b/i })
 export const Play = createToken({ name: 'Play', pattern: /\bPLAY\b/i })
 export const If = createToken({ name: 'If', pattern: /\bIF\b/i })
 export const Then = createToken({ name: 'Then', pattern: /\bTHEN\b/i })
@@ -204,6 +206,7 @@ export const allTokens = [
   End,
   Rem,
   Pause,
+  Bgplay,
   Play,
   If,
   Then,

--- a/test/core/parser/parser-statements-core.test.ts
+++ b/test/core/parser/parser-statements-core.test.ts
@@ -11,6 +11,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { getFirstCstNode } from '@/core/parser/cst-helpers'
 import { FBasicParser } from '@/core/parser/FBasicParser'
 
 describe('parser-statements-core: GOTO Statement', () => {
@@ -150,6 +151,60 @@ describe('parser-statements-core: PLAY Statement', () => {
     const result = await parser.parse('10 PLAY "C" + "D"')
     expect(result.success).toBe(true)
     expect(result.cst).toBeDefined()
+  })
+})
+
+describe('parser-statements-core: BGPLAY Statement', () => {
+  let parser: FBasicParser
+
+  beforeEach(() => {
+    parser = new FBasicParser()
+  })
+
+  it('should parse BGPLAY with string literal', async () => {
+    const result = await parser.parse('10 BGPLAY "CDEFG"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse BGPLAY with variable', async () => {
+    const result = await parser.parse('10 BGPLAY M$')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should parse BGPLAY with string concatenation', async () => {
+    const result = await parser.parse('10 BGPLAY "C" + "D"')
+    expect(result.success).toBe(true)
+    expect(result.cst).toBeDefined()
+  })
+
+  it('should reject BGPLAY without argument', async () => {
+    const result = await parser.parse('10 BGPLAY')
+    expect(result.success).toBe(false)
+    expect(result.errors).toBeDefined()
+  })
+
+  it('should distinguish BGPLAY from PLAY', async () => {
+    const bgplayResult = await parser.parse('10 BGPLAY "C"')
+    const playResult = await parser.parse('10 PLAY "C"')
+    expect(bgplayResult.success).toBe(true)
+    expect(playResult.success).toBe(true)
+    // Verify they produce different CST node names
+    // CST path: statement -> commandList -> command -> singleCommand -> bgplayStatement/playStatement
+    const bgplayCmdList = getFirstCstNode(bgplayResult.cst?.children?.statement)
+    const playCmdList = getFirstCstNode(playResult.cst?.children?.statement)
+    const bgplayCmd = getFirstCstNode(bgplayCmdList?.children?.commandList)
+    const playCmd = getFirstCstNode(playCmdList?.children?.commandList)
+    const bgplaySingle = getFirstCstNode(bgplayCmd?.children?.command)
+    const playSingle = getFirstCstNode(playCmd?.children?.command)
+    const bgplayLeaf = getFirstCstNode(bgplaySingle?.children?.singleCommand)
+    const playLeaf = getFirstCstNode(playSingle?.children?.singleCommand)
+    expect(getFirstCstNode(bgplayLeaf?.children?.bgplayStatement)).toBeDefined()
+    expect(getFirstCstNode(playLeaf?.children?.playStatement)).toBeDefined()
+    // Cross-check: BGPLAY should NOT produce playStatement and vice versa
+    expect(getFirstCstNode(bgplayLeaf?.children?.playStatement)).toBeUndefined()
+    expect(getFirstCstNode(playLeaf?.children?.bgplayStatement)).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
- Fixes #186 — adds BGPLAY as a new parser statement with identical grammar to PLAY (string expression)

## Changes
- `parser-tokens.ts`: Added `Bgplay` token with correct ordering before `Play` (longer form first)
- `parser-statements-core.ts`: Added `bgplayStatement` grammar rule (CONSUME Bgplay + SUBRULE expression)
- `parser-dispatcher.ts`: Added `bgplayStatement` to command dispatcher with GATE condition
- `FBasicChevrotainParser.ts`: Declared `bgplayStatement` rule
- `parser-statements-core.test.ts`: Added 5 BGPLAY test cases

## Test plan
- [x] All 2409 tests pass (152 test files)
- [x] ESLint passes on all changed files
- [ ] CI passes

## CST Structure
```
bgplayStatement → { Bgplay: Token[], expression: CstNode[] }
Path: statement → commandList → command → singleCommand → bgplayStatement
```

Step 1 of 5 for parent issue #179 (PLAY sync semantics and BGPLAY extension).