### PR TITLE
fix: resolve #223 - ForExecutor loop variable modification silently overwritten on NEXT

### DIFF
--- a/src/core/execution/executors/ForExecutor.ts
+++ b/src/core/execution/executors/ForExecutor.ts
@@ -8,7 +8,7 @@ import type { CstNode } from 'chevrotain'
 
 import { DEFAULTS, ERROR_TYPES } from '@/core/constants'
 import type { ExpressionEvaluator } from '@/core/evaluation/ExpressionEvaluator'
-import { getCstNodes, getFirstToken } from '@/core/parser/cst-helpers'
+import { getCstNodes, getFirstCstNode, getFirstToken } from '@/core/parser/cst-helpers'
 import type { VariableService } from '@/core/services/VariableService'
 import type { LoopState } from '@/core/state/ExecutionContext'
 
@@ -91,6 +91,37 @@ export class ForExecutor {
     // Initialize loop variable with start value
     this.variableService.setVariable(varName, startValue)
 
+    // Determine if the loop should execute at all
+    const shouldExecute = this.shouldExecuteLoop(startValue, endValue, stepValue)
+
+    if (!shouldExecute) {
+      // Loop condition not met: skip to after the matching NEXT statement
+      // Per Family BASIC manual page 65: "When the condition is not met, the loop should not execute."
+      if (this.context.config.enableDebugMode) {
+        this.context.addDebugOutput(
+          `FOR: ${varName} = ${startValue} TO ${endValue} STEP ${stepValue} (shouldExecute: false, skipping to NEXT)`
+        )
+      }
+
+      // Find the matching NEXT by scanning forward and counting nesting depth
+      const nextStatementIndex = this.findMatchingNext(statementIndex)
+      if (nextStatementIndex === -1) {
+        this.context.addError({
+          line: lineNumber,
+          message: 'FOR without matching NEXT',
+          type: ERROR_TYPES.RUNTIME,
+        })
+        return
+      }
+
+      // Set the loop variable to start value (spec: variable gets the start value even if loop doesn't execute)
+      this.variableService.setVariable(varName, startValue)
+
+      // Jump past the NEXT statement (NEXT itself should not execute)
+      this.context.jumpToStatement(nextStatementIndex + 1)
+      return
+    }
+
     // Create loop state
     // Note: statementIndex is the current statement index where FOR is located
     // When NEXT jumps back, it should jump to the same statement (to re-execute the loop body)
@@ -101,7 +132,7 @@ export class ForExecutor {
       stepValue,
       currentValue: startValue,
       statementIndex, // Jump back to the same statement index
-      shouldExecute: this.shouldExecuteLoop(startValue, endValue, stepValue),
+      shouldExecute: true,
     }
 
     // Push loop state onto stack
@@ -109,7 +140,7 @@ export class ForExecutor {
 
     if (this.context.config.enableDebugMode) {
       this.context.addDebugOutput(
-        `FOR: ${varName} = ${startValue} TO ${endValue} STEP ${stepValue} (shouldExecute: ${loopState.shouldExecute})`
+        `FOR: ${varName} = ${startValue} TO ${endValue} STEP ${stepValue} (shouldExecute: true)`
       )
     }
   }
@@ -128,5 +159,32 @@ export class ForExecutor {
       // Zero step: infinite loop (should be an error, but handle gracefully)
       return false
     }
+  }
+
+  /**
+   * Find the statement index of the matching NEXT for the FOR at the given index.
+   * Handles nested FOR/NEXT pairs by tracking nesting depth.
+   * Returns -1 if no matching NEXT is found.
+   */
+  private findMatchingNext(forStatementIndex: number): number {
+    let depth = 0
+    for (let i = forStatementIndex; i < this.context.statements.length; i++) {
+      const stmt = this.context.statements[i]
+      if (!stmt) continue
+
+      const commandCst = stmt.command
+      const singleCommandCst = getFirstCstNode(commandCst.children.singleCommand)
+      if (!singleCommandCst) continue
+
+      if (singleCommandCst.children.forStatement) {
+        depth++
+      } else if (singleCommandCst.children.nextStatement) {
+        depth--
+        if (depth === 0) {
+          return i
+        }
+      }
+    }
+    return -1
   }
 }

--- a/src/core/execution/executors/NextExecutor.ts
+++ b/src/core/execution/executors/NextExecutor.ts
@@ -37,8 +37,14 @@ export class NextExecutor {
 
     const loopState = this.context.loopStack[this.context.loopStack.length - 1]!
 
-    // Increment loop variable
-    loopState.currentValue += loopState.stepValue
+    // Read the current variable value to respect any user modifications inside the loop body
+    const actualVariable = this.variableService.getVariable(loopState.variableName)
+    const currentValue = actualVariable && typeof actualVariable.value === 'number'
+      ? actualVariable.value
+      : loopState.currentValue
+
+    // Compute next value from the actual current value
+    loopState.currentValue = currentValue + loopState.stepValue
 
     // Update the actual variable
     this.variableService.setVariable(loopState.variableName, loopState.currentValue)

--- a/test/executors/ForNextExecutor.test.ts
+++ b/test/executors/ForNextExecutor.test.ts
@@ -151,10 +151,8 @@ describe('FOR/NEXT Executor', () => {
   })
 
   describe('Loop Execution Conditions', () => {
-    it('should execute loop once then exit when start > end with positive step', async () => {
-      // Note: According to manual page 65, when condition is not met, loop should not execute.
-      // However, current implementation executes loop body once before checking condition at NEXT.
-      // This test reflects the current implementation behavior.
+    it('should not execute loop body when start > end with positive step', async () => {
+      // Per Family BASIC manual page 65: "When the condition is not met, the loop should not execute."
       const source = `
 10 FOR I = 10 TO 1
 20 PRINT I;
@@ -167,16 +165,12 @@ describe('FOR/NEXT Executor', () => {
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
       const outputs = deviceAdapter.getAllOutputs()
-      // PRINT I; ends with semicolon, so "Done" continues on same line
-      // But PRINT "Done" doesn't end with semicolon, so adds newline
-      // Numbers always get a space BEFORE them, strings don't get spaces
-      expect(outputs).toEqual(' 10Done\n')
+      // Loop should not execute at all; only "Done" should print
+      expect(outputs).toEqual('Done\n')
     })
 
-    it('should execute loop once then exit when start < end with negative step', async () => {
-      // Note: According to manual, when condition is not met, loop should not execute.
-      // However, current implementation executes loop body once before checking condition at NEXT.
-      // This test reflects the current implementation behavior.
+    it('should not execute loop body when start < end with negative step', async () => {
+      // Per Family BASIC manual page 65: "When the condition is not met, the loop should not execute."
       const source = `
 10 FOR I = 1 TO 10 STEP -1
 20 PRINT I;
@@ -189,10 +183,8 @@ describe('FOR/NEXT Executor', () => {
       expect(result.success).toBe(true)
       expect(result.errors).toHaveLength(0)
       const outputs = deviceAdapter.getAllOutputs()
-      // PRINT I; ends with semicolon, so "Done" continues on same line
-      // But PRINT "Done" doesn't end with semicolon, so adds newline
-      // Numbers always get a space BEFORE them, strings don't get spaces
-      expect(outputs).toEqual(' 1Done\n')
+      // Loop should not execute at all; only "Done" should print
+      expect(outputs).toEqual('Done\n')
     })
 
     it('should execute loop exactly once when start equals end', async () => {
@@ -367,6 +359,43 @@ describe('FOR/NEXT Executor', () => {
       // After loop ends, I should be 4 (3 + 1)
       // Numbers always get a space BEFORE them
       expect(outputs).toEqual(' 4')
+    })
+
+    it('should set loop variable to start value when loop does not execute', async () => {
+      const source = `
+10 FOR I = 10 TO 1
+20 PRINT I;
+30 NEXT
+40 PRINT I;
+50 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+      expect(result.errors).toHaveLength(0)
+      const outputs = deviceAdapter.getAllOutputs()
+      // Loop does not execute; I retains start value 10
+      // PRINT I; ends with semicolon, so output is just " 10"
+      expect(outputs).toEqual(' 10')
+    })
+
+    it('should respect user modification of loop variable inside body', async () => {
+      const source = `
+10 FOR I = 1 TO 10
+20 I = 100
+30 PRINT I;
+40 NEXT
+50 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+      expect(result.errors).toHaveLength(0)
+      const outputs = deviceAdapter.getAllOutputs()
+      // User sets I = 100; NEXT reads 100, adds step 1 -> 101
+      // 101 > end value 10, so loop exits after first iteration
+      // PRINT I; prints the user-set value 100
+      expect(outputs).toEqual(' 100')
     })
   })
 


### PR DESCRIPTION
## Summary
- Fixes #223

## Changes
- **ForExecutor**: Consult the stored `shouldExecute` flag — when false (e.g., `FOR I = 10 TO 1`), jump past the matching NEXT instead of entering the loop body
- **NextExecutor**: Read the actual variable value from `variableService.getVariable()` before computing next step, so user modifications to the loop variable inside the body are respected
- **Tests**: Updated 2 existing tests that expected buggy behavior (body executing once when condition not met), added 2 new tests for zero-execution and variable modification scenarios

## Test plan
- [x] All 2474 tests pass (155 test files)
- [x] TypeScript type-check passes
- [x] ESLint passes on changed files
- [ ] CI passes