### PR TITLE
fix: resolve #244 - replace spinning icon with proper CSS spinner in GameIconButton loading state

### DIFF
--- a/src/shared/components/ui/GameIconButton.vue
+++ b/src/shared/components/ui/GameIconButton.vue
@@ -76,9 +76,7 @@ const getIconSize = computed(() => {
     @click="handleClick"
     type="button"
   >
-    <span v-if="loading" class="game-icon-button-spinner">
-      <GameIcon :icon="icon" :size="getIconSize" rotate />
-    </span>
+    <span v-if="loading" class="game-icon-button-spinner" aria-label="Loading" />
     <GameIcon v-else-if="icon" :icon="icon" :size="getIconSize" class="game-icon-button-icon" />
     <slot v-else />
   </button>
@@ -290,9 +288,28 @@ const getIconSize = computed(() => {
 }
 
 .game-icon-button-spinner {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  display: inline-block;
+  width: var(--spinner-size, 1em);
+  height: var(--spinner-size, 1em);
+  border: 2px solid var(--base-alpha-gray-100-20);
+  border-top-color: var(--game-text-secondary);
+  border-radius: 50%;
+  animation: spinner-rotate 0.6s linear infinite;
+}
+
+.game-icon-button-small .game-icon-button-spinner {
+  --spinner-size: 0.875em;
+  border-width: 1.5px;
+}
+
+.game-icon-button-large .game-icon-button-spinner {
+  --spinner-size: 1.125em;
+}
+
+@keyframes spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .game-icon-button-icon {

--- a/test/shared/components/ui/GameIconButton.test.ts
+++ b/test/shared/components/ui/GameIconButton.test.ts
@@ -1,0 +1,175 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+
+import GameIconButton from '@/shared/components/ui/GameIconButton.vue'
+
+/**
+ * Stub for GameIcon to isolate GameIconButton tests.
+ * Renders a span with data-icon attribute so we can verify icon prop passing.
+ */
+const gameIconStub = defineComponent({
+  props: ['icon', 'size', 'rotate', 'class'],
+  template:
+    '<span class="game-icon-stub" :data-icon="icon" :data-size="size" :data-rotate="rotate" />',
+})
+
+function mountButton(props: Record<string, unknown> = {}) {
+  return mount(GameIconButton, {
+    props,
+    global: {
+      stubs: {
+        GameIcon: gameIconStub,
+      },
+    },
+  })
+}
+
+describe('GameIconButton', () => {
+  it('renders the icon via GameIcon when icon prop is provided', () => {
+    const wrapper = mountButton({ icon: 'mdi:play' })
+    const icon = wrapper.find('.game-icon-stub')
+    expect(icon.exists()).toBe(true)
+    expect(icon.attributes('data-icon')).toEqual('mdi:play')
+    wrapper.unmount()
+  })
+
+  it('renders slot content when no icon prop is provided', () => {
+    const wrapper = mount(GameIconButton, {
+      props: {},
+      slots: { default: '<span class="slot-content">X</span>' },
+      global: { stubs: { GameIcon: gameIconStub } },
+    })
+    expect(wrapper.find('.slot-content').exists()).toBe(true)
+    expect(wrapper.find('.game-icon-stub').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('disables the button when disabled prop is true', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', disabled: true })
+    expect((wrapper.element as HTMLButtonElement).disabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('does not emit click when disabled', async () => {
+    const wrapper = mountButton({ icon: 'mdi:play', disabled: true })
+    await wrapper.trigger('click')
+    expect(wrapper.emitted('click')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('emits click when not disabled and not loading', async () => {
+    const wrapper = mountButton({ icon: 'mdi:play' })
+    await wrapper.trigger('click')
+    expect(wrapper.emitted('click')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('disables the button when loading prop is true', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', loading: true })
+    expect((wrapper.element as HTMLButtonElement).disabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('does not emit click when loading', async () => {
+    const wrapper = mountButton({ icon: 'mdi:play', loading: true })
+    await wrapper.trigger('click')
+    expect(wrapper.emitted('click')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('shows a CSS spinner element instead of the icon when loading', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', loading: true })
+    // The spinner should be rendered
+    const spinner = wrapper.find('.game-icon-button-spinner')
+    expect(spinner.exists()).toBe(true)
+    // The icon should NOT be rendered (spinner replaces it)
+    expect(wrapper.find('.game-icon-stub').exists()).toBe(false)
+    // Spinner should have aria-label for accessibility
+    expect(spinner.attributes('aria-label')).toEqual('Loading')
+    wrapper.unmount()
+  })
+
+  it('shows the icon when not loading', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', loading: false })
+    expect(wrapper.find('.game-icon-button-spinner').exists()).toBe(false)
+    expect(wrapper.find('.game-icon-stub').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('applies loading CSS class when loading', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', loading: true })
+    const button = wrapper.element as HTMLButtonElement
+    expect(button.classList.contains('game-icon-button-loading')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('applies disabled CSS class when loading', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', loading: true })
+    const button = wrapper.element as HTMLButtonElement
+    expect(button.classList.contains('game-icon-button-disabled')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('applies size-specific class', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', size: 'large' })
+    const button = wrapper.element as HTMLButtonElement
+    expect(button.classList.contains('game-icon-button-large')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('applies type-specific class', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', type: 'primary' })
+    const button = wrapper.element as HTMLButtonElement
+    expect(button.classList.contains('game-icon-button-primary')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('applies circular class when circular prop is true', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', circular: true })
+    const button = wrapper.element as HTMLButtonElement
+    expect(button.classList.contains('game-icon-button-circular')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('applies selected class when selected prop is true', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', selected: true })
+    const button = wrapper.element as HTMLButtonElement
+    expect(button.classList.contains('game-icon-button-selected')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('passes data-testid to the button element', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', dataTestid: 'my-button' })
+    expect(wrapper.attributes('data-testid')).toEqual('my-button')
+    wrapper.unmount()
+  })
+
+  it('passes title to the button element', () => {
+    const wrapper = mountButton({ icon: 'mdi:play', title: 'Play button' })
+    expect(wrapper.attributes('title')).toEqual('Play button')
+    wrapper.unmount()
+  })
+
+  it('switches from icon to spinner when loading changes to true', async () => {
+    const wrapper = mountButton({ icon: 'mdi:play', loading: false })
+    expect(wrapper.find('.game-icon-stub').exists()).toBe(true)
+    expect(wrapper.find('.game-icon-button-spinner').exists()).toBe(false)
+
+    await wrapper.setProps({ loading: true })
+    expect(wrapper.find('.game-icon-stub').exists()).toBe(false)
+    expect(wrapper.find('.game-icon-button-spinner').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('switches from spinner to icon when loading changes to false', async () => {
+    const wrapper = mountButton({ icon: 'mdi:play', loading: true })
+    expect(wrapper.find('.game-icon-button-spinner').exists()).toBe(true)
+    expect(wrapper.find('.game-icon-stub').exists()).toBe(false)
+
+    await wrapper.setProps({ loading: false })
+    expect(wrapper.find('.game-icon-button-spinner').exists()).toBe(false)
+    expect(wrapper.find('.game-icon-stub').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #244

## Changes
- Replaced rotating icon with a proper CSS border-based circular spinner in `GameIconButton.vue`
- Loading state now shows a distinct spinner with `aria-label="Loading"` instead of the button's own icon spinning
- Added size-aware spinner via CSS custom property `--spinner-size` for small/large button variants
- Uses theme CSS variables (`--base-alpha-gray-100-20`, `--game-text-secondary`) for consistent styling
- Added 19 new test cases in `GameIconButton.test.ts`

## Test plan
- [x] 19 GameIconButton tests pass (new file)
- [x] 2530 total tests pass
- [x] Type-check clean
- [x] ESLint clean
- [x] Stylelint clean
- [ ] CI passes