### PR TITLE
fix: resolve #256 - remove mismatched i18n fallback string in IdeEditorPanel

### DIFF
--- a/src/features/ide/components/IdeEditorPanel.vue
+++ b/src/features/ide/components/IdeEditorPanel.vue
@@ -90,7 +90,7 @@ const useLiteEditor = computed(() => {
             type="default"
             icon="mdi:folder-open"
             size="small"
-            :title="t('ide.samples.load', 'Load Sample')"
+            :title="t('ide.samples.load')"
             @click="emit('openSampleSelector')"
           />
         </template>


### PR DESCRIPTION
## Summary
- Fixes #256

## Changes
- Removed mismatched fallback argument `'Load Sample'` from `t('ide.samples.load', 'Load Sample')` in IdeEditorPanel.vue
- The i18n key `ide.samples.load` resolves to `"Sample"` in all 4 locales, so no fallback is needed

## Test plan
- [x] Targeted tests pass (10 IdeEditorPanel tests)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes