### PR TITLE
fix: resolve #231 - add i18n support to 3 shared/ui components

### DIFF
--- a/src/shared/components/ui/GameCollapseToggle.vue
+++ b/src/shared/components/ui/GameCollapseToggle.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 import GameIcon from './GameIcon.vue'
 
 /**
@@ -24,6 +26,8 @@ withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<Emits>()
 
+const { t } = useI18n()
+
 interface Props {
   expanded?: boolean
   size?: 'small' | 'medium' | 'large'
@@ -46,7 +50,7 @@ const handleClick = (event: Event) => {
     @click="handleClick"
     type="button"
     :aria-expanded="expanded"
-    aria-label="Toggle collapse"
+    :aria-label="t('common.ariaLabels.toggleCollapse')"
   >
     <GameIcon :icon="expanded ? 'mdi:chevron-up' : 'mdi:chevron-down'" :size="size" />
   </button>

--- a/src/shared/components/ui/GameInput.vue
+++ b/src/shared/components/ui/GameInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import type { GameInputEmits, GameInputProps } from './GameInput.types'
 
@@ -30,6 +31,8 @@ const props = withDefaults(defineProps<GameInputProps>(), {
 })
 
 const emit = defineEmits<GameInputEmits>()
+
+const { t } = useI18n()
 
 const inputValue = computed({
   get: () => props.modelValue,
@@ -85,7 +88,7 @@ const inputClasses = computed(() => {
       type="button"
       class="game-input-clear"
       @click="handleClear"
-      aria-label="Clear"
+      :aria-label="t('common.ariaLabels.clear')"
     >
       ×
     </button>

--- a/src/shared/components/ui/GameTag.vue
+++ b/src/shared/components/ui/GameTag.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import GameIcon from './GameIcon.vue'
 import type { GameTagEmits, GameTagProps } from './GameTag.types'
@@ -27,6 +28,8 @@ const props = withDefaults(defineProps<GameTagProps>(), {
 })
 
 const emit = defineEmits<GameTagEmits>()
+
+const { t } = useI18n()
 
 const tagClasses = computed(() => {
   const baseClasses = {
@@ -59,7 +62,15 @@ const handleClose = () => {
     <span v-if="$slots.default" class="game-tag-content">
       <slot />
     </span>
-    <button v-if="closable" type="button" class="game-tag-close" @click="handleClose" aria-label="Close">×</button>
+    <button
+      v-if="closable"
+      type="button"
+      class="game-tag-close"
+      @click="handleClose"
+      :aria-label="t('common.ariaLabels.close')"
+    >
+      ×
+    </button>
   </span>
 </template>
 

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -32,5 +32,10 @@
   "labels": {
     "yes": "Yes",
     "no": "No"
+  },
+  "ariaLabels": {
+    "toggleCollapse": "Toggle collapse",
+    "clear": "Clear",
+    "close": "Close"
   }
 }

--- a/src/shared/i18n/locales/ja/common.json
+++ b/src/shared/i18n/locales/ja/common.json
@@ -32,5 +32,10 @@
   "labels": {
     "yes": "はい",
     "no": "いいえ"
+  },
+  "ariaLabels": {
+    "toggleCollapse": "折りたたみの切り替え",
+    "clear": "クリア",
+    "close": "閉じる"
   }
 }

--- a/src/shared/i18n/locales/zh-CN/common.json
+++ b/src/shared/i18n/locales/zh-CN/common.json
@@ -32,5 +32,10 @@
   "labels": {
     "yes": "是",
     "no": "否"
+  },
+  "ariaLabels": {
+    "toggleCollapse": "切换折叠",
+    "clear": "清除",
+    "close": "关闭"
   }
 }

--- a/src/shared/i18n/locales/zh-TW/common.json
+++ b/src/shared/i18n/locales/zh-TW/common.json
@@ -32,5 +32,10 @@
   "labels": {
     "yes": "是",
     "no": "否"
+  },
+  "ariaLabels": {
+    "toggleCollapse": "切換摺疊",
+    "clear": "清除",
+    "close": "關閉"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #231

## Changes
- Added `useI18n` to `GameCollapseToggle.vue`, `GameInput.vue`, `GameTag.vue`
- Replaced hardcoded `aria-label` strings with i18n `t()` calls
- Added `ariaLabels` section to all 4 locale files (en, ja, zh-CN, zh-TW): `toggleCollapse`, `clear`, `close`

## Test plan
- [x] All 2482 tests pass (155 test files)
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] CI passes