### PR TITLE
fix: resolve #198 - restore deleted tests and fix weakened assertions from commit a37ac53

### DIFF
--- a/src/core/parser/parse-with-chevrotain.ts
+++ b/src/core/parser/parse-with-chevrotain.ts
@@ -56,13 +56,23 @@ function checkReplOnlyCommands(cst: CstNode): Array<{ message: string; line?: nu
       return
     }
 
+    // Extract line number from NumberLiteral token in statement nodes
+    let currentLineNumber = lineNumber
+    if (cstNode.name === 'statement' && cstNode.children.NumberLiteral?.[0]) {
+      const token = cstNode.children.NumberLiteral[0] as IToken
+      const parsed = parseInt(token.image, 10)
+      if (!isNaN(parsed)) {
+        currentLineNumber = parsed
+      }
+    }
+
     // Check if this node is a REPL-only statement
     const errorMsg = REPL_ONLY_COMMANDS[cstNode.name]
     if (errorMsg && !seenErrors.has(errorMsg)) {
       seenErrors.add(errorMsg)
       errors.push({
         message: errorMsg,
-        line: lineNumber,
+        line: currentLineNumber,
         column: 1,
       })
     }
@@ -80,7 +90,7 @@ function checkReplOnlyCommands(cst: CstNode): Array<{ message: string; line?: nu
                 seenErrors.add(funcError)
                 errors.push({
                   message: funcError,
-                  line: lineNumber,
+                  line: currentLineNumber,
                   column: 1,
                 })
               }
@@ -98,7 +108,7 @@ function checkReplOnlyCommands(cst: CstNode): Array<{ message: string; line?: nu
           if (child && typeof child === 'object') {
             if ('name' in child) {
               // It's a CST node - recurse
-              traverse(child, lineNumber)
+              traverse(child, currentLineNumber)
             }
             // Token objects don't need recursion
           }

--- a/src/features/ide/composables/usePerformanceDiagnosticsMetrics.ts
+++ b/src/features/ide/composables/usePerformanceDiagnosticsMetrics.ts
@@ -71,6 +71,7 @@ export function usePerformanceDiagnosticsMetrics({
   let metricsInterval: number | null = null
   let fpsRafId: number | null = null
   let workerStartTime = 0
+  let lastRenderSampleAt: number | null = null
 
   const workerTimePercent = computed(() =>
     totalTime.value === 0 ? 0 : Math.round((workerTime.value / totalTime.value) * 100)
@@ -121,6 +122,7 @@ export function usePerformanceDiagnosticsMetrics({
     lastMetricsUpdate = startTime
     code.value = PERFORMANCE_TEST_SCENARIOS[scenario]
     workerStartTime = performance.now()
+    lastRenderSampleAt = null
     await runCode()
   }
 
@@ -135,6 +137,7 @@ export function usePerformanceDiagnosticsMetrics({
     rendersPerSecond.value = 0
     fps.value = 0
     output.value = []
+    lastRenderSampleAt = null
   }
 
   let measurementActive = false
@@ -149,6 +152,7 @@ export function usePerformanceDiagnosticsMetrics({
         performance.clearMeasures()
         measurementActive = true
         workerStartTime = performance.now()
+        lastRenderSampleAt = null
       } else if (!running && wasRunning) {
         measurementActive = false
         if (workerStartTime > 0) {
@@ -171,7 +175,16 @@ export function usePerformanceDiagnosticsMetrics({
   watch(
     () => screenBuffer.value,
     () => {
-      if (measurementActive) {
+      if (measurementActive && renderingEnabled.value) {
+        const now = performance.now()
+        const targetFps = Number.isFinite(renderFpsTarget.value) && renderFpsTarget.value > 0
+          ? renderFpsTarget.value
+          : 60
+        const minIntervalMs = 1000 / targetFps
+        if (lastRenderSampleAt !== null && now - lastRenderSampleAt < minIntervalMs) {
+          return
+        }
+        lastRenderSampleAt = now
         performance.mark(`render-start-${renderSequence}`)
         renderCount++
         requestAnimationFrame(() => {

--- a/test/demo/PauseDemo.test.ts
+++ b/test/demo/PauseDemo.test.ts
@@ -5,20 +5,14 @@
  * PAUSE command usage with countdown and timing delays.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BasicInterpreter } from '@/core/BasicInterpreter'
 import type { BasicDeviceAdapter } from '@/core/interfaces'
 import { FBasicParser } from '@/core/parser/FBasicParser'
 import { getSampleCode } from '@/core/samples'
 
-// Skip by default - this test takes a long time due to PAUSE delays
-// To run manually:
-//   - Remove .skip() temporarily, OR
-//   - Set RUN_PAUSE_DEMO_TESTS=true pnpm test:run -- test/parser/PauseDemo.test.ts
-const shouldRunPauseDemoTests = process.env.RUN_PAUSE_DEMO_TESTS === 'true'
-
-describe.skipIf(!shouldRunPauseDemoTests)('Pause Demo Program', () => {
+describe('Pause Demo Program', () => {
   let interpreter: BasicInterpreter
   let mockDeviceAdapter: BasicDeviceAdapter
   let printOutputMock: ReturnType<typeof vi.fn<(output: string) => void>>
@@ -56,6 +50,40 @@ describe.skipIf(!shouldRunPauseDemoTests)('Pause Demo Program', () => {
     })
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  async function executeWithCapturedTimeouts(code: string): Promise<{
+    durations: number[]
+    result: Awaited<ReturnType<BasicInterpreter['execute']>>
+  }> {
+    const durations: number[] = []
+
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((callback: TimerHandler, delay?: number) => {
+      durations.push(typeof delay === 'number' ? delay : 0)
+      if (typeof callback === 'function') {
+        callback()
+      }
+      return {} as ReturnType<typeof setTimeout>
+    })
+
+    const result = await interpreter.execute(code)
+    expect(result.success).toBe(true)
+    expect(result.errors).toHaveLength(0)
+
+    return {
+      result,
+      durations: durations.filter((duration) => duration > 1),
+    }
+  }
+
+  function getPrintedLines(): string[] {
+    return printOutputMock.mock.calls
+      .map(call => call[0].trim().replace(/\s+/g, ' '))
+      .filter(call => call.length > 0)
+  }
+
   const pauseDemoCode = getSampleCode('pause')?.code
   if (!pauseDemoCode) {
     throw new Error('Pause demo code not found')
@@ -72,7 +100,8 @@ describe.skipIf(!shouldRunPauseDemoTests)('Pause Demo Program', () => {
       // Verify all statements are parsed
       const statements = result.cst?.children.statement
       expect(Array.isArray(statements)).toBe(true)
-      expect(statements?.length).toBe(10) // 10 lines (10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
+      // Current pause.bas has 33 lines (10-330)
+      expect(statements?.length).toBe(33)
     })
 
     it('should parse PAUSE statements correctly', async () => {
@@ -94,73 +123,75 @@ describe.skipIf(!shouldRunPauseDemoTests)('Pause Demo Program', () => {
 
   describe('Execution Tests', () => {
     it('should execute the complete pause demo program', async () => {
-      const result = await interpreter.execute(pauseDemoCode)
+      const { durations } = await executeWithCapturedTimeouts(pauseDemoCode)
 
-      // Check for errors first
-      if (!result.success || result.errors.length > 0) {
-        console.log('Execution errors:', result.errors)
-        console.log('Print calls:', printOutputMock.mock.calls.length)
-        console.log(
-          'Print outputs:',
-          printOutputMock.mock.calls.map(c => c[0])
-        )
-      }
+      // Current pause.bas has:
+      // 5x PAUSE 80 + 1x PAUSE 50 + 5x PAUSE 30 + 1x PAUSE 50 + 1x PAUSE 50 + 1x PAUSE 250 = 14 pauses
+      // PAUSE 0 has durationMs = 0 so it is filtered out (> 1 check)
+      expect(durations).toHaveLength(14)
 
-      // Program should execute successfully
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
+      // PAUSE 80: (80 * 33.33) / 2.75 = 969.45ms each (5 of these)
+      expect(durations.filter((d) => Math.abs(d - 969.45) < 1)).toHaveLength(5)
+
+      // PAUSE 50: (50 * 33.33) / 2.75 = 606.06ms each (3 of these)
+      expect(durations.filter((d) => Math.abs(d - 606.06) < 1)).toHaveLength(3)
+
+      // PAUSE 30: (30 * 33.33) / 2.75 = 363.63ms each (5 of these)
+      expect(durations.filter((d) => Math.abs(d - 363.63) < 1)).toHaveLength(5)
+
+      // PAUSE 250: (250 * 33.33) / 2.75 = 3030.30ms (1 of these)
+      expect(durations.some((d) => Math.abs(d - 3030.30) < 1)).toBe(true)
     })
 
     it('should produce correct output sequence', async () => {
-      const result = await interpreter.execute(pauseDemoCode)
+      await executeWithCapturedTimeouts(pauseDemoCode)
 
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
+      const calls = getPrintedLines()
 
-      // Verify all PRINT statements executed
-      // Line 10: "PAUSE Command Demo"
-      // Line 20: "Starting countdown..."
-      // Line 40: "Countdown: "; I (5 times: 5, 4, 3, 2, 1)
-      // Line 70: "Blast off!"
-      // Line 90: "Mission complete!"
-      // Total: 2 + 5 + 1 + 1 = 9 PRINT calls
-      expect(printOutputMock).toHaveBeenCalledTimes(9)
+      // Verify section headers
+      expect(calls[0]).toBe('=== COUNTDOWN ===')
+      expect(calls[1]).toBe('Countdown: 5')
+      expect(calls[2]).toBe('Countdown: 4')
+      expect(calls[3]).toBe('Countdown: 3')
+      expect(calls[4]).toBe('Countdown: 2')
+      expect(calls[5]).toBe('Countdown: 1')
+      expect(calls[6]).toBe('Blast off!')
 
-      // Verify the output order and content
-      const calls = printOutputMock.mock.calls.map(call => call[0])
+      // Short pause section
+      expect(calls[7]).toBe('=== SHORT PAUSE ===')
+      expect(calls[8]).toBe('Quick dots...')
+      expect(calls[9]).toBe('.')
+      expect(calls[10]).toBe('.')
+      expect(calls[11]).toBe('.')
+      expect(calls[12]).toBe('.')
+      expect(calls[13]).toBe('.')
 
-      // First two PRINT statements
-      expect(calls[0]).toBe('PAUSE Command Demo')
-      expect(calls[1]).toBe('Starting countdown...')
+      // Wait for keypress section
+      expect(calls[14]).toBe('=== WAIT FOR KEYPRESS ===')
+      expect(calls[15]).toBe('PAUSE 0 waits for a key...')
+      expect(calls[16]).toBe('You pressed a key!')
 
-      // Countdown outputs (I=5, 4, 3, 2, 1)
-      // PRINT "Countdown:"; I outputs "Countdown: 5" etc. (semicolon concatenates, number gets leading space)
-      expect(calls[2]).toEqual('Countdown: 5')
-      expect(calls[3]).toEqual('Countdown: 4')
-      expect(calls[4]).toEqual('Countdown: 3')
-      expect(calls[5]).toEqual('Countdown: 2')
-      expect(calls[6]).toEqual('Countdown: 1')
+      // Long pause section
+      expect(calls[17]).toBe('=== LONG PAUSE ===')
+      expect(calls[18]).toBe('Waiting 3 seconds...')
+      expect(calls[19]).toBe('Done!')
 
-      // Final outputs
-      expect(calls[7]).toBe('Blast off!')
-      expect(calls[8]).toBe('Mission complete!')
+      // OK prompt after successful execution
+      expect(calls[calls.length - 1]).toBe('OK')
     })
 
     it('should execute FOR loop with negative STEP correctly', async () => {
-      const result = await interpreter.execute(pauseDemoCode)
+      const { result } = await executeWithCapturedTimeouts(pauseDemoCode)
 
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
-
-      // After loop completion, I should be 0 (1 - 1 = 0, but loop exits when I < 1)
-      // Actually, in Family Basic, after NEXT when I becomes 0, the loop exits
-      // So I should be 0 after the loop
+      // The current pause.bas has two FOR I loops:
+      // 1. FOR I = 5 TO 1 STEP -1 (countdown) - exits when I becomes 0
+      // 2. FOR I = 1 TO 5 (short pause dots) - exits when I becomes 6
+      // After both loops complete, I = 6 (from the second loop)
       const iValue = result.variables.get('I')?.value
-      expect(iValue).toBe(0) // After loop: I = 1, then NEXT decrements to 0, loop exits
+      expect(iValue).toBe(6)
     })
 
     it('should include PAUSE delays in execution', async () => {
-      // Use shorter delays for faster test execution
       const codeWithShortDelays = `10 PRINT "Start"
 20 PAUSE 10
 30 PRINT "Middle"
@@ -168,23 +199,17 @@ describe.skipIf(!shouldRunPauseDemoTests)('Pause Demo Program', () => {
 50 PRINT "End"
 60 END`
 
-      const startTime = Date.now()
-      const result = await interpreter.execute(codeWithShortDelays)
-      const endTime = Date.now()
+      const { durations } = await executeWithCapturedTimeouts(codeWithShortDelays)
+      expect(durations).toEqual([
+        expect.closeTo(121.21, 1),
+        expect.closeTo(242.42, 1),
+      ])
 
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
-
-      // Verify execution took at least the pause duration
-      // (10ms + 20ms = 30ms minimum, but allow some margin)
-      expect(endTime - startTime).toBeGreaterThanOrEqual(25)
-
-      // Verify outputs
-      expect(printOutputMock).toHaveBeenCalledTimes(3)
-      const calls = printOutputMock.mock.calls.map(call => call[0])
+      const calls = getPrintedLines()
       expect(calls[0]).toBe('Start')
       expect(calls[1]).toBe('Middle')
       expect(calls[2]).toBe('End')
+      expect(calls[3]).toBe('OK')
     })
 
     it('should handle PAUSE with expressions', async () => {
@@ -194,21 +219,13 @@ describe.skipIf(!shouldRunPauseDemoTests)('Pause Demo Program', () => {
 40 PRINT "Done"
 50 END`
 
-      const startTime = Date.now()
-      const result = await interpreter.execute(code)
-      const endTime = Date.now()
+      const { durations } = await executeWithCapturedTimeouts(code)
+      expect(durations).toEqual([expect.closeTo(606.06, 1)])
 
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
-
-      // Verify execution took at least the pause duration
-      expect(endTime - startTime).toBeGreaterThanOrEqual(45)
-
-      // Verify outputs
-      expect(printOutputMock).toHaveBeenCalledTimes(2)
-      const calls = printOutputMock.mock.calls.map(call => call[0])
+      const calls = getPrintedLines()
       expect(calls[0]).toBe('Pausing...')
       expect(calls[1]).toBe('Done')
+      expect(calls[2]).toBe('OK')
     })
 
     it('should handle multiple PAUSE statements in sequence', async () => {
@@ -221,55 +238,39 @@ describe.skipIf(!shouldRunPauseDemoTests)('Pause Demo Program', () => {
 70 PRINT "Done"
 80 END`
 
-      const startTime = Date.now()
-      const result = await interpreter.execute(code)
-      const endTime = Date.now()
+      const { durations } = await executeWithCapturedTimeouts(code)
+      expect(durations).toHaveLength(3)
+      expect(durations.every((duration) => Math.abs(duration - 121.21) < 1)).toBe(true)
 
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
-
-      // Verify execution took at least the total pause duration
-      expect(endTime - startTime).toBeGreaterThanOrEqual(25)
-
-      // Verify all outputs
-      expect(printOutputMock).toHaveBeenCalledTimes(4)
+      const calls = getPrintedLines()
+      expect(calls).toHaveLength(5)
+      expect(calls[4]).toBe('OK')
     })
 
     it('should handle PAUSE in FOR loop correctly', async () => {
-      // Test that PAUSE works correctly inside a loop
       const code = `10 FOR J = 1 TO 3
 20   PRINT "Loop "; J
 30   PAUSE 10
-40 NEXT J
+40 NEXT
 50 PRINT "Loop complete"
 60 END`
 
-      const startTime = Date.now()
-      const result = await interpreter.execute(code)
-      const endTime = Date.now()
+      const { durations } = await executeWithCapturedTimeouts(code)
+      expect(durations).toHaveLength(3)
+      expect(durations.every((duration) => Math.abs(duration - 121.21) < 1)).toBe(true)
 
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
-
-      // Verify execution took at least the total pause duration (3 * 10ms = 30ms)
-      expect(endTime - startTime).toBeGreaterThanOrEqual(25)
-
-      // Verify outputs: 3 loop prints + 1 final print = 4 total
-      expect(printOutputMock).toHaveBeenCalledTimes(4)
-
-      const calls = printOutputMock.mock.calls.map(call => call[0])
-      // PRINT "Loop"; I outputs "Loop 1" etc. (semicolon concatenates, number gets leading space)
+      // Verify outputs: 3 loop prints + 1 final print + final OK.
+      const calls = getPrintedLines()
+      expect(calls).toHaveLength(5)
       expect(calls[0]).toEqual('Loop 1')
       expect(calls[1]).toEqual('Loop 2')
       expect(calls[2]).toEqual('Loop 3')
       expect(calls[3]).toBe('Loop complete')
+      expect(calls[4]).toBe('OK')
     })
 
     it('should handle END statement correctly', async () => {
-      const result = await interpreter.execute(pauseDemoCode)
-
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
+      await executeWithCapturedTimeouts(pauseDemoCode)
 
       // Program should complete without errors
       // END statement should stop execution
@@ -283,17 +284,12 @@ describe.skipIf(!shouldRunPauseDemoTests)('Pause Demo Program', () => {
 30 PRINT "After"
 40 END`
 
-      const startTime = Date.now()
-      const result = await interpreter.execute(code)
-      const endTime = Date.now()
+      const { durations } = await executeWithCapturedTimeouts(code)
+      expect(durations).toHaveLength(0)
 
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
-
-      // PAUSE 0 should not cause significant delay
-      expect(endTime - startTime).toBeLessThan(50)
-
-      expect(printOutputMock).toHaveBeenCalledTimes(2)
+      const calls = getPrintedLines()
+      expect(calls).toHaveLength(3)
+      expect(calls[2]).toBe('OK')
     })
 
     it('should handle PAUSE with negative value (no delay)', async () => {
@@ -302,17 +298,12 @@ describe.skipIf(!shouldRunPauseDemoTests)('Pause Demo Program', () => {
 30 PRINT "After"
 40 END`
 
-      const startTime = Date.now()
-      const result = await interpreter.execute(code)
-      const endTime = Date.now()
+      const { durations } = await executeWithCapturedTimeouts(code)
+      expect(durations).toHaveLength(0)
 
-      expect(result.success).toBe(true)
-      expect(result.errors).toHaveLength(0)
-
-      // Negative PAUSE should not cause delay
-      expect(endTime - startTime).toBeLessThan(50)
-
-      expect(printOutputMock).toHaveBeenCalledTimes(2)
+      const calls = getPrintedLines()
+      expect(calls).toHaveLength(3)
+      expect(calls[2]).toBe('OK')
     })
   })
 })

--- a/test/ide/usePerformanceDiagnosticsMetrics.test.ts
+++ b/test/ide/usePerformanceDiagnosticsMetrics.test.ts
@@ -22,14 +22,20 @@ describe('usePerformanceDiagnosticsMetrics', () => {
     vi.unstubAllGlobals()
   })
 
-  function mountHarness() {
+  function mountHarness(): {
+    wrapper: ReturnType<typeof mount>
+    api: DiagnosticsApi
+    isRunning: { value: boolean }
+    output: { value: string[] }
+    screenBuffer: { value: Record<string, unknown> }
+  } {
     const code = ref('')
     const isRunning = ref(false)
     const output = ref<string[]>([])
     const screenBuffer = ref({})
     const runCode = vi.fn(async () => {})
 
-    let api!: DiagnosticsApi
+    let api: DiagnosticsApi | null = null
 
     const harnessComponent = defineComponent({
       setup() {
@@ -48,12 +54,14 @@ describe('usePerformanceDiagnosticsMetrics', () => {
     if (!api) {
       throw new Error('failed to initialize diagnostics metrics harness')
     }
+    const metricsApi = api as ReturnType<typeof usePerformanceDiagnosticsMetrics>
 
     return {
       wrapper,
-      api,
+      api: metricsApi,
       isRunning,
       output,
+      screenBuffer,
     }
   }
 
@@ -86,6 +94,51 @@ describe('usePerformanceDiagnosticsMetrics', () => {
     vi.advanceTimersByTime(100)
 
     expect(api.messagesPerSecond.value).toBe(2)
+    wrapper.unmount()
+  })
+
+  it('does not count renders when rendering is disabled', async () => {
+    const { wrapper, api, isRunning, screenBuffer } = mountHarness()
+
+    isRunning.value = true
+    await nextTick()
+    api.renderingEnabled.value = false
+
+    screenBuffer.value = { frame: 1 }
+    await nextTick()
+
+    now = 1000
+    vi.advanceTimersByTime(100)
+
+    expect(api.rendersPerSecond.value).toBe(0)
+    wrapper.unmount()
+  })
+
+  it('throttles render metrics to renderFpsTarget', async () => {
+    const { wrapper, api, isRunning, screenBuffer } = mountHarness()
+
+    isRunning.value = true
+    await nextTick()
+    api.renderingEnabled.value = true
+    api.renderFpsTarget.value = 10
+
+    now = 0
+    screenBuffer.value = { frame: 1 }
+    await nextTick()
+    now = 20
+    screenBuffer.value = { frame: 2 }
+    await nextTick()
+    now = 50
+    screenBuffer.value = { frame: 3 }
+    await nextTick()
+    now = 100
+    screenBuffer.value = { frame: 4 }
+    await nextTick()
+
+    now = 1000
+    vi.advanceTimersByTime(100)
+
+    expect(api.rendersPerSecond.value).toBe(2)
     wrapper.unmount()
   })
 })

--- a/test/integration/SharedJoystickBufferIntegration.test.ts
+++ b/test/integration/SharedJoystickBufferIntegration.test.ts
@@ -171,10 +171,10 @@ describe('Shared Joystick Buffer Integration', () => {
 
       // Relative threshold avoids flaky absolute wall-clock assumptions while still
       // detecting major overhead regressions (e.g., accidental messaging/sync work).
-      // Using 20x multiplier to tolerate CI environment timing variance while still
+      // Using 12x multiplier to tolerate CI environment timing variance while still
       // catching major regressions (setStickState should be ~same speed as direct write).
       const baselineFloorMs = Math.max(baselineDuration, 0.5)
-      expect(setStickStateDuration).toBeLessThanOrEqual(baselineFloorMs * 20)
+      expect(setStickStateDuration).toBeLessThanOrEqual(baselineFloorMs * 12)
     })
 
     it('should support concurrent read/write (same joystick)', () => {

--- a/test/parser/ReplOnlyCommands.test.ts
+++ b/test/parser/ReplOnlyCommands.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect,test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 import { parseWithChevrotain } from '@/core/parser/FBasicChevrotainParser'
+import { FBasicParser } from '@/core/parser/FBasicParser'
 
 describe('REPL-only Commands Parser', () => {
   // REPL-only commands that should parse but produce errors
@@ -88,6 +89,33 @@ describe('REPL-only Commands Parser', () => {
     expect(result.success).toBe(true)
     expect(result.cst).toBeDefined()
     expect(result.errors).toBeUndefined()
+  })
+
+  test('includes concrete line number for LIST diagnostic', () => {
+    const result = parseWithChevrotain('10 LIST')
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0]?.message).toBe('LIST: Not applicable for IDE version')
+    expect(result.errors?.[0]?.line).toBe(10)
+    expect(result.errors?.[0]?.column).toBe(1)
+  })
+
+  test('includes concrete line number for PEEK diagnostic', () => {
+    const result = parseWithChevrotain('120 A=PEEK(&H7000)')
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0]?.message).toBe('PEEK: Not applicable for IDE version')
+    expect(result.errors?.[0]?.line).toBe(120)
+    expect(result.errors?.[0]?.column).toBe(1)
+  })
+
+  test('parser error message never reports line undefined', async () => {
+    const parser = new FBasicParser()
+    const result = await parser.parse('10 LIST')
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0]?.message).toContain('(line 10, col 1)')
+    expect(result.errors?.[0]?.message).not.toContain('line undefined')
   })
 
   // INKEY$ is now a fully implemented function (GitHub issue #4)


### PR DESCRIPTION
## Summary
- Fixes #198 — restores 5 deleted tests and fixes 2 weakened assertions from commit a37ac53

## Changes

### Source fixes (2 files)
- `src/core/parser/parse-with-chevrotain.ts` — Fixed `checkReplOnlyCommands()` to extract F-BASIC line numbers from CST tokens, enabling diagnostic line/column info for REPL-only command errors
- `src/features/ide/composables/usePerformanceDiagnosticsMetrics.ts` — Restored `renderingEnabled` gate and `renderFpsTarget` throttle logic in screen buffer watcher

### Test restorations (4 files)
- `test/parser/ReplOnlyCommands.test.ts` — Restored 3 diagnostic tests (LIST/PEEK line numbers, undefined line guard)
- `test/ide/usePerformanceDiagnosticsMetrics.test.ts` — Restored 2 tests (render disabled = 0 FPS, FPS throttle respects target)
- `test/demo/PauseDemo.test.ts` — Re-instantiated deterministic testing via setTimeout mocking, removed skipIf wrapper
- `test/integration/SharedJoystickBufferIntegration.test.ts` — Tightened performance threshold from `* 20` to `* 12`

## Test plan
- [x] All 2422 tests pass across 153 test files
- [x] TypeScript type-check passes
- [x] ESLint passes