### PR TITLE
fix: resolve #239 - CLS does not hide sprites, leaving them visible after screen clear

### DIFF
--- a/src/core/execution/executors/ClsExecutor.ts
+++ b/src/core/execution/executors/ClsExecutor.ts
@@ -1,7 +1,7 @@
 /**
  * CLS Statement Executor
  *
- * Handles execution of CLS statements to clear the screen.
+ * Handles execution of CLS statements to clear the screen and hide all sprites.
  */
 
 import type { CstNode } from 'chevrotain'
@@ -13,7 +13,7 @@ export class ClsExecutor {
 
   /**
    * Execute a CLS statement from CST
-   * Clears the background screen
+   * Clears the background screen and hides all sprites
    */
   execute(_clsStmtCst: CstNode): void {
     // Clear screen via device adapter
@@ -21,8 +21,28 @@ export class ClsExecutor {
       this.context.deviceAdapter.clearScreen()
     }
 
+    // Hide all sprites (visible = false) but preserve definitions
+    if (this.context.spriteStateManager) {
+      this.context.spriteStateManager.hideAllSprites()
+    }
+
+    // Notify main thread of sprite state change
+    this.notifySpriteStatesChanged()
+
     if (this.context.config.enableDebugMode) {
       this.context.addDebugOutput('CLS: Screen cleared')
+    }
+  }
+
+  /**
+   * Notify main thread that sprite states have changed
+   */
+  private notifySpriteStatesChanged(): void {
+    if (this.context.spriteStateManager && this.context.deviceAdapter?.sendSpriteStates) {
+      this.context.deviceAdapter.sendSpriteStates(
+        this.context.spriteStateManager.getAllSpriteStates(),
+        this.context.spriteStateManager.isSpriteEnabled()
+      )
     }
   }
 }

--- a/src/core/sprite/SpriteStateManager.ts
+++ b/src/core/sprite/SpriteStateManager.ts
@@ -77,6 +77,19 @@ export class SpriteStateManager {
   }
 
   /**
+   * Hide all sprites (set visible = false for all 8 slots).
+   * Used by CLS to clear sprites from screen without removing definitions.
+   */
+  hideAllSprites(): void {
+    for (let i = 0; i < 8; i++) {
+      const sprite = this.spriteStates.get(i)
+      if (sprite) {
+        sprite.visible = false
+      }
+    }
+  }
+
+  /**
    * Hide a sprite
    */
   hideSprite(spriteNumber: number): void {

--- a/test/core/sprite/SpriteStateManager.test.ts
+++ b/test/core/sprite/SpriteStateManager.test.ts
@@ -127,6 +127,62 @@ describe('SpriteStateManager', () => {
     })
   })
 
+  describe('hideAllSprites', () => {
+    it('should hide all visible sprites', () => {
+      manager.defineSprite(createDefinition({ spriteNumber: 0 }))
+      manager.defineSprite(createDefinition({ spriteNumber: 3 }))
+      manager.defineSprite(createDefinition({ spriteNumber: 7 }))
+      manager.displaySprite(0, 10, 20)
+      manager.displaySprite(3, 50, 60)
+      manager.displaySprite(7, 100, 110)
+
+      manager.hideAllSprites()
+
+      expect(manager.getVisibleSprites()).toEqual([])
+    })
+
+    it('should preserve sprite definitions after hiding', () => {
+      const def0 = createDefinition({ spriteNumber: 0 })
+      const def3 = createDefinition({ spriteNumber: 3, priority: 1 })
+      manager.defineSprite(def0)
+      manager.defineSprite(def3)
+      manager.displaySprite(0, 10, 20)
+      manager.displaySprite(3, 50, 60)
+
+      manager.hideAllSprites()
+
+      expect(manager.getSpriteState(0)?.definition).toEqual(def0)
+      expect(manager.getSpriteState(3)?.definition).toEqual(def3)
+    })
+
+    it('should preserve sprite positions after hiding', () => {
+      manager.defineSprite(createDefinition({ spriteNumber: 2 }))
+      manager.displaySprite(2, 123, 45)
+
+      manager.hideAllSprites()
+
+      const state = manager.getSpriteState(2)
+      expect(state?.x).toEqual(123)
+      expect(state?.y).toEqual(45)
+    })
+
+    it('should work when no sprites are visible', () => {
+      manager.hideAllSprites()
+
+      expect(manager.getVisibleSprites()).toEqual([])
+    })
+
+    it('should work on already-hidden sprites', () => {
+      manager.defineSprite(createDefinition({ spriteNumber: 0 }))
+      manager.displaySprite(0, 10, 10)
+      manager.hideSprite(0)
+
+      manager.hideAllSprites()
+
+      expect(manager.getSpriteState(0)?.visible).toEqual(false)
+    })
+  })
+
   describe('hideSprite', () => {
     it('should hide a visible sprite', () => {
       manager.defineSprite(createDefinition())

--- a/test/executors/ClsExecutor.test.ts
+++ b/test/executors/ClsExecutor.test.ts
@@ -129,4 +129,134 @@ describe('ClsExecutor', () => {
     const outputs = deviceAdapter.getAllOutputs()
     expect(outputs).toEqual('Done\nOK\n')
   })
+
+  describe('sprite hiding', () => {
+    it('should hide all sprites when CLS is executed', async () => {
+      const source = `
+10 DEF SPRITE 0,(0,0,0,0,0)=CHR$(240)
+20 SPRITE 0,100,50
+30 CLS
+40 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+      expect(result.errors).toHaveLength(0)
+      expect(deviceAdapter.clearScreenCalls).toBe(1)
+
+      // Sprite 0 should be hidden after CLS
+      const spriteStates = interpreter.getSpriteStates()
+      expect(spriteStates[0]?.visible).toBe(false)
+    })
+
+    it('should preserve sprite definitions after CLS', async () => {
+      const source = `
+10 DEF SPRITE 0,(0,0,0,0,0)=CHR$(240)
+20 SPRITE 0,100,50
+30 CLS
+40 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+
+      // Sprite definition should still be present after CLS
+      const spriteStates = interpreter.getSpriteStates()
+      expect(spriteStates[0]?.definition).not.toBeNull()
+    })
+
+    it('should preserve sprite positions after CLS', async () => {
+      const source = `
+10 DEF SPRITE 0,(0,0,0,0,0)=CHR$(240)
+20 SPRITE 0,100,50
+30 CLS
+40 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+
+      // Sprite position should still be present after CLS
+      const spriteStates = interpreter.getSpriteStates()
+      expect(spriteStates[0]?.x).toBe(100)
+      expect(spriteStates[0]?.y).toBe(50)
+    })
+
+    it('should hide multiple visible sprites', async () => {
+      const source = `
+10 DEF SPRITE 0,(0,0,0,0,0)=CHR$(240)
+20 DEF SPRITE 3,(0,0,0,0,0)=CHR$(241)
+30 DEF SPRITE 7,(0,0,0,0,0)=CHR$(242)
+40 SPRITE 0,10,20
+50 SPRITE 3,50,60
+60 SPRITE 7,100,110
+70 CLS
+80 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+
+      // All sprites should be hidden after CLS
+      const spriteStates = interpreter.getSpriteStates()
+      expect(spriteStates[0]?.visible).toBe(false)
+      expect(spriteStates[3]?.visible).toBe(false)
+      expect(spriteStates[7]?.visible).toBe(false)
+    })
+
+    it('should hide sprites in a loop', async () => {
+      const source = `
+10 DEF SPRITE 0,(0,0,0,0,0)=CHR$(240)
+20 FOR I = 1 TO 3
+30 SPRITE 0,I*10,I*10
+40 CLS
+50 NEXT
+60 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.clearScreenCalls).toBe(3)
+
+      // Sprite should be hidden after final CLS
+      const spriteStates = interpreter.getSpriteStates()
+      expect(spriteStates[0]?.visible).toBe(false)
+    })
+
+    it('should handle CLS when no sprites are defined', async () => {
+      const source = `
+10 CLS
+20 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.clearScreenCalls).toBe(1)
+
+      // All sprite states should remain hidden (default)
+      const spriteStates = interpreter.getSpriteStates()
+      for (const state of spriteStates) {
+        expect(state.visible).toBe(false)
+      }
+    })
+
+    it('should allow re-displaying sprites after CLS', async () => {
+      const source = `
+10 DEF SPRITE 0,(0,0,0,0,0)=CHR$(240)
+20 SPRITE 0,100,50
+30 CLS
+40 SPRITE 0,200,75
+50 END
+`
+      const result = await interpreter.execute(source)
+
+      expect(result.success).toBe(true)
+
+      // Sprite should be visible again after re-display
+      const spriteStates = interpreter.getSpriteStates()
+      expect(spriteStates[0]?.visible).toBe(true)
+      expect(spriteStates[0]?.x).toBe(200)
+      expect(spriteStates[0]?.y).toBe(75)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes #239

## Changes
- **SpriteStateManager**: Added `hideAllSprites()` method that iterates all 8 sprite slots and sets `visible = false`, preserving definitions and positions
- **ClsExecutor**: Now calls `hideAllSprites()` after `clearScreen()`, with `notifySpriteStatesChanged()` to push updated states to main thread
- **Tests**: Added 12 new tests — 5 for `hideAllSprites()` in SpriteStateManager, 7 for CLS sprite hiding behavior (preserve definitions, preserve positions, hide multiple sprites, loop handling, re-display after CLS)

## Test plan
- [x] All 2509 tests pass (156 test files)
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] CI passes