### PR TITLE
fix: resolve #224 - READ from DATA with type mismatch silently assigns wrong type

### DIFF
--- a/src/core/execution/executors/ReadExecutor.ts
+++ b/src/core/execution/executors/ReadExecutor.ts
@@ -3,14 +3,17 @@
  *
  * Handles READ statement execution for reading data values from DATA statements.
  * Supports both scalar variables and array elements.
+ * Validates type compatibility between DATA values and variable types (TM ERROR on mismatch).
  */
 
 import type { CstNode } from 'chevrotain'
 
+import { ERROR_TYPES } from '@/core/constants'
 import type { ExpressionEvaluator } from '@/core/evaluation/ExpressionEvaluator'
 import { getCstNodes, getFirstCstNode, getFirstToken, getTokens } from '@/core/parser/cst-helpers'
 import type { DataService } from '@/core/services/DataService'
 import type { VariableService } from '@/core/services/VariableService'
+import type { BasicScalarValue } from '@/core/types/BasicTypes'
 
 export class ReadExecutor {
   constructor(
@@ -28,10 +31,16 @@ export class ReadExecutor {
     const identifierTokens = getTokens(cst.children.Identifier)
 
     for (const identifierToken of identifierTokens) {
-      const variableName = identifierToken.image
+      const variableName = identifierToken.image.toUpperCase()
 
       // Read next data value
       const dataValue = this.dataService.readNextDataValue()
+
+      // Check for errors from readNextDataValue (e.g., OD ERROR)
+      if (this.variableService.context.shouldStop) return
+
+      // Validate type compatibility
+      if (!this.validateType(variableName, dataValue, _lineNumber)) return
 
       // Set the variable
       this.variableService.setVariable(variableName, dataValue)
@@ -68,8 +77,35 @@ export class ReadExecutor {
       // Read next data value
       const dataValue = this.dataService.readNextDataValue()
 
+      // Check for errors from readNextDataValue (e.g., OD ERROR)
+      if (this.variableService.context.shouldStop) return
+
+      // Validate type compatibility
+      if (!this.validateType(arrayName, dataValue, _lineNumber)) return
+
       // Set the array element
       this.variableService.setArrayElement(arrayName, indices, dataValue)
     }
+  }
+
+  /**
+   * Validate that a DATA value type is compatible with the target variable type.
+   * F-BASIC variable types are fixed: names ending with $ are string, others are numeric.
+   * Returns true if compatible, false if a TM ERROR was raised.
+   */
+  private validateType(name: string, value: BasicScalarValue, lineNumber: number): boolean {
+    const isStringVar = name.endsWith('$')
+    const isStringValue = typeof value === 'string'
+
+    if (isStringVar !== isStringValue) {
+      this.variableService.context.addError({
+        line: lineNumber,
+        message: 'TM ERROR',
+        type: ERROR_TYPES.RUNTIME,
+      })
+      return false
+    }
+
+    return true
   }
 }

--- a/test/executors/DataReadRestoreExecutor.test.ts
+++ b/test/executors/DataReadRestoreExecutor.test.ts
@@ -235,6 +235,56 @@ describe('ReadExecutor', () => {
       expect(context.variables.get('D$')?.value).toBe('WORLD')
     })
 
+    it('should report TM ERROR when reading string into numeric variable', async () => {
+      context.dataValues = ['HELLO']
+      context.dataIndex = 0
+
+      const readStmtCst = await parseReadStatement('10 READ A')
+      expect(readStmtCst).not.toBeNull()
+
+      executor.execute(readStmtCst!, 10)
+
+      const errors = context.getErrors()
+      expect(errors.length).toBe(1)
+      expect(errors[0]?.message).toBe('TM ERROR')
+      // Variable should NOT be set with the wrong type
+      expect(context.variables.get('A')).toBeUndefined()
+    })
+
+    it('should report TM ERROR when reading number into string variable', async () => {
+      context.dataValues = [123]
+      context.dataIndex = 0
+
+      const readStmtCst = await parseReadStatement('10 READ B$')
+      expect(readStmtCst).not.toBeNull()
+
+      executor.execute(readStmtCst!, 10)
+
+      const errors = context.getErrors()
+      expect(errors.length).toBe(1)
+      expect(errors[0]?.message).toBe('TM ERROR')
+      // Variable should NOT be set with the wrong type
+      expect(context.variables.get('B$')).toBeUndefined()
+    })
+
+    it('should halt on first type mismatch in multi-variable READ', async () => {
+      context.dataValues = [10, 'HELLO', 30]
+      context.dataIndex = 0
+
+      const readStmtCst = await parseReadStatement('10 READ A, B, C')
+      expect(readStmtCst).not.toBeNull()
+
+      executor.execute(readStmtCst!, 10)
+
+      const errors = context.getErrors()
+      expect(errors.length).toBe(1)
+      expect(errors[0]?.message).toBe('TM ERROR')
+      // First variable was set correctly (numeric into numeric)
+      expect(context.variables.get('A')?.value).toBe(10)
+      // Data pointer should have advanced past the consumed value
+      expect(context.dataIndex).toBe(2)
+    })
+
     it('should report OD ERROR when out of data', async () => {
       context.dataValues = [10]
       context.dataIndex = 0

--- a/test/executors/ReadExecutor.test.ts
+++ b/test/executors/ReadExecutor.test.ts
@@ -161,6 +161,80 @@ describe('ReadExecutor (Integration)', () => {
     })
   })
 
+  describe('TM ERROR (type mismatch)', () => {
+    it('should report TM ERROR when reading string into numeric variable', async () => {
+      const source = `
+10 DATA "HELLO"
+20 READ A
+30 PRINT A
+40 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors[0]?.message).toEqual('TM ERROR')
+    })
+
+    it('should report TM ERROR when reading number into string variable', async () => {
+      const source = `
+10 DATA 123
+20 READ B$
+30 PRINT B$
+40 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors[0]?.message).toEqual('TM ERROR')
+    })
+
+    it('should report TM ERROR when reading string into numeric array element', async () => {
+      const source = `
+10 DATA "BAD"
+20 DIM X(2)
+30 READ X(0)
+40 PRINT X(0)
+50 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors[0]?.message).toEqual('TM ERROR')
+    })
+
+    it('should report TM ERROR when reading number into string array element', async () => {
+      const source = `
+10 DATA 999
+20 DIM X$(2)
+30 READ X$(0)
+40 PRINT X$(0)
+50 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors[0]?.message).toEqual('TM ERROR')
+    })
+
+    it('should halt on first type mismatch in multi-variable READ', async () => {
+      const source = `
+10 DATA 10, "HELLO", 30
+20 READ A, B, C
+30 PRINT A; B; C
+40 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors[0]?.message).toEqual('TM ERROR')
+    })
+  })
+
   describe('READ in a loop', () => {
     it('should read data values inside a FOR loop', async () => {
       const source = `


### PR DESCRIPTION
## Summary
- Fixes #224

## Changes
- **ReadExecutor**: Added `validateType()` check that verifies DATA value type matches the target variable type (string vs numeric). Raises `TM ERROR` runtime error on mismatch, consistent with F-BASIC manual error codes.
- **ReadExecutor**: Added `shouldStop` guards after `readNextDataValue()` to properly halt on OD ERROR before reaching type validation.
- **Tests**: Added 8 new tests (5 integration + 3 unit) covering string→numeric, number→string, array type mismatches, and halt-on-first-mismatch behavior.

## Test plan
- [x] All 2480 tests pass (155 test files)
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] CI passes