### PR TITLE
refactor: resolve #255 - reduce WebWorkerDeviceAdapter.ts from 499 to under 500 lines

### DIFF
--- a/src/core/devices/DeviceSpritePositionHelpers.ts
+++ b/src/core/devices/DeviceSpritePositionHelpers.ts
@@ -1,0 +1,56 @@
+/**
+ * Sprite Position Helpers
+ *
+ * Manages sprite position queries and state notifications.
+ * Extracted from WebWorkerDeviceAdapter to reduce file size.
+ */
+
+import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
+import type { SpriteState } from '@/core/sprite/types'
+
+/** Mutable sprite position cache: actionNumber → { x, y }. */
+export type SpritePositionCache = Map<number, { x: number; y: number }>
+
+/**
+ * Read sprite position from shared display buffer, falling back to cached last-known position.
+ *
+ * Logic:
+ * 1. If sharedDisplayAccessor reports a live position, prefer it (unless it's origin 0,0
+ *    with no active/visible sprite — which likely means "no position set").
+ * 2. Otherwise fall back to the last-known position from the cache.
+ */
+export function getSpritePosition(
+  accessor: SharedDisplayBufferAccessor | null,
+  cache: SpritePositionCache,
+  actionNumber: number
+): { x: number; y: number } | null {
+  if (accessor) {
+    const livePos = accessor.readSpritePosition(actionNumber)
+    if (livePos !== null) {
+      const isOrigin = livePos.x === 0 && livePos.y === 0
+      const hasLiveSpriteState =
+        accessor.readSpriteIsActive(actionNumber) ||
+        accessor.readSpriteIsVisible(actionNumber)
+      if (!isOrigin || hasLiveSpriteState) {
+        cache.set(actionNumber, livePos)
+        return livePos
+      }
+    }
+  }
+  return cache.get(actionNumber) ?? null
+}
+
+/**
+ * Send sprite states to main thread for rendering via postMessage.
+ */
+export function postSpriteStates(
+  spriteStates: SpriteState[],
+  spriteEnabled: boolean
+): void {
+  self.postMessage({
+    type: 'SPRITE_STATES',
+    id: `sprite-states-${Date.now()}`,
+    timestamp: Date.now(),
+    data: { spriteStates, spriteEnabled },
+  })
+}

--- a/src/core/devices/WebWorkerDeviceAdapter.ts
+++ b/src/core/devices/WebWorkerDeviceAdapter.ts
@@ -36,6 +36,11 @@ import {
   rejectAllInputRequests as rejectAllInput,
 } from './DeviceInputRequestHelpers'
 import { postBeep, postOutputMessage, postPlaySound } from './DeviceOutputHelpers'
+import {
+  getSpritePosition as getSpritePositionFromHelper,
+  postSpriteStates,
+  type SpritePositionCache,
+} from './DeviceSpritePositionHelpers'
 import { MessageHandler } from './MessageHandler'
 import { ScreenStateManager } from './ScreenStateManager'
 import { ScreenUpdateBatcher } from './ScreenUpdateBatcher'
@@ -60,7 +65,7 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
   /** Shared keyboard buffer view for INKEY$. Set when receiving SET_SHARED_KEYBOARD_BUFFER. */
   private sharedKeyboardView: KeyboardBufferView | null = null
   /** Last POSITION per sprite; getSpritePosition returns it so MOVE uses it (not buffer 0,0). */
-  private lastPositionBySprite: Map<number, { x: number; y: number }> = new Map()
+  private lastPositionBySprite: SpritePositionCache = new Map()
   private isEnabled = true
   /** BG GRAPHIC data for VIEW command. Set via SET_BG_DATA message from main thread. */
   private bgGridData: BgGridData | null = null
@@ -224,20 +229,7 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
   }
 
   getSpritePosition(actionNumber: number): { x: number; y: number } | null {
-    if (this.sharedDisplayAccessor) {
-      const livePos = this.sharedDisplayAccessor.readSpritePosition(actionNumber)
-      if (livePos !== null) {
-        const isOrigin = livePos.x === 0 && livePos.y === 0
-        const hasLiveSpriteState =
-          this.sharedDisplayAccessor.readSpriteIsActive(actionNumber) ||
-          this.sharedDisplayAccessor.readSpriteIsVisible(actionNumber)
-        if (!isOrigin || hasLiveSpriteState) {
-          this.lastPositionBySprite.set(actionNumber, livePos)
-          return livePos
-        }
-      }
-    }
-    return this.lastPositionBySprite.get(actionNumber) ?? null
+    return getSpritePositionFromHelper(this.sharedDisplayAccessor, this.lastPositionBySprite, actionNumber)
   }
 
   setSpritePosition(actionNumber: number, x: number, y: number): void {
@@ -256,12 +248,7 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
 
   /** Send sprite states to main thread for rendering. */
   sendSpriteStates(spriteStates: SpriteState[], spriteEnabled: boolean): void {
-    self.postMessage({
-      type: 'SPRITE_STATES',
-      id: `sprite-states-${Date.now()}`,
-      timestamp: Date.now(),
-      data: { spriteStates, spriteEnabled },
-    })
+    postSpriteStates(spriteStates, spriteEnabled)
   }
 
   // === BG GRAPHIC METHODS (VIEW command) ===


### PR DESCRIPTION
## Summary
- Fixes #255

## Changes
- Extract sprite position logic (`getSpritePosition`) into `DeviceSpritePositionHelpers.ts`
- Extract sprite state notification (`sendSpriteStates`) into `DeviceSpritePositionHelpers.ts`
- Add `SpritePositionCache` type alias for cleaner field typing
- WebWorkerDeviceAdapter.ts: 499 → 486 lines (14 lines of margin under 500 limit)
- New file follows existing `Device*Helpers.ts` naming convention

## Test plan
- [x] All 2588 tests pass (including 27 WebWorkerDeviceAdapter tests)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes