### PR TITLE
fix: resolve #232 - IdeControls stop button icon and Run loading state

### DIFF
--- a/src/features/ide/components/IdeControls.vue
+++ b/src/features/ide/components/IdeControls.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { InputMode } from '@/features/ide/composables/useBasicIdeState'
@@ -27,7 +28,7 @@ defineOptions({
   name: 'IdeControls',
 })
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   canRun: true,
   canStop: false,
   debugMode: false,
@@ -35,6 +36,27 @@ withDefaults(defineProps<Props>(), {
 })
 
 const emit = defineEmits<Emits>()
+
+/**
+ * Loading state for the Run button.
+ * Set on click, cleared once isRunning flips to true (or canRun flips to false).
+ * Prevents double-clicks during the async startup window.
+ */
+const isStarting = ref(false)
+
+watch(
+  () => props.isRunning,
+  (running) => {
+    if (running) isStarting.value = false
+  }
+)
+
+watch(
+  () => props.canRun,
+  (canRun) => {
+    if (!canRun) isStarting.value = false
+  }
+)
 
 const { t } = useI18n()
 
@@ -67,6 +89,7 @@ interface Emits {
 }
 
 const handleRun = () => {
+  isStarting.value = true
   emit('run')
 }
 
@@ -105,6 +128,7 @@ const handleInputModeChange = (value: InputMode) => {
     <GameIconButton
       type="primary"
       :disabled="!canRun"
+      :loading="isStarting"
       icon="mdi:play"
       size="small"
       :title="t('ide.controls.run')"
@@ -115,7 +139,7 @@ const handleInputModeChange = (value: InputMode) => {
     <GameIconButton
       type="danger"
       :disabled="!canStop"
-      icon="mdi:pause"
+      icon="mdi:stop"
       size="small"
       :title="t('ide.controls.stop')"
       data-testid="ide-stop-button"

--- a/test/ide/IdeControls.test.ts
+++ b/test/ide/IdeControls.test.ts
@@ -11,8 +11,8 @@ vi.mock('vue-i18n', () => ({
 }))
 
 const gameIconButtonStub = defineComponent({
-  props: ['type', 'disabled', 'icon', 'size', 'title', 'variant', 'selected'],
-  template: '<button :disabled="disabled" :data-testid="$attrs[\'data-testid\']" :data-type="type" :data-icon="icon" :data-variant="variant" :data-selected="selected" :title="title"><slot /></button>',
+  props: ['type', 'disabled', 'icon', 'size', 'title', 'variant', 'selected', 'loading'],
+  template: '<button :disabled="disabled || loading" :data-testid="$attrs[\'data-testid\']" :data-type="type" :data-icon="icon" :data-variant="variant" :data-selected="selected" :data-loading="loading" :title="title"><slot /></button>',
 })
 
 const inputModeToggleStub = defineComponent({
@@ -242,6 +242,63 @@ describe('IdeControls', () => {
     })
 
     expect(wrapper.find('.control-divider').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('stop button uses mdi:stop icon', () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: true, canStop: true },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const stopButton = wrapper.find('[data-testid="ide-stop-button"]')
+    expect(stopButton.attributes('data-icon')).toEqual('mdi:stop')
+    wrapper.unmount()
+  })
+
+  it('run button shows loading state after click', async () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false, canRun: true },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const runButton = wrapper.find('[data-testid="ide-run-button"]')
+    expect(runButton.attributes('data-loading')).toEqual('false')
+
+    await runButton.trigger('click')
+    expect(runButton.attributes('data-loading')).toEqual('true')
+    expect(wrapper.emitted('run')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('run button loading clears when isRunning becomes true', async () => {
+    const wrapper = mount(IdeControls, {
+      props: { isRunning: false, canRun: true },
+      global: {
+        stubs: {
+          GameIconButton: gameIconButtonStub,
+          InputModeToggle: inputModeToggleStub,
+        },
+      },
+    })
+
+    const runButton = wrapper.find('[data-testid="ide-run-button"]')
+    await runButton.trigger('click')
+    expect(runButton.attributes('data-loading')).toEqual('true')
+
+    // Simulate the parent setting isRunning to true
+    await wrapper.setProps({ isRunning: true, canRun: false, canStop: true })
+    expect(runButton.attributes('data-loading')).toEqual('false')
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #232

## Changes
- Changed stop button icon from `mdi:pause` to `mdi:stop` (semantically correct)
- Added loading state to Run button — shows spinner while program is starting up, prevents double-clicks
- Loading clears automatically when `isRunning` becomes true or `canRun` changes

## Test plan
- [x] All 2500 tests pass (156 test files)
- [x] 3 new tests: stop icon verification, loading on click, loading clears on isRunning
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] CI passes