### PR TITLE
fix: resolve #233 - add loading feedback and error handling to ProgramToolbar

### DIFF
--- a/src/features/ide/components/ProgramToolbar.vue
+++ b/src/features/ide/components/ProgramToolbar.vue
@@ -22,6 +22,34 @@ const nameInputEl = useTemplateRef<HTMLInputElement>('nameInputEl')
 const showConfirmDialog = ref(false)
 const pendingAction = ref<(() => void) | null>(null)
 
+// File operation state
+const isFileOperationPending = ref(false)
+const errorMessage = ref('')
+let errorTimer: ReturnType<typeof setTimeout> | null = null
+
+onUnmounted(() => {
+  if (errorTimer !== null) {
+    clearTimeout(errorTimer)
+  }
+})
+
+function clearError(): void {
+  errorMessage.value = ''
+  if (errorTimer !== null) {
+    clearTimeout(errorTimer)
+    errorTimer = null
+  }
+}
+
+function showError(message: string): void {
+  clearError()
+  errorMessage.value = message
+  errorTimer = setTimeout(() => {
+    errorMessage.value = ''
+    errorTimer = null
+  }, 5000)
+}
+
 function confirmDiscard(action: () => void): void {
   if (!programStore.isDirty.value) {
     action()
@@ -49,11 +77,30 @@ function handleNew() {
 }
 
 function handleOpen() {
-  confirmDiscard(() => void programStore.open())
+  confirmDiscard(async () => {
+    isFileOperationPending.value = true
+    try {
+      const success = await programStore.open()
+      if (!success) {
+        showError(t('ide.toolbar.openFailed'))
+      }
+    } catch {
+      showError(t('ide.toolbar.openFailed'))
+    } finally {
+      isFileOperationPending.value = false
+    }
+  })
 }
 
 async function handleSave() {
-  await programStore.save()
+  isFileOperationPending.value = true
+  try {
+    await programStore.save()
+  } catch {
+    showError(t('ide.toolbar.saveFailed'))
+  } finally {
+    isFileOperationPending.value = false
+  }
 }
 
 // Renaming
@@ -145,6 +192,7 @@ onUnmounted(() => {
           type="default"
           icon="mdi:file-plus"
           size="small"
+          :disabled="isFileOperationPending"
           :title="`${t('ide.toolbar.new')} (Ctrl+N)`"
           @click="handleNew"
         />
@@ -152,6 +200,7 @@ onUnmounted(() => {
           type="default"
           icon="mdi:import"
           size="small"
+          :loading="isFileOperationPending"
           :title="`${t('ide.toolbar.import')} (Ctrl+O)`"
           @click="handleOpen"
         />
@@ -159,6 +208,7 @@ onUnmounted(() => {
           type="primary"
           icon="mdi:export"
           size="small"
+          :loading="isFileOperationPending"
           :title="`${t('ide.toolbar.export')} (Ctrl+S)`"
           @click="handleSave"
         />
@@ -168,6 +218,7 @@ onUnmounted(() => {
           type="default"
           icon="mdi:file-plus"
           size="small"
+          :disabled="isFileOperationPending"
           @click="handleNew"
         >
           {{ t('ide.toolbar.new') }}
@@ -176,6 +227,7 @@ onUnmounted(() => {
           type="default"
           icon="mdi:import"
           size="small"
+          :loading="isFileOperationPending"
           @click="handleOpen"
         >
           {{ t('ide.toolbar.import') }}
@@ -184,12 +236,20 @@ onUnmounted(() => {
           type="primary"
           icon="mdi:export"
           size="small"
+          :loading="isFileOperationPending"
           @click="handleSave"
         >
           {{ t('ide.toolbar.export') }}
         </GameButton>
       </template>
     </div>
+
+    <!-- Error message -->
+    <Transition name="error-fade">
+      <span v-if="errorMessage" class="error-message" @click="clearError">
+        {{ errorMessage }}
+      </span>
+    </Transition>
 
     <!-- Program name -->
     <div class="program-name-container">
@@ -315,5 +375,25 @@ onUnmounted(() => {
   color: var(--base-solid-primary-90);
   font-size: 0.75rem;
   line-height: 1;
+}
+
+.error-message {
+  color: var(--semantic-solid-danger);
+  font-size: 0.75rem;
+  cursor: pointer;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.error-fade-enter-active,
+.error-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.error-fade-enter-from,
+.error-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -6,7 +6,9 @@
     "export": "Export",
     "discardConfirm": "Discard unsaved changes?",
     "programNamePlaceholder": "Program name",
-    "unsavedChanges": "Unsaved changes"
+    "unsavedChanges": "Unsaved changes",
+    "openFailed": "Failed to open file",
+    "saveFailed": "Failed to save file"
   },
   "codeEditor": {
     "title": "Code Editor",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -6,7 +6,9 @@
     "export": "エクスポート",
     "discardConfirm": "未保存の変更を破棄しますか？",
     "programNamePlaceholder": "プログラム名",
-    "unsavedChanges": "未保存の変更"
+    "unsavedChanges": "未保存の変更",
+    "openFailed": "ファイルを開けませんでした",
+    "saveFailed": "ファイルを保存できませんでした"
   },
   "codeEditor": {
     "title": "コードエディター",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -6,7 +6,9 @@
     "export": "导出",
     "discardConfirm": "是否放弃未保存的更改？",
     "programNamePlaceholder": "程序名称",
-    "unsavedChanges": "未保存的更改"
+    "unsavedChanges": "未保存的更改",
+    "openFailed": "打开文件失败",
+    "saveFailed": "保存文件失败"
   },
   "codeEditor": {
     "title": "代码编辑器",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -6,7 +6,9 @@
     "export": "匯出",
     "discardConfirm": "是否放棄未儲存的變更？",
     "programNamePlaceholder": "程式名稱",
-    "unsavedChanges": "未儲存的變更"
+    "unsavedChanges": "未儲存的變更",
+    "openFailed": "開啟檔案失敗",
+    "saveFailed": "儲存檔案失敗"
   },
   "codeEditor": {
     "title": "程式碼編輯器",

--- a/test/ide/ProgramToolbar.test.ts
+++ b/test/ide/ProgramToolbar.test.ts
@@ -6,6 +6,7 @@ import ProgramToolbar from '@/features/ide/components/ProgramToolbar.vue'
 
 const mockNewProgram = vi.fn()
 const mockOpen = vi.fn()
+const mockSave = vi.fn()
 const isDirtyRef = ref(true)
 
 vi.mock('vue-i18n', () => ({
@@ -18,6 +19,8 @@ vi.mock('vue-i18n', () => ({
         'ide.toolbar.discardConfirm': 'Discard unsaved changes?',
         'ide.toolbar.programNamePlaceholder': 'Program name',
         'ide.toolbar.unsavedChanges': 'Unsaved changes',
+        'ide.toolbar.openFailed': 'Failed to open file',
+        'ide.toolbar.saveFailed': 'Failed to save file',
         'common.confirmDialog.confirm': 'OK',
         'common.confirmDialog.cancel': 'Cancel',
       }
@@ -33,7 +36,7 @@ vi.mock('@/features/ide/composables/useProgramStore', () => ({
     programName: 'Test Program',
     newProgram: mockNewProgram,
     open: mockOpen,
-    save: vi.fn(),
+    save: mockSave,
     currentProgram: ref(null),
     loadProgram: vi.fn(),
   }),
@@ -43,6 +46,7 @@ describe('ProgramToolbar', () => {
   beforeEach(() => {
     mockNewProgram.mockReset()
     mockOpen.mockReset()
+    mockSave.mockReset()
     isDirtyRef.value = true
   })
 
@@ -146,5 +150,168 @@ describe('ProgramToolbar', () => {
     expect(overlay.attributes('aria-describedby')).toEqual('confirm-dialog-message')
 
     wrapper.unmount()
+  })
+
+  describe('file operation loading state', () => {
+    it('disables New button while file operation is pending', async () => {
+      let resolveOpen!: () => void
+      mockOpen.mockReturnValue(
+        new Promise<boolean>((resolve) => {
+          resolveOpen = () => resolve(true)
+        }),
+      )
+
+      isDirtyRef.value = false
+      const wrapper = mount(ProgramToolbar, {
+        props: { isCompact: false },
+      })
+
+      // Click Import (Open) button
+      const buttons = wrapper.findAll('button')
+      await buttons[1]!.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // New button should be disabled during file operation
+      expect(buttons[0]!.attributes('disabled')).toBeDefined()
+
+      // Resolve the pending operation
+      resolveOpen()
+      await wrapper.vm.$nextTick()
+
+      wrapper.unmount()
+    })
+
+    it('disables New button while save is pending', async () => {
+      let resolveSave!: () => void
+      mockSave.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveSave = () => resolve()
+        }),
+      )
+
+      const wrapper = mount(ProgramToolbar, {
+        props: { isCompact: false },
+      })
+
+      // Click Export (Save) button
+      const buttons = wrapper.findAll('button')
+      await buttons[2]!.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // New button should be disabled during file operation
+      expect(buttons[0]!.attributes('disabled')).toBeDefined()
+
+      // Resolve the pending operation
+      resolveSave()
+      await wrapper.vm.$nextTick()
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('error handling', () => {
+    it('shows error message when open fails (returns false)', async () => {
+      mockOpen.mockResolvedValue(false)
+
+      isDirtyRef.value = false
+      const wrapper = mount(ProgramToolbar, {
+        props: { isCompact: false },
+      })
+
+      // Click Import button
+      const buttons = wrapper.findAll('button')
+      await buttons[1]!.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // Error message should be displayed
+      expect(wrapper.find('.error-message').exists()).toBe(true)
+      expect(wrapper.find('.error-message').text()).toEqual('Failed to open file')
+
+      wrapper.unmount()
+    })
+
+    it('shows error message when open throws', async () => {
+      mockOpen.mockRejectedValue(new Error('read error'))
+
+      isDirtyRef.value = false
+      const wrapper = mount(ProgramToolbar, {
+        props: { isCompact: false },
+      })
+
+      // Click Import button
+      const buttons = wrapper.findAll('button')
+      await buttons[1]!.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // Error message should be displayed
+      expect(wrapper.find('.error-message').exists()).toBe(true)
+      expect(wrapper.find('.error-message').text()).toEqual('Failed to open file')
+
+      wrapper.unmount()
+    })
+
+    it('shows error message when save throws', async () => {
+      mockSave.mockRejectedValue(new Error('write error'))
+
+      const wrapper = mount(ProgramToolbar, {
+        props: { isCompact: false },
+      })
+
+      // Click Export (Save) button
+      const buttons = wrapper.findAll('button')
+      await buttons[2]!.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // Error message should be displayed
+      expect(wrapper.find('.error-message').exists()).toBe(true)
+      expect(wrapper.find('.error-message').text()).toEqual('Failed to save file')
+
+      wrapper.unmount()
+    })
+
+    it('clears error message when clicked', async () => {
+      mockOpen.mockResolvedValue(false)
+
+      isDirtyRef.value = false
+      const wrapper = mount(ProgramToolbar, {
+        props: { isCompact: false },
+      })
+
+      // Click Import button to trigger error
+      const buttons = wrapper.findAll('button')
+      await buttons[1]!.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // Error message should be visible
+      expect(wrapper.find('.error-message').exists()).toBe(true)
+
+      // Click the error message to dismiss
+      await wrapper.find('.error-message').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // Error message should be gone
+      expect(wrapper.find('.error-message').exists()).toBe(false)
+
+      wrapper.unmount()
+    })
+
+    it('does not show error when open succeeds', async () => {
+      mockOpen.mockResolvedValue(true)
+
+      isDirtyRef.value = false
+      const wrapper = mount(ProgramToolbar, {
+        props: { isCompact: false },
+      })
+
+      // Click Import button
+      const buttons = wrapper.findAll('button')
+      await buttons[1]!.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // No error message should be displayed
+      expect(wrapper.find('.error-message').exists()).toBe(false)
+
+      wrapper.unmount()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #233

## Changes
- Added `isFileOperationPending` loading state to disable buttons during save/open operations
- Added `errorMessage` ref with 5s auto-dismiss timer for user-visible error feedback
- `handleOpen` now awaits result and shows error on failure (return false or throw)
- `handleSave` now has try/catch with error display
- Added error message display with `<Transition>` and dismiss-on-click
- i18n keys added for `toolbar.openFailed` and `toolbar.saveFailed` in all 4 locales (en, ja, zh-CN, zh-TW)
- 7 new test cases covering loading states, error handling, and error dismissal

## Test plan
- [x] 12 ProgramToolbar tests pass (5 existing + 7 new)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes