### PR TITLE
fix: resolve #210 - add i18n support to KonvaSpriteTestPage

### DIFF
--- a/src/features/konva-test/KonvaSpriteTestPage.vue
+++ b/src/features/konva-test/KonvaSpriteTestPage.vue
@@ -2,6 +2,7 @@
 import Konva from 'konva'
 import type { Ref } from 'vue'
 import { computed, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import type { MovementState } from '@/core/sprite/types'
 import { GameButton, GameLayout, GameSelect, GameSwitch } from '@/shared/components/ui'
@@ -15,6 +16,8 @@ defineOptions({
   name: 'KonvaSpriteTestPage',
 })
 
+const { t } = useI18n()
+
 const CANVAS_WIDTH = 256
 const CANVAS_HEIGHT = 240
 
@@ -25,25 +28,25 @@ const showBackgroundItems = ref<boolean>(true)
 const randomBgChange = ref<boolean>(true)
 
 // Speed options (speed value: 60/speed = dots per second)
-const speedOptions = [
-  { label: 'Very Slow (5)', value: 5 },
-  { label: 'Slow (8)', value: 8 },
-  { label: 'Normal (10)', value: 10 },
-  { label: 'Fast (12)', value: 12 },
-  { label: 'Very Fast (15)', value: 15 },
-  { label: 'Ultra Fast (20)', value: 20 },
-]
+const speedOptions = computed(() => [
+  { label: t('konvaTest.speedVerySlow', { value: 5 }), value: 5 },
+  { label: t('konvaTest.speedSlow', { value: 8 }), value: 8 },
+  { label: t('konvaTest.speedNormal', { value: 10 }), value: 10 },
+  { label: t('konvaTest.speedFast', { value: 12 }), value: 12 },
+  { label: t('konvaTest.speedVeryFast', { value: 15 }), value: 15 },
+  { label: t('konvaTest.speedUltraFast', { value: 20 }), value: 20 },
+])
 
 // Count options
-const countOptions = [
-  { label: '1 Sprite', value: 1 },
-  { label: '2 Sprites', value: 2 },
-  { label: '4 Sprites', value: 4 },
-  { label: '6 Sprites', value: 6 },
-  { label: '8 Sprites', value: 8 },
-  { label: '12 Sprites', value: 12 },
-  { label: '16 Sprites', value: 16 },
-]
+const countOptions = computed(() => [
+  { label: t('konvaTest.spriteCountLabel', { count: 1 }), value: 1 },
+  { label: t('konvaTest.spriteCountLabel', { count: 2 }), value: 2 },
+  { label: t('konvaTest.spriteCountLabel', { count: 4 }), value: 4 },
+  { label: t('konvaTest.spriteCountLabel', { count: 6 }), value: 6 },
+  { label: t('konvaTest.spriteCountLabel', { count: 8 }), value: 8 },
+  { label: t('konvaTest.spriteCountLabel', { count: 12 }), value: 12 },
+  { label: t('konvaTest.spriteCountLabel', { count: 16 }), value: 16 },
+])
 
 const movements = ref<MovementState[]>(generateMovements(8, 10))
 const spriteRefs = ref<Map<number, Konva.Image>>(new Map())
@@ -124,17 +127,17 @@ onUnmounted(() => {
   <GameLayout>
     <div class="konva-test-page">
       <div class="test-header">
-        <h1>Konva Sprite Animation Test</h1>
-        <p>Testing Konva.js for sprite animation with Family BASIC sprites</p>
+        <h1>{{ t('konvaTest.title') }}</h1>
+        <p>{{ t('konvaTest.description') }}</p>
         <div class="test-info">
-          <p><strong>Movements:</strong> {{ movements.length }}</p>
-          <p><strong>Note:</strong> Simplified animation; full animation is handled by Animation Worker</p>
+          <p><strong>{{ t('konvaTest.movements') }}</strong> {{ movements.length }}</p>
+          <p><strong>{{ t('konvaTest.note') }}</strong> {{ t('konvaTest.noteMessage') }}</p>
         </div>
       </div>
 
       <div class="test-controls">
         <div class="control-group">
-          <label class="control-label">Sprite Count:</label>
+          <label class="control-label">{{ t('konvaTest.spriteCount') }}</label>
           <GameSelect
             :model-value="spriteCount"
             :options="countOptions"
@@ -144,7 +147,7 @@ onUnmounted(() => {
           />
         </div>
         <div class="control-group">
-          <label class="control-label">Speed:</label>
+          <label class="control-label">{{ t('konvaTest.speed') }}</label>
           <GameSelect
             :model-value="spriteSpeed"
             :options="speedOptions"
@@ -154,7 +157,7 @@ onUnmounted(() => {
           />
         </div>
         <div class="control-group">
-          <label class="control-label">Background:</label>
+          <label class="control-label">{{ t('konvaTest.background') }}</label>
           <GameSwitch
             :model-value="showBackgroundItems"
             size="small"
@@ -162,7 +165,7 @@ onUnmounted(() => {
           />
         </div>
         <div class="control-group">
-          <label class="control-label">Random BG Change:</label>
+          <label class="control-label">{{ t('konvaTest.randomBgChange') }}</label>
           <GameSwitch
             :model-value="randomBgChange"
             size="small"
@@ -171,10 +174,10 @@ onUnmounted(() => {
           />
         </div>
         <GameButton type="primary" size="small" @click="initializeSprites">
-          Reinitialize
+          {{ t('konvaTest.reinitialize') }}
         </GameButton>
         <GameButton type="default" size="small" @click="resetMovements">
-          Reset
+          {{ t('konvaTest.reset') }}
         </GameButton>
       </div>
 

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -10,6 +10,7 @@ import enDiagnostics from './locales/en/diagnostics.json'
 import enHome from './locales/en/home.json'
 import enIde from './locales/en/ide.json'
 import enImageAnalyzer from './locales/en/image-analyzer.json'
+import enKonvaTest from './locales/en/konva-test.json'
 import enMonacoEditor from './locales/en/monaco-editor.json'
 import enNavigation from './locales/en/navigation.json'
 import enSoundTest from './locales/en/sound-test.json'
@@ -22,6 +23,7 @@ import jaDiagnostics from './locales/ja/diagnostics.json'
 import jaHome from './locales/ja/home.json'
 import jaIde from './locales/ja/ide.json'
 import jaImageAnalyzer from './locales/ja/image-analyzer.json'
+import jaKonvaTest from './locales/ja/konva-test.json'
 import jaMonacoEditor from './locales/ja/monaco-editor.json'
 import jaNavigation from './locales/ja/navigation.json'
 import jaSoundTest from './locales/ja/sound-test.json'
@@ -34,6 +36,7 @@ import zhCNDiagnostics from './locales/zh-CN/diagnostics.json'
 import zhCNHome from './locales/zh-CN/home.json'
 import zhCNIde from './locales/zh-CN/ide.json'
 import zhCNImageAnalyzer from './locales/zh-CN/image-analyzer.json'
+import zhCNKonvaTest from './locales/zh-CN/konva-test.json'
 import zhCNMonacoEditor from './locales/zh-CN/monaco-editor.json'
 import zhCNNavigation from './locales/zh-CN/navigation.json'
 import zhCNSoundTest from './locales/zh-CN/sound-test.json'
@@ -46,6 +49,7 @@ import zhTWDiagnostics from './locales/zh-TW/diagnostics.json'
 import zhTWHome from './locales/zh-TW/home.json'
 import zhTWIde from './locales/zh-TW/ide.json'
 import zhTWImageAnalyzer from './locales/zh-TW/image-analyzer.json'
+import zhTWKonvaTest from './locales/zh-TW/konva-test.json'
 import zhTWMonacoEditor from './locales/zh-TW/monaco-editor.json'
 import zhTWNavigation from './locales/zh-TW/navigation.json'
 import zhTWSoundTest from './locales/zh-TW/sound-test.json'
@@ -93,6 +97,7 @@ const i18n = createI18n<{ message: MessageSchema }, Locale>({
       soundTest: enSoundTest,
       diagnostics: enDiagnostics,
       testing: enTesting,
+      konvaTest: enKonvaTest,
     },
     ja: {
       navigation: jaNavigation,
@@ -107,6 +112,7 @@ const i18n = createI18n<{ message: MessageSchema }, Locale>({
       soundTest: jaSoundTest,
       diagnostics: jaDiagnostics,
       testing: jaTesting,
+      konvaTest: jaKonvaTest,
     },
     'zh-CN': {
       navigation: zhCNNavigation,
@@ -121,6 +127,7 @@ const i18n = createI18n<{ message: MessageSchema }, Locale>({
       soundTest: zhCNSoundTest,
       diagnostics: zhCNDiagnostics,
       testing: zhCNTesting,
+      konvaTest: zhCNKonvaTest,
     },
     'zh-TW': {
       navigation: zhTWNavigation,
@@ -135,6 +142,7 @@ const i18n = createI18n<{ message: MessageSchema }, Locale>({
       soundTest: zhTWSoundTest,
       diagnostics: zhTWDiagnostics,
       testing: zhTWTesting,
+      konvaTest: zhTWKonvaTest,
     },
   },
 })

--- a/src/shared/i18n/locales/en/konva-test.json
+++ b/src/shared/i18n/locales/en/konva-test.json
@@ -1,0 +1,20 @@
+{
+  "title": "Konva Sprite Animation Test",
+  "description": "Testing Konva.js for sprite animation with Family BASIC sprites",
+  "movements": "Movements:",
+  "note": "Note:",
+  "noteMessage": "Simplified animation; full animation is handled by Animation Worker",
+  "spriteCount": "Sprite Count:",
+  "speed": "Speed:",
+  "background": "Background:",
+  "randomBgChange": "Random BG Change:",
+  "reinitialize": "Reinitialize",
+  "reset": "Reset",
+  "speedVerySlow": "Very Slow ({value})",
+  "speedSlow": "Slow ({value})",
+  "speedNormal": "Normal ({value})",
+  "speedFast": "Fast ({value})",
+  "speedVeryFast": "Very Fast ({value})",
+  "speedUltraFast": "Ultra Fast ({value})",
+  "spriteCountLabel": "{count} Sprite | {count} Sprites"
+}

--- a/src/shared/i18n/locales/ja/konva-test.json
+++ b/src/shared/i18n/locales/ja/konva-test.json
@@ -1,0 +1,20 @@
+{
+  "title": "Konva スプライトアニメーションテスト",
+  "description": "Family BASIC スプライトでの Konva.js アニメーションテスト",
+  "movements": "動作数：",
+  "note": "注意：",
+  "noteMessage": "簡略化されたアニメーション。完全なアニメーションは Animation Worker で処理されます",
+  "spriteCount": "スプライト数：",
+  "speed": "速度：",
+  "background": "背景：",
+  "randomBgChange": "ランダム背景変更：",
+  "reinitialize": "再初期化",
+  "reset": "リセット",
+  "speedVerySlow": "非常に遅い（{value}）",
+  "speedSlow": "遅い（{value}）",
+  "speedNormal": "通常（{value}）",
+  "speedFast": "速い（{value}）",
+  "speedVeryFast": "非常に速い（{value}）",
+  "speedUltraFast": "超高速（{value}）",
+  "spriteCountLabel": "{count} スプライト"
+}

--- a/src/shared/i18n/locales/zh-CN/konva-test.json
+++ b/src/shared/i18n/locales/zh-CN/konva-test.json
@@ -1,0 +1,20 @@
+{
+  "title": "Konva 精灵动画测试",
+  "description": "使用 Konva.js 测试 Family BASIC 精灵动画",
+  "movements": "动作数：",
+  "note": "注意：",
+  "noteMessage": "简化版动画；完整动画由 Animation Worker 处理",
+  "spriteCount": "精灵数量：",
+  "speed": "速度：",
+  "background": "背景：",
+  "randomBgChange": "随机背景变化：",
+  "reinitialize": "重新初始化",
+  "reset": "重置",
+  "speedVerySlow": "非常慢（{value}）",
+  "speedSlow": "慢速（{value}）",
+  "speedNormal": "正常（{value}）",
+  "speedFast": "快速（{value}）",
+  "speedVeryFast": "非常快（{value}）",
+  "speedUltraFast": "超快（{value}）",
+  "spriteCountLabel": "{count} 个精灵"
+}

--- a/src/shared/i18n/locales/zh-TW/konva-test.json
+++ b/src/shared/i18n/locales/zh-TW/konva-test.json
@@ -1,0 +1,20 @@
+{
+  "title": "Konva 精靈動畫測試",
+  "description": "使用 Konva.js 測試 Family BASIC 精靈動畫",
+  "movements": "動作數：",
+  "note": "注意：",
+  "noteMessage": "簡化版動畫；完整動畫由 Animation Worker 處理",
+  "spriteCount": "精靈數量：",
+  "speed": "速度：",
+  "background": "背景：",
+  "randomBgChange": "隨機背景變化：",
+  "reinitialize": "重新初始化",
+  "reset": "重設",
+  "speedVerySlow": "非常慢（{value}）",
+  "speedSlow": "慢速（{value}）",
+  "speedNormal": "正常（{value}）",
+  "speedFast": "快速（{value}）",
+  "speedVeryFast": "非常快（{value}）",
+  "speedUltraFast": "超快（{value}）",
+  "spriteCountLabel": "{count} 個精靈"
+}

--- a/src/shared/i18n/types.ts
+++ b/src/shared/i18n/types.ts
@@ -12,6 +12,7 @@ import type enDiagnostics from './locales/en/diagnostics.json'
 import type enHome from './locales/en/home.json'
 import type enIde from './locales/en/ide.json'
 import type enImageAnalyzer from './locales/en/image-analyzer.json'
+import type enKonvaTest from './locales/en/konva-test.json'
 import type enMonacoEditor from './locales/en/monaco-editor.json'
 import type enNavigation from './locales/en/navigation.json'
 import type enSoundTest from './locales/en/sound-test.json'
@@ -32,6 +33,7 @@ export type MessageSchema = {
   soundTest: typeof enSoundTest
   diagnostics: typeof enDiagnostics
   testing: typeof enTesting
+  konvaTest: typeof enKonvaTest
 }
 
 // Define available locales


### PR DESCRIPTION
## Summary
- Fixes #210

## Changes
- Added `useI18n` to KonvaSpriteTestPage.vue with `t('konvaTest.*')` calls
- Replaced all 10+ hardcoded English strings with i18n keys
- Converted static option arrays to `computed()` for reactive locale switching
- Created 4 locale files (en, ja, zh-CN, zh-TW) with konva-test translations
- Registered new locale namespace in i18n/index.ts and types.ts

## Test plan
- [x] All 2427 tests pass
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes