### PR TITLE
fix: resolve #225 - RESTORE to non-existent line leaves dataIndex stale

### DIFF
--- a/src/core/services/DataService.ts
+++ b/src/core/services/DataService.ts
@@ -119,6 +119,8 @@ export class DataService {
           message: `RESTORE target line ${lineNumber} not found`,
           type: ERROR_TYPES.RUNTIME,
         })
+        // Reset to 0 as a safe default so dataIndex is never left stale
+        this.context.dataIndex = 0
       }
     } else {
       // Restore to beginning

--- a/test/core/services/DataService.test.ts
+++ b/test/core/services/DataService.test.ts
@@ -236,6 +236,24 @@ describe('DataService', () => {
       expect(errors[0]?.message).toEqual('RESTORE target line 100 not found')
     })
 
+    it('should reset dataIndex to 0 when RESTORE targets non-existent line', () => {
+      service.addDataValuesCst([
+        createNumberLiteralCst('10'),
+        createNumberLiteralCst('20'),
+        createNumberLiteralCst('30'),
+      ] as never)
+      service.readNextDataValue() // reads 10, dataIndex = 1
+      service.readNextDataValue() // reads 20, dataIndex = 2
+
+      expect(service.getCurrentDataIndex()).toEqual(2)
+
+      context.statements = []
+      service.restoreData(9999)
+
+      // dataIndex must not be left stale at 2 — it should be reset to 0
+      expect(service.getCurrentDataIndex()).toEqual(0)
+    })
+
     it('should log debug output when debug mode is enabled', () => {
       const debugContext = createTestContext({ enableDebugMode: true })
       const mockAdapter = { debugOutput: vi.fn() }

--- a/test/executors/RestoreExecutor.test.ts
+++ b/test/executors/RestoreExecutor.test.ts
@@ -203,10 +203,10 @@ describe('RestoreExecutor', () => {
 `
       const result = await interpreter.execute(source)
 
-      // Should error or fall back to beginning
-      // The behavior depends on implementation
-      // For now, we check it doesn't crash
+      // Should produce a runtime error and halt execution
       expect(result).toBeDefined()
+      expect(result.errors.length).toBeGreaterThanOrEqual(1)
+      expect(result.errors[0]?.message).toEqual('RESTORE target line 999 not found')
     })
 
     it('should handle RESTORE before any DATA statements', async () => {


### PR DESCRIPTION
## Summary
- Fixes #225

## Changes
- **DataService**: Reset `dataIndex` to 0 when RESTORE targets a non-existent line, ensuring the data pointer is always in a well-defined state
- **DataService.test.ts**: Added test verifying dataIndex resets to 0 after failed RESTORE
- **RestoreExecutor.test.ts**: Strengthened existing edge case test to assert error message and count

## Test plan
- [x] All 2473 tests pass (155 test files)
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] CI passes