### PR TITLE
fix: resolve #204 - remap Run hotkey from F5 to Ctrl+Enter

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -206,7 +206,7 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
     id: 'run.start',
     title: 'Run Program',
     description: 'Execute the current BASIC program.',
-    shortcut: 'F5',
+    shortcut: 'Ctrl+Enter / Cmd+Enter',
     keywords: ['execute', 'start', 'run'],
     enabled: !isRunning.value,
     execute: () => {
@@ -217,7 +217,7 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
     id: 'run.stop',
     title: 'Stop Program',
     description: 'Stop the currently running program.',
-    shortcut: 'Shift+F5',
+    shortcut: 'Ctrl+Shift+Enter / Cmd+Shift+Enter',
     keywords: ['halt', 'stop'],
     enabled: isRunning.value,
     execute: stopCode,
@@ -226,7 +226,7 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
     id: 'run.restart',
     title: 'Restart Program',
     description: 'Stop and execute the current program again.',
-    shortcut: 'Ctrl+Shift+F5 / Cmd+Shift+F5',
+    shortcut: 'Ctrl+Shift+R / Cmd+Shift+R',
     keywords: ['restart', 'rerun'],
     execute: () => {
       void restartCode()
@@ -326,19 +326,19 @@ function handleGlobalKeydown(e: KeyboardEvent) {
 
   if (commandPaletteOpen.value || isEditableTarget(e.target)) return
 
-  if (matchesAnyShortcut(e, ['F5'])) {
+  if (matchesAnyShortcut(e, ['Ctrl+Enter', 'Meta+Enter'])) {
     e.preventDefault()
     void runCode()
     return
   }
 
-  if (matchesAnyShortcut(e, ['Shift+F5'])) {
+  if (matchesAnyShortcut(e, ['Ctrl+Shift+Enter', 'Meta+Shift+Enter'])) {
     e.preventDefault()
     stopCode()
     return
   }
 
-  if (matchesAnyShortcut(e, ['Ctrl+Shift+F5', 'Meta+Shift+F5'])) {
+  if (matchesAnyShortcut(e, ['Ctrl+Shift+R', 'Meta+Shift+R'])) {
     e.preventDefault()
     void restartCode()
     return

--- a/test/ide/commandPalette.test.ts
+++ b/test/ide/commandPalette.test.ts
@@ -47,7 +47,7 @@ describe('commandPalette helpers', () => {
   })
 
   it('supports multiple shortcut variants', () => {
-    const restartEvent = new KeyboardEvent('keydown', { key: 'F5', metaKey: true, shiftKey: true })
-    expect(matchesAnyShortcut(restartEvent, ['Ctrl+Shift+F5', 'Meta+Shift+F5'])).toBe(true)
+    const restartEvent = new KeyboardEvent('keydown', { key: 'r', metaKey: true, shiftKey: true })
+    expect(matchesAnyShortcut(restartEvent, ['Ctrl+Shift+R', 'Meta+Shift+R'])).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #204

## Changes
- Run: F5 → Ctrl+Enter / Cmd+Enter
- Stop: Shift+F5 → Ctrl+Shift+Enter / Cmd+Shift+Enter
- Restart: Ctrl+Shift+F5 → Ctrl+Shift+R / Cmd+Shift+R
- Updated CommandPalette shortcut labels to match
- Updated commandPalette test to use new restart shortcut

## Test plan
- [x] Targeted tests pass (2427 tests, 153 files)
- [ ] CI passes