### PR TITLE
fix: resolve #212 - complete i18n for test and diagnostics pages

### DIFF
--- a/src/features/diagnostics/PerformanceDiagnosticsPage.vue
+++ b/src/features/diagnostics/PerformanceDiagnosticsPage.vue
@@ -109,8 +109,7 @@ const {
       <!-- Page Header -->
       <GameBlock :title="t('diagnostics.title')" title-icon="mdi:speedometer">
         <p class="description">
-          Diagnose PRINT performance issues by running test scenarios and measuring timing at each
-          stage: worker execution, message passing, and screen rendering.
+          {{ t('diagnostics.description') }}
         </p>
       </GameBlock>
 
@@ -118,20 +117,20 @@ const {
       <GameBlock :title="t('diagnostics.testScenarios')" title-icon="mdi:test-tube">
         <div class="scenario-buttons">
           <GameButton @click="runTest('light')" :disabled="isRunning" type="primary">
-            Light (50 iterations)
+            {{ t('diagnostics.light') }}
           </GameButton>
           <GameButton @click="runTest('medium')" :disabled="isRunning" type="primary">
-            Medium (200 iterations)
+            {{ t('diagnostics.medium') }}
           </GameButton>
           <GameButton @click="runTest('heavy')" :disabled="isRunning" type="primary">
-            Heavy (500 iterations)
+            {{ t('diagnostics.heavy') }}
           </GameButton>
           <GameButton @click="runTest('infinite')" :disabled="isRunning" type="primary">
-            Infinite Loop
+            {{ t('diagnostics.infiniteLoop') }}
           </GameButton>
-          <GameButton @click="stopCode" :disabled="!isRunning" type="danger">Stop</GameButton>
+          <GameButton @click="stopCode" :disabled="!isRunning" type="danger">{{ t('diagnostics.stop') }}</GameButton>
           <GameButton @click="clearMetrics" :disabled="isRunning" type="default">
-            Clear Metrics
+            {{ t('diagnostics.clearMetrics') }}
           </GameButton>
         </div>
       </GameBlock>
@@ -140,21 +139,21 @@ const {
       <GameBlock :title="t('diagnostics.settings')" title-icon="mdi:cog">
         <div class="settings-grid">
           <div class="setting-item">
-            <label class="setting-label">Screen Rendering</label>
+            <label class="setting-label">{{ t('diagnostics.screenRendering') }}</label>
             <GameSwitch
               :model-value="renderingEnabled"
               @update:model-value="(val) => (renderingEnabled = Boolean(val))"
             />
           </div>
           <div class="setting-item">
-            <label class="setting-label">OUTPUT Messages</label>
+            <label class="setting-label">{{ t('diagnostics.outputMessages') }}</label>
             <GameSwitch
               :model-value="messageOutputEnabled"
               @update:model-value="(val) => (messageOutputEnabled = Boolean(val))"
             />
           </div>
           <div class="setting-item">
-            <label class="setting-label">Render FPS Target</label>
+            <label class="setting-label">{{ t('diagnostics.renderFpsTarget') }}</label>
             <GameSelect
               :model-value="renderFpsTarget"
               @update:model-value="(val) => (renderFpsTarget = Number(val))"
@@ -170,19 +169,19 @@ const {
       <GameBlock :title="t('diagnostics.performanceMetrics')" title-icon="mdi:chart-line">
         <div class="metrics-grid">
           <div class="metric-card">
-            <div class="metric-label">FPS</div>
+            <div class="metric-label">{{ t('diagnostics.fps') }}</div>
             <div class="metric-value">{{ fps }}</div>
           </div>
           <div class="metric-card">
-            <div class="metric-label">Messages/sec</div>
+            <div class="metric-label">{{ t('diagnostics.messagesPerSecond') }}</div>
             <div class="metric-value">{{ messagesPerSecond }}</div>
           </div>
           <div class="metric-card">
-            <div class="metric-label">Renders/sec</div>
+            <div class="metric-label">{{ t('diagnostics.rendersPerSecond') }}</div>
             <div class="metric-value">{{ rendersPerSecond }}</div>
           </div>
           <div class="metric-card">
-            <div class="metric-label">Total Time</div>
+            <div class="metric-label">{{ t('diagnostics.totalTime') }}</div>
             <div class="metric-value">{{ totalTime }}ms</div>
           </div>
         </div>
@@ -192,7 +191,7 @@ const {
       <GameBlock :title="t('diagnostics.cpuTimeBreakdown')" title-icon="mdi:clock-outline">
         <div class="breakdown-bars">
           <div class="breakdown-item">
-            <span class="breakdown-label">Worker Execution</span>
+            <span class="breakdown-label">{{ t('diagnostics.workerExecution') }}</span>
             <div class="breakdown-bar">
               <div class="breakdown-fill worker" :style="{ width: workerTimePercent + '%' }"></div>
               <span class="breakdown-value"
@@ -201,7 +200,7 @@ const {
             </div>
           </div>
           <div class="breakdown-item">
-            <span class="breakdown-label">Message Handling</span>
+            <span class="breakdown-label">{{ t('diagnostics.messageHandling') }}</span>
             <div class="breakdown-bar">
               <div
                 class="breakdown-fill message"
@@ -213,7 +212,7 @@ const {
             </div>
           </div>
           <div class="breakdown-item">
-            <span class="breakdown-label">Screen Rendering</span>
+            <span class="breakdown-label">{{ t('diagnostics.screenRendering') }}</span>
             <div class="breakdown-bar">
               <div
                 class="breakdown-fill render"

--- a/src/features/testing/PositionSyncLoadTestPage.vue
+++ b/src/features/testing/PositionSyncLoadTestPage.vue
@@ -138,22 +138,21 @@ onBeforeUnmount(() => {
       >
         <template #default>
           <p class="description">
-            Runs 8 simultaneous MOVE actions. Positions and isActive are written to a shared
-            buffer every frame (no postMessage). Worker reads for XPOS/YPOS and MOVE(n).
+            {{ t('testing.positionSync.description') }}
           </p>
           <div class="metrics-grid">
             <div class="metric">
-              <span class="metric-label">FPS</span>
+              <span class="metric-label">{{ t('testing.positionSync.fps') }}</span>
               <span class="metric-value">{{ fps }}</span>
-              <span class="metric-hint">main thread</span>
+              <span class="metric-hint">{{ t('testing.positionSync.mainThread') }}</span>
             </div>
           </div>
           <div class="actions">
             <GameButton type="primary" @click="startLoadTest" :disabled="isRunning">
-              Start load test
+              {{ t('testing.positionSync.startLoadTest') }}
             </GameButton>
             <GameButton type="default" @click="stopCode" :disabled="!isRunning">
-              Stop
+              {{ t('testing.positionSync.stop') }}
             </GameButton>
           </div>
         </template>

--- a/src/features/testing/PrintVsSpritesTestPage.vue
+++ b/src/features/testing/PrintVsSpritesTestPage.vue
@@ -138,22 +138,20 @@ onBeforeUnmount(() => {
       >
         <template #default>
           <p class="description">
-            Runs 8 moving sprites and a tight loop that <strong>PRINT</strong>s many lines.
-            Sprites should move smoothly without sticking (dirty background, buffer-only
-            render, animation-first).
+            {{ t('testing.printVsSprites.description') }}
           </p>
           <div class="metrics-row">
             <div class="metric">
-              <span class="metric-label">FPS</span>
+              <span class="metric-label">{{ t('testing.printVsSprites.fps') }}</span>
               <span class="metric-value">{{ fps }}</span>
             </div>
           </div>
           <div class="actions">
             <GameButton type="primary" @click="startTest" :disabled="isRunning">
-              Run test
+              {{ t('testing.printVsSprites.runTest') }}
             </GameButton>
             <GameButton type="default" @click="stopCode" :disabled="!isRunning">
-              Stop
+              {{ t('testing.printVsSprites.stop') }}
             </GameButton>
           </div>
         </template>
@@ -190,10 +188,6 @@ onBeforeUnmount(() => {
   margin: 0 0 1rem;
   color: var(--game-text-secondary);
   font-size: var(--game-font-size-base);
-}
-
-.description strong {
-  color: var(--game-text-primary);
 }
 
 .metrics-row {

--- a/src/shared/i18n/locales/en/diagnostics.json
+++ b/src/shared/i18n/locales/en/diagnostics.json
@@ -4,5 +4,21 @@
   "settings": "Settings",
   "performanceMetrics": "Performance Metrics",
   "cpuTimeBreakdown": "CPU Time Breakdown",
-  "screenOutput": "Screen Output"
+  "screenOutput": "Screen Output",
+  "description": "Diagnose PRINT performance issues by running test scenarios and measuring timing at each stage: worker execution, message passing, and screen rendering.",
+  "light": "Light (50 iterations)",
+  "medium": "Medium (200 iterations)",
+  "heavy": "Heavy (500 iterations)",
+  "infiniteLoop": "Infinite Loop",
+  "stop": "Stop",
+  "clearMetrics": "Clear Metrics",
+  "screenRendering": "Screen Rendering",
+  "outputMessages": "OUTPUT Messages",
+  "renderFpsTarget": "Render FPS Target",
+  "fps": "FPS",
+  "messagesPerSecond": "Messages/sec",
+  "rendersPerSecond": "Renders/sec",
+  "totalTime": "Total Time",
+  "workerExecution": "Worker Execution",
+  "messageHandling": "Message Handling"
 }

--- a/src/shared/i18n/locales/en/testing.json
+++ b/src/shared/i18n/locales/en/testing.json
@@ -1,9 +1,18 @@
 {
   "screen": "Screen",
   "printVsSprites": {
-    "title": "PRINT vs moving sprites (Phase 6.1)"
+    "title": "PRINT vs moving sprites (Phase 6.1)",
+    "description": "Runs 8 moving sprites and a tight loop that PRINTs many lines. Sprites should move smoothly without sticking (dirty background, buffer-only render, animation-first).",
+    "fps": "FPS",
+    "runTest": "Run test",
+    "stop": "Stop"
   },
   "positionSync": {
-    "title": "Position sync load test"
+    "title": "Position sync load test",
+    "description": "Runs 8 simultaneous MOVE actions. Positions and isActive are written to a shared buffer every frame (no postMessage). Worker reads for XPOS/YPOS and MOVE(n).",
+    "fps": "FPS",
+    "mainThread": "main thread",
+    "startLoadTest": "Start load test",
+    "stop": "Stop"
   }
 }

--- a/src/shared/i18n/locales/ja/diagnostics.json
+++ b/src/shared/i18n/locales/ja/diagnostics.json
@@ -4,5 +4,21 @@
   "settings": "設定",
   "performanceMetrics": "パフォーマンス指標",
   "cpuTimeBreakdown": "CPU時間の内訳",
-  "screenOutput": "画面出力"
+  "screenOutput": "画面出力",
+  "description": "テストシナリオを実行し、ワーカー実行、メッセージパッシング、画面レンダリングの各段階のタイミングを測定して、PRINTのパフォーマンス問題を診断します。",
+  "light": "軽量（50回反復）",
+  "medium": "中程度（200回反復）",
+  "heavy": "高負荷（500回反復）",
+  "infiniteLoop": "無限ループ",
+  "stop": "停止",
+  "clearMetrics": "指標をクリア",
+  "screenRendering": "画面レンダリング",
+  "outputMessages": "OUTPUT メッセージ",
+  "renderFpsTarget": "レンダリング FPS 目標",
+  "fps": "FPS",
+  "messagesPerSecond": "メッセージ/秒",
+  "rendersPerSecond": "レンダリング/秒",
+  "totalTime": "合計時間",
+  "workerExecution": "ワーカー実行",
+  "messageHandling": "メッセージ処理"
 }

--- a/src/shared/i18n/locales/ja/testing.json
+++ b/src/shared/i18n/locales/ja/testing.json
@@ -1,9 +1,18 @@
 {
   "screen": "画面",
   "printVsSprites": {
-    "title": "PRINT vs 移動スプライト（フェーズ6.1）"
+    "title": "PRINT vs 移動スプライト（フェーズ6.1）",
+    "description": "8つの移動スプライトと多数のPRINTを行うタイトループを実行します。スプライトはスタックせずにスムーズに移動する必要があります（ダーティバックグラウンド、バッファのみレンダリング、アニメーション優先）。",
+    "fps": "FPS",
+    "runTest": "テスト実行",
+    "stop": "停止"
   },
   "positionSync": {
-    "title": "位置同期負荷テスト"
+    "title": "位置同期負荷テスト",
+    "description": "8つの同時MOVEアクションを実行します。位置とisActiveは毎フレーム共有バッファに書き込まれます（postMessageなし）。ワーカーはXPOS/YPOSとMOVE(n)のために読み取ります。",
+    "fps": "FPS",
+    "mainThread": "メインスレッド",
+    "startLoadTest": "負荷テスト開始",
+    "stop": "停止"
   }
 }

--- a/src/shared/i18n/locales/zh-CN/diagnostics.json
+++ b/src/shared/i18n/locales/zh-CN/diagnostics.json
@@ -4,5 +4,21 @@
   "settings": "设置",
   "performanceMetrics": "性能指标",
   "cpuTimeBreakdown": "CPU 时间分解",
-  "screenOutput": "屏幕输出"
+  "screenOutput": "屏幕输出",
+  "description": "通过运行测试场景并测量各阶段（工作线程执行、消息传递、屏幕渲染）的耗时来诊断 PRINT 性能问题。",
+  "light": "轻量（50 次迭代）",
+  "medium": "中等（200 次迭代）",
+  "heavy": "高负载（500 次迭代）",
+  "infiniteLoop": "无限循环",
+  "stop": "停止",
+  "clearMetrics": "清除指标",
+  "screenRendering": "屏幕渲染",
+  "outputMessages": "OUTPUT 消息",
+  "renderFpsTarget": "渲染 FPS 目标",
+  "fps": "FPS",
+  "messagesPerSecond": "消息/秒",
+  "rendersPerSecond": "渲染/秒",
+  "totalTime": "总时间",
+  "workerExecution": "工作线程执行",
+  "messageHandling": "消息处理"
 }

--- a/src/shared/i18n/locales/zh-CN/testing.json
+++ b/src/shared/i18n/locales/zh-CN/testing.json
@@ -1,9 +1,18 @@
 {
   "screen": "屏幕",
   "printVsSprites": {
-    "title": "PRINT 与移动精灵对比（阶段 6.1）"
+    "title": "PRINT 与移动精灵对比（阶段 6.1）",
+    "description": "运行 8 个移动精灵和一个紧密循环，执行大量 PRINT。精灵应平滑移动而不卡顿（脏背景、仅缓冲区渲染、动画优先）。",
+    "fps": "FPS",
+    "runTest": "运行测试",
+    "stop": "停止"
   },
   "positionSync": {
-    "title": "位置同步负载测试"
+    "title": "位置同步负载测试",
+    "description": "运行 8 个同步 MOVE 操作。位置和 isActive 每帧写入共享缓冲区（无 postMessage）。工作线程读取以处理 XPOS/YPOS 和 MOVE(n)。",
+    "fps": "FPS",
+    "mainThread": "主线程",
+    "startLoadTest": "开始负载测试",
+    "stop": "停止"
   }
 }

--- a/src/shared/i18n/locales/zh-TW/diagnostics.json
+++ b/src/shared/i18n/locales/zh-TW/diagnostics.json
@@ -4,5 +4,21 @@
   "settings": "設定",
   "performanceMetrics": "效能指標",
   "cpuTimeBreakdown": "CPU 時間分解",
-  "screenOutput": "螢幕輸出"
+  "screenOutput": "螢幕輸出",
+  "description": "透過執行測試場景並測量各階段（工作執行緒執行、訊息傳遞、螢幕渲染）的耗時來診斷 PRINT 效能問題。",
+  "light": "輕量（50 次迭代）",
+  "medium": "中等（200 次迭代）",
+  "heavy": "高負載（500 次迭代）",
+  "infiniteLoop": "無限迴圈",
+  "stop": "停止",
+  "clearMetrics": "清除指標",
+  "screenRendering": "螢幕渲染",
+  "outputMessages": "OUTPUT 訊息",
+  "renderFpsTarget": "渲染 FPS 目標",
+  "fps": "FPS",
+  "messagesPerSecond": "訊息/秒",
+  "rendersPerSecond": "渲染/秒",
+  "totalTime": "總時間",
+  "workerExecution": "工作執行緒執行",
+  "messageHandling": "訊息處理"
 }

--- a/src/shared/i18n/locales/zh-TW/testing.json
+++ b/src/shared/i18n/locales/zh-TW/testing.json
@@ -1,9 +1,18 @@
 {
   "screen": "螢幕",
   "printVsSprites": {
-    "title": "PRINT 與移動精靈對比（階段 6.1）"
+    "title": "PRINT 與移動精靈對比（階段 6.1）",
+    "description": "執行 8 個移動精靈和一個緊密迴圈，進行大量 PRINT。精靈應平滑移動而不卡頓（髒背景、僅緩衝區渲染、動畫優先）。",
+    "fps": "FPS",
+    "runTest": "執行測試",
+    "stop": "停止"
   },
   "positionSync": {
-    "title": "位置同步負載測試"
+    "title": "位置同步負載測試",
+    "description": "執行 8 個同步 MOVE 操作。位置和 isActive 每幀寫入共享緩衝區（無 postMessage）。工作執行緒讀取以處理 XPOS/YPOS 和 MOVE(n)。",
+    "fps": "FPS",
+    "mainThread": "主執行緒",
+    "startLoadTest": "開始負載測試",
+    "stop": "停止"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #212

## Changes
- PerformanceDiagnosticsPage.vue: localized ~16 hardcoded strings (buttons, metric labels, unit labels, section headers)
- PositionSyncLoadTestPage.vue: localized 3 hardcoded strings (main thread, Start/Stop buttons)
- PrintVsSpritesTestPage.vue: localized 3 hardcoded strings (description, Run/Stop buttons)
- Added diagnostics.json and testing.json locale files for all 4 locales (en, ja, zh-CN, zh-TW)

## Test plan
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes