### PR TITLE
fix: resolve #245 - remove non-functional Debug Buffer button

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -108,7 +108,6 @@ const toggleDebugMode =
   (() => {
     debugMode.value = !debugMode.value
   })
-const debugBuffer = basicIde?.debugBuffer ?? (() => {})
 const sendStrigEvent = basicIde?.sendStrigEvent ?? (() => {})
 const sharedDisplayBufferAccessor =
   basicIde?.sharedDisplayBufferAccessor ?? ({} as SharedDisplayBufferAccessor)
@@ -380,7 +379,6 @@ function toggleInputMode() {
             @stop="stopCode"
             @clear="clearOutput"
             @toggle-debug="toggleDebugMode"
-            @debug-buffer="debugBuffer"
             @open-sample-selector="sampleSelectorOpen = true"
           />
         </div>

--- a/src/features/ide/components/IdeControls.vue
+++ b/src/features/ide/components/IdeControls.vue
@@ -82,8 +82,6 @@ interface Emits {
   (e: 'clear'): void
   /** Emitted when the debug toggle is changed */
   (e: 'toggleDebug'): void
-  /** Emitted when the buffer debug button is clicked */
-  (e: 'debugBuffer'): void
   /** Emitted when the input mode changes */
   (e: 'update:inputMode', value: InputMode): void
 }
@@ -103,10 +101,6 @@ const handleClear = () => {
 
 const handleDebugToggle = () => {
   emit('toggleDebug')
-}
-
-const handleDebugBuffer = () => {
-  emit('debugBuffer')
 }
 
 const handleInputModeChange = (value: InputMode) => {
@@ -162,14 +156,6 @@ const handleInputModeChange = (value: InputMode) => {
       :selected="debugMode"
       :title="t('ide.controls.debug')"
       @click="handleDebugToggle"
-    />
-
-    <GameIconButton
-      type="default"
-      icon="mdi:memory"
-      size="small"
-      :title="t('ide.controls.debugBuffer')"
-      @click="handleDebugBuffer"
     />
   </div>
 </template>

--- a/src/features/ide/components/IdeEditorPanel.vue
+++ b/src/features/ide/components/IdeEditorPanel.vue
@@ -29,7 +29,6 @@ const emit = defineEmits<{
   (e: 'stop'): void
   (e: 'clear'): void
   (e: 'toggleDebug'): void
-  (e: 'debugBuffer'): void
   (e: 'openSampleSelector'): void
 }>()
 
@@ -101,7 +100,6 @@ const useLiteEditor = computed(() => {
           @stop="emit('stop')"
           @clear="emit('clear')"
           @toggle-debug="emit('toggleDebug')"
-          @debug-buffer="emit('debugBuffer')"
           @update:input-mode="emit('update:inputMode', $event)"
         />
       </div>

--- a/src/features/ide/composables/useBasicIdeEnhanced.ts
+++ b/src/features/ide/composables/useBasicIdeEnhanced.ts
@@ -79,10 +79,6 @@ export function useBasicIde() {
     state.debugMode.value = !state.debugMode.value
   }
 
-  const debugBuffer = () => {
-    // no-op: console.log debug output removed; retained for API compatibility
-  }
-
   watch(
     state.code,
     () => {
@@ -143,7 +139,6 @@ export function useBasicIde() {
     getParserCapabilities: editor.getParserCapabilities,
     getHighlighterCapabilities: editor.getHighlighterCapabilities,
     toggleDebugMode,
-    debugBuffer,
 
     // Web worker / screen
     sendStickEvent: worker.sendStickEvent,

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -16,8 +16,7 @@
     "run": "Run",
     "stop": "Stop",
     "clear": "Clear",
-    "debug": "Debug",
-    "debugBuffer": "Buffer"
+    "debug": "Debug"
   },
   "output": {
     "title": "Runtime Output",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -16,8 +16,7 @@
     "run": "実行",
     "stop": "停止",
     "clear": "クリア",
-    "debug": "デバッグ",
-    "debugBuffer": "バッファ"
+    "debug": "デバッグ"
   },
   "output": {
     "title": "実行出力",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -16,8 +16,7 @@
     "run": "运行",
     "stop": "停止",
     "clear": "清除",
-    "debug": "调试",
-    "debugBuffer": "缓冲区"
+    "debug": "调试"
   },
   "output": {
     "title": "运行时输出",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -16,8 +16,7 @@
     "run": "執行",
     "stop": "停止",
     "clear": "清除",
-    "debug": "除錯",
-    "debugBuffer": "緩衝區"
+    "debug": "除錯"
   },
   "output": {
     "title": "執行時輸出",

--- a/test/ide/IdeControls.test.ts
+++ b/test/ide/IdeControls.test.ts
@@ -34,7 +34,7 @@ describe('IdeControls', () => {
     })
 
     const buttons = wrapper.findAll('button')
-    expect(buttons.length).toEqual(5) // run, stop, clear, debug, debugBuffer
+    expect(buttons.length).toEqual(4) // run, stop, clear, debug
     wrapper.unmount()
   })
 
@@ -172,24 +172,6 @@ describe('IdeControls', () => {
     await buttons[3]!.trigger('click') // debug toggle button
 
     expect(wrapper.emitted('toggleDebug')).toHaveLength(1)
-    wrapper.unmount()
-  })
-
-  it('emits debugBuffer event when debug buffer button is clicked', async () => {
-    const wrapper = mount(IdeControls, {
-      props: { isRunning: false },
-      global: {
-        stubs: {
-          GameIconButton: gameIconButtonStub,
-          InputModeToggle: inputModeToggleStub,
-        },
-      },
-    })
-
-    const buttons = wrapper.findAll('button')
-    await buttons[4]!.trigger('click') // debug buffer button (5th button)
-
-    expect(wrapper.emitted('debugBuffer')).toHaveLength(1)
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## Summary
- Fixes #245

## Changes
- Removed the non-functional "Debug Buffer" button (`mdi:memory` icon) from `IdeControls.vue` — it was wired to an empty no-op function
- Removed `debugBuffer` emit and handler from `IdeControls.vue`
- Removed `debugBuffer` emit forwarding from `IdeEditorPanel.vue`
- Removed `debugBuffer` fallback and event binding from `IdePage.vue`
- Removed no-op `debugBuffer` function from `useBasicIdeEnhanced.ts`
- Removed `debugBuffer` i18n keys from all 4 locales (en, ja, zh-CN, zh-TW)
- Updated test: button count 5 → 4, removed debugBuffer emit test

## Test plan
- [x] IdeControls tests pass (updated button count)
- [x] 2510 total tests pass
- [x] Type-check clean
- [x] ESLint clean
- [x] Stylelint clean
- [ ] CI passes