### PR TITLE
fix: resolve #257 - add i18n for MovementCard character type labels

### DIFF
--- a/src/features/ide/components/MovementCard.vue
+++ b/src/features/ide/components/MovementCard.vue
@@ -53,7 +53,8 @@ function directionTitle(dir: number): string {
 
 function characterTypeLabel(code: number): string {
   const name = MoveCharacterCode[code as MoveCharacterCode]
-  return name ?? String(code)
+  if (name === undefined) return String(code)
+  return t(`ide.movementCard.characterTypes.${name}`)
 }
 </script>
 

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -381,6 +381,24 @@
       "6": "down-left",
       "7": "left",
       "8": "up-left"
+    },
+    "characterTypes": {
+      "MARIO": "Mario",
+      "LADY": "Lady",
+      "FIGHTER_FLY": "Fighter Fly",
+      "ACHILLES": "Achilles",
+      "PENGUIN": "Penguin",
+      "FIREBALL": "Fireball",
+      "CAR": "Car",
+      "SPINNER": "Spinner",
+      "STAR_KILLER": "Star Killer",
+      "STARSHIP": "Starship",
+      "EXPLOSION": "Explosion",
+      "SMILEY": "Smiley",
+      "LASER": "Laser",
+      "SHELL_CREEPER": "Shellcreeper",
+      "SIDE_STEPPER": "Sidestepper",
+      "NITPICKER": "Nitpicker"
     }
   },
   "screenTab": {

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -381,6 +381,24 @@
       "6": "左下",
       "7": "左",
       "8": "左上"
+    },
+    "characterTypes": {
+      "MARIO": "マリオ",
+      "LADY": "レディ",
+      "FIGHTER_FLY": "ファイターフライ",
+      "ACHILLES": "アキレス",
+      "PENGUIN": "ペンギン",
+      "FIREBALL": "ファイアボール",
+      "CAR": "カー",
+      "SPINNER": "スピナー",
+      "STAR_KILLER": "スターキラー",
+      "STARSHIP": "スターシップ",
+      "EXPLOSION": "エクスプロージョン",
+      "SMILEY": "スマイリー",
+      "LASER": "レーザー",
+      "SHELL_CREEPER": "シェルクリーパー",
+      "SIDE_STEPPER": "サイドステッパー",
+      "NITPICKER": "ニットピッカー"
     }
   },
   "screenTab": {

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -381,6 +381,24 @@
       "6": "左下",
       "7": "左",
       "8": "左上"
+    },
+    "characterTypes": {
+      "MARIO": "马里奥",
+      "LADY": "女士",
+      "FIGHTER_FLY": "斗士蝇",
+      "ACHILLES": "阿喀琉斯",
+      "PENGUIN": "企鹅",
+      "FIREBALL": "火球",
+      "CAR": "赛车",
+      "SPINNER": "旋转器",
+      "STAR_KILLER": "星杀者",
+      "STARSHIP": "星际飞船",
+      "EXPLOSION": "爆炸",
+      "SMILEY": "笑脸",
+      "LASER": "激光",
+      "SHELL_CREEPER": "龟壳怪",
+      "SIDE_STEPPER": "侧步怪",
+      "NITPICKER": "啄木鸟"
     }
   },
   "screenTab": {

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -381,6 +381,24 @@
       "6": "左下",
       "7": "左",
       "8": "左上"
+    },
+    "characterTypes": {
+      "MARIO": "瑪利歐",
+      "LADY": "女士",
+      "FIGHTER_FLY": "鬥士蠅",
+      "ACHILLES": "阿基里斯",
+      "PENGUIN": "企鵝",
+      "FIREBALL": "火球",
+      "CAR": "賽車",
+      "SPINNER": "旋轉器",
+      "STAR_KILLER": "星殺者",
+      "STARSHIP": "星際飛船",
+      "EXPLOSION": "爆炸",
+      "SMILEY": "笑臉",
+      "LASER": "雷射",
+      "SHELL_CREEPER": "龜殼怪",
+      "SIDE_STEPPER": "側步怪",
+      "NITPICKER": "啄木鳥"
     }
   },
   "screenTab": {

--- a/test/ide/MovementCard.test.ts
+++ b/test/ide/MovementCard.test.ts
@@ -1,0 +1,137 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import type { MovementSlotData } from '@/features/ide/components/MovementCard.vue'
+import MovementCard from '@/features/ide/components/MovementCard.vue'
+
+const gameIconStub = defineComponent({
+  props: ['icon', 'size'],
+  template: '<span :data-icon="icon" />',
+})
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+function createSlotData(overrides: Partial<MovementSlotData> = {}): MovementSlotData {
+  return {
+    actionNumber: 0,
+    hasData: true,
+    x: 10,
+    y: 5,
+    isActive: true,
+    remainingDistance: 20,
+    totalDistance: 30,
+    direction: 3,
+    speed: 4,
+    priority: 1,
+    characterType: 0,
+    colorCombination: 0,
+    ...overrides,
+  }
+}
+
+function mountCard(slotData: MovementSlotData) {
+  return mount(MovementCard, {
+    props: { slot: slotData },
+    global: {
+      stubs: { GameIcon: gameIconStub },
+    },
+  })
+}
+
+describe('MovementCard', () => {
+  describe('character type i18n', () => {
+    it('uses i18n key for MARIO character type (code 0)', () => {
+      const wrapper = mountCard(createSlotData({ characterType: 0 }))
+      const charSpan = wrapper.find('.move-card-char')
+      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.MARIO')
+      wrapper.unmount()
+    })
+
+    it('uses i18n key for PENGUIN character type (code 4)', () => {
+      const wrapper = mountCard(createSlotData({ characterType: 4 }))
+      const charSpan = wrapper.find('.move-card-char')
+      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.PENGUIN')
+      wrapper.unmount()
+    })
+
+    it('uses i18n key for FIREBALL character type (code 5)', () => {
+      const wrapper = mountCard(createSlotData({ characterType: 5 }))
+      const charSpan = wrapper.find('.move-card-char')
+      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.FIREBALL')
+      wrapper.unmount()
+    })
+
+    it('uses i18n key for STAR_KILLER character type (code 8)', () => {
+      const wrapper = mountCard(createSlotData({ characterType: 8 }))
+      const charSpan = wrapper.find('.move-card-char')
+      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.STAR_KILLER')
+      wrapper.unmount()
+    })
+
+    it('uses i18n key for SHELL_CREEPER character type (code 13)', () => {
+      const wrapper = mountCard(createSlotData({ characterType: 13 }))
+      const charSpan = wrapper.find('.move-card-char')
+      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.SHELL_CREEPER')
+      wrapper.unmount()
+    })
+
+    it('shows numeric code for unknown character type', () => {
+      const wrapper = mountCard(createSlotData({ characterType: 99 }))
+      const charSpan = wrapper.find('.move-card-char')
+      expect(charSpan.attributes('title')).toEqual('99')
+      wrapper.unmount()
+    })
+  })
+
+  describe('layout', () => {
+    it('renders action number', () => {
+      const wrapper = mountCard(createSlotData({ actionNumber: 3 }))
+      expect(wrapper.find('.move-card-id').text()).toContain('3')
+      wrapper.unmount()
+    })
+
+    it('shows active status icon when slot is active', () => {
+      const wrapper = mountCard(createSlotData({ isActive: true }))
+      const statusSpan = wrapper.find('.move-card-status')
+      expect(statusSpan.attributes('title')).toEqual('ide.movementCard.statusActive')
+      wrapper.unmount()
+    })
+
+    it('shows paused status icon when slot is paused', () => {
+      const wrapper = mountCard(createSlotData({ isActive: false }))
+      const statusSpan = wrapper.find('.move-card-status')
+      expect(statusSpan.attributes('title')).toEqual('ide.movementCard.statusPaused')
+      wrapper.unmount()
+    })
+
+    it('shows direction icon for known direction', () => {
+      const wrapper = mountCard(createSlotData({ direction: 3 }))
+      const dirSpan = wrapper.find('.move-card-dir')
+      expect(dirSpan.attributes('aria-label')).toEqual(
+        'ide.movementCard.directionAria',
+      )
+      wrapper.unmount()
+    })
+
+    it('hides data fields when hasData is false', () => {
+      const wrapper = mountCard(createSlotData({ hasData: false }))
+      expect(wrapper.find('.move-card-char').exists()).toBe(false)
+      expect(wrapper.find('.move-card-status').exists()).toBe(false)
+      wrapper.unmount()
+    })
+
+    it('displays truncated character type label in card text', () => {
+      const wrapper = mountCard(createSlotData({ characterType: 0 }))
+      const charSpan = wrapper.find('.move-card-char')
+      // With i18n mock returning the key, the key is sliced to 5 chars
+      const text = charSpan.text()
+      expect(text.length).toBeLessThanOrEqual(5)
+      wrapper.unmount()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #257

## Changes
- Replace raw `MoveCharacterCode` enum names (MARIO, PENGUIN, etc.) with i18n keys in MovementCard.vue
- Add 16 character type translations in all 4 locales (en, ja, zh-CN, zh-TW)
- Add 12 unit tests for MovementCard covering i18n labels and layout behavior
- Fallback to numeric code for unknown character types

## Test plan
- [x] 12 MovementCard tests pass
- [x] 2600 total tests pass
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes