### PR TITLE
fix: resolve #238 - string vs number comparison uses lexicographic comparison

### DIFF
--- a/src/core/evaluation/ExpressionComparison.ts
+++ b/src/core/evaluation/ExpressionComparison.ts
@@ -6,16 +6,53 @@
  */
 
 /**
+ * Check if a value is a numeric string (parseable as a finite number).
+ * Integer-only strings like "42" or "-7" return true.
+ * Strings like "3.14", "hello", "" return false.
+ */
+function isNumericString(value: string): boolean {
+  if (value.length === 0) return false
+  return /^-?\d+$/.test(value)
+}
+
+/**
  * Compare two values using the given operator.
  * Returns -1 for true, 0 for false (per Family BASIC spec).
- * String comparisons are lexicographic.
+ *
+ * Comparison rules:
+ * - number vs number: numeric comparison
+ * - string vs string: lexicographic comparison
+ * - number vs string (or string vs number): if the string is a valid integer,
+ *   do numeric comparison; otherwise fall back to string comparison
  */
 export function compareValues(
   leftValue: number | string,
   rightValue: number | string,
   operator: '=' | '<>' | '<' | '>' | '<=' | '>='
 ): number {
-  if (typeof leftValue === 'string' || typeof rightValue === 'string') {
+  const leftIsString = typeof leftValue === 'string'
+  const rightIsString = typeof rightValue === 'string'
+
+  // Mixed types: number vs string — try numeric comparison if string is numeric
+  if (leftIsString !== rightIsString) {
+    const strValue = leftIsString ? (leftValue) : (rightValue as string)
+    if (isNumericString(strValue)) {
+      const leftNum = Number(leftValue)
+      const rightNum = Number(rightValue)
+      switch (operator) {
+        case '=': return leftNum === rightNum ? -1 : 0
+        case '<>': return leftNum !== rightNum ? -1 : 0
+        case '<': return leftNum < rightNum ? -1 : 0
+        case '>': return leftNum > rightNum ? -1 : 0
+        case '<=': return leftNum <= rightNum ? -1 : 0
+        case '>=': return leftNum >= rightNum ? -1 : 0
+      }
+    }
+    // Non-numeric string vs number: fall through to string comparison
+  }
+
+  // Both strings, or mixed with non-numeric string — lexicographic comparison
+  if (leftIsString || rightIsString) {
     const leftStr = String(leftValue)
     const rightStr = String(rightValue)
     switch (operator) {
@@ -26,17 +63,18 @@ export function compareValues(
       case '<=': return leftStr <= rightStr ? -1 : 0
       case '>=': return leftStr >= rightStr ? -1 : 0
     }
-  } else {
-    const leftNum = Number(leftValue)
-    const rightNum = Number(rightValue)
-    switch (operator) {
-      case '=': return leftNum === rightNum ? -1 : 0
-      case '<>': return leftNum !== rightNum ? -1 : 0
-      case '<': return leftNum < rightNum ? -1 : 0
-      case '>': return leftNum > rightNum ? -1 : 0
-      case '<=': return leftNum <= rightNum ? -1 : 0
-      case '>=': return leftNum >= rightNum ? -1 : 0
-    }
+  }
+
+  // Both numbers — numeric comparison
+  const leftNum = Number(leftValue)
+  const rightNum = Number(rightValue)
+  switch (operator) {
+    case '=': return leftNum === rightNum ? -1 : 0
+    case '<>': return leftNum !== rightNum ? -1 : 0
+    case '<': return leftNum < rightNum ? -1 : 0
+    case '>': return leftNum > rightNum ? -1 : 0
+    case '<=': return leftNum <= rightNum ? -1 : 0
+    case '>=': return leftNum >= rightNum ? -1 : 0
   }
   return 0
 }

--- a/test/evaluation/RelationalOperators.test.ts
+++ b/test/evaluation/RelationalOperators.test.ts
@@ -205,6 +205,130 @@ describe('Relational Operators', () => {
     })
   })
 
+  describe('Mixed Type Comparisons (number vs numeric string)', () => {
+    it('should compare number < numeric string numerically (5 < "10" = TRUE)', async () => {
+      const code = `
+10 A$ = "10"
+20 IF 5 < A$ THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+
+    it('should compare number > numeric string numerically (100 > "9" = TRUE)', async () => {
+      const code = `
+10 A$ = "9"
+20 IF 100 > A$ THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+
+    it('should compare numeric string < number numerically ("5" < 10 = TRUE)', async () => {
+      const code = `
+10 A$ = "5"
+20 IF A$ < 10 THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+
+    it('should compare number = numeric string as equal (5 = "5" = TRUE)', async () => {
+      const code = `
+10 A$ = "5"
+20 IF 5 = A$ THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+
+    it('should compare numeric string = number as equal ("5" = 5 = TRUE)', async () => {
+      const code = `
+10 A$ = "5"
+20 IF A$ = 5 THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+
+    it('should detect inequality between number and numeric string (5 <> "10" = TRUE)', async () => {
+      const code = `
+10 A$ = "10"
+20 IF 5 <> A$ THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+
+    it('should compare number <= numeric string numerically (5 <= "5" = TRUE)', async () => {
+      const code = `
+10 A$ = "5"
+20 IF 5 <= A$ THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+
+    it('should compare numeric string >= number numerically ("10" >= 10 = TRUE)', async () => {
+      const code = `
+10 A$ = "10"
+20 IF A$ >= 10 THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+
+    it('should use string comparison for non-numeric string vs number', async () => {
+      // "hello" vs 5 — "hello" is not a numeric string, so compare as strings
+      // String("hello") = "hello", String(5) = "5", "hello" > "5" lexicographically
+      const code = `
+10 A$ = "hello"
+20 IF A$ > 5 THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+
+    it('should handle negative numeric strings correctly (5 > "-3" = TRUE)', async () => {
+      const code = `
+10 A$ = "-3"
+20 IF 5 > A$ THEN PRINT "TRUE"
+30 END
+`
+      const result = await interpreter.execute(code)
+
+      expect(result.success).toBe(true)
+      expect(deviceAdapter.getAllOutputs()).toEqual('TRUE\n')
+    })
+  })
+
   describe('String Comparisons', () => {
     it('should compare strings lexicographically', async () => {
       const code = `


### PR DESCRIPTION
## Summary
- Fixes #238

## Changes
- Added `isNumericString()` helper to `ExpressionComparison.ts` that checks if a string matches `/^-?\d+$/`
- Restructured `compareValues()` to attempt numeric comparison when one operand is a numeric string, falling back to lexicographic comparison for non-numeric strings
- Added 10 test cases covering mixed-type comparisons: numeric strings, equality, inequality, non-numeric fallback, and negative numbers

## Test plan
- [x] 2510 tests pass (10 new mixed-type comparison tests)
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] CI passes