### PR TITLE
feat: resolve #187 - implement sync PLAY with message-based wakeup

### DIFF
--- a/src/core/devices/DeviceOutputHelpers.ts
+++ b/src/core/devices/DeviceOutputHelpers.ts
@@ -73,14 +73,17 @@ export function serializeAudioEvents(audio: CompiledAudio): SerializedAudioEvent
 export function buildPlaySoundMessage(
   executionId: string,
   events: SerializedAudioEvent[],
-  musicString?: string
+  musicString?: string,
+  playId?: string
 ) {
+  const id = playId ?? `play-sound-${Date.now()}`
   return {
     type: 'PLAY_SOUND' as const,
-    id: `play-sound-${Date.now()}`,
+    id,
     timestamp: Date.now(),
     data: {
       executionId,
+      playId: id,
       events,
       ...(musicString ? { musicString } : {}),
     },
@@ -98,11 +101,13 @@ export function buildBeepMessage(executionId: string) {
   )
 }
 
-/** Post a PLAY_SOUND message to main thread. */
-export function postPlaySound(executionId: string, audio: CompiledAudio): void {
+/** Post a PLAY_SOUND message to main thread. Returns the playId for completion tracking. */
+export function postPlaySound(executionId: string, audio: CompiledAudio): string {
   logWorker.debug('Playing sound, channels:', audio.channels.length)
   const events = serializeAudioEvents(audio)
-  self.postMessage(buildPlaySoundMessage(executionId, events))
+  const message = buildPlaySoundMessage(executionId, events)
+  self.postMessage(message)
+  return message.data.playId
 }
 
 /** Post a BEEP message to main thread. */

--- a/src/core/devices/DevicePlayCompleteHelpers.ts
+++ b/src/core/devices/DevicePlayCompleteHelpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Device Play Complete Helpers
+ *
+ * Standalone functions for PLAY sound completion tracking in WebWorkerDeviceAdapter.
+ * Extracted from WebWorkerDeviceAdapter.ts for modularity.
+ *
+ * Handles: PLAY_SOUND/PLAY_SOUND_COMPLETE promise lifecycle.
+ * Pattern mirrors DeviceInputRequestHelpers (INPUT_VALUE).
+ */
+
+import type { PlaySoundCompleteMessage } from '@/core/interfaces'
+
+// ============================================================================
+// Play Complete State
+// ============================================================================
+
+interface PendingPlayComplete {
+  resolve: () => void
+  reject: (err: Error) => void
+}
+
+/**
+ * Create a pending play completion promise and store it in the map.
+ * Returns the playId and the promise that resolves when PLAY_SOUND_COMPLETE arrives.
+ */
+export function createPlayCompleteRequest(
+  pendingPlayComplete: Map<string, PendingPlayComplete>,
+  playId: string
+): Promise<void> {
+  const promise = new Promise<void>((resolve, reject) => {
+    pendingPlayComplete.set(playId, { resolve, reject })
+  })
+  return promise
+}
+
+/**
+ * Handle a PLAY_SOUND_COMPLETE message from main thread.
+ * Resolves the matching pending promise.
+ */
+export function handlePlaySoundCompleteMessage(
+  pendingPlayComplete: Map<string, PendingPlayComplete>,
+  message: PlaySoundCompleteMessage
+): void {
+  const { playId } = message.data
+  const pending = pendingPlayComplete.get(playId)
+  pendingPlayComplete.delete(playId)
+  if (!pending) return
+  pending.resolve()
+}
+
+/**
+ * Reject all pending play complete requests (e.g., when STOP is pressed).
+ */
+export function rejectAllPlayCompleteRequests(
+  pendingPlayComplete: Map<string, PendingPlayComplete>,
+  reason: string = 'Execution stopped'
+): void {
+  for (const [, pending] of pendingPlayComplete) {
+    pending.reject(new Error(reason))
+  }
+  pendingPlayComplete.clear()
+}

--- a/src/core/devices/TestDeviceAdapter.ts
+++ b/src/core/devices/TestDeviceAdapter.ts
@@ -200,9 +200,10 @@ export class TestDeviceAdapter implements BasicDeviceAdapter {
   /** Captured playSound calls for testing */
   public playSoundCalls: CompiledAudio[] = []
 
-  playSound?(audio: CompiledAudio): void {
+  playSound?(audio: CompiledAudio): Promise<void> {
     this.playSoundCalls.push(audio)
     logDevice.debug('Play sound, channels:', audio.channels.length)
+    return Promise.resolve()
   }
 
   /** Captured beep calls for testing */

--- a/src/core/devices/WebWorkerDeviceAdapter.ts
+++ b/src/core/devices/WebWorkerDeviceAdapter.ts
@@ -13,6 +13,7 @@ import type {
   InputValueMessage,
   InterpreterConfig,
   OutputMessage,
+  PlaySoundCompleteMessage,
 } from '@/core/interfaces'
 import type { CompiledAudio } from '@/core/sound/types'
 import type { SpriteState } from '@/core/sprite/types'
@@ -36,6 +37,7 @@ import {
   rejectAllInputRequests as rejectAllInput,
 } from './DeviceInputRequestHelpers'
 import { postBeep, postOutputMessage, postPlaySound } from './DeviceOutputHelpers'
+import { createPlayCompleteRequest, handlePlaySoundCompleteMessage as handlePlayComplete, rejectAllPlayCompleteRequests as rejectAllPlayComplete } from './DevicePlayCompleteHelpers'
 import {
   getSpritePosition as getSpritePositionFromHelper,
   postSpriteStates,
@@ -80,6 +82,8 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
     string,
     { resolve: (values: string[]) => void; reject: (err: Error) => void }
   > = new Map()
+  // === PLAY COMPLETE (worker only: sync PLAY) ===
+  private pendingPlayComplete: Map<string, { resolve: () => void; reject: (err: Error) => void }> = new Map()
   // === SCREEN UPDATE BATCHING ===
   private readonly screenUpdateBatcher: ScreenUpdateBatcher
 
@@ -411,9 +415,15 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
     handleInputValue(this.pendingInputRequests, message)
   }
 
+  /** Resolve a pending play completion request. */
+  handlePlaySoundCompleteMessage(message: PlaySoundCompleteMessage): void {
+    handlePlayComplete(this.pendingPlayComplete, message)
+  }
+
   /** Reject all pending input requests. */
   rejectAllInputRequests(reason: string = 'Execution stopped'): void {
     rejectAllInput(this.pendingInputRequests, reason)
+    rejectAllPlayComplete(this.pendingPlayComplete, reason)
   }
 
   // === EXECUTION MANAGEMENT ===
@@ -437,9 +447,11 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
 
   // === SOUND METHODS (delegated to DeviceOutputHelpers) ===
 
-  /** Play compiled audio. */
-  playSound(audio: CompiledAudio): void {
-    postPlaySound(this.screenStateManager.getCurrentExecutionId() ?? 'unknown', audio)
+  /** Play compiled audio synchronously. Blocks until PLAY_SOUND_COMPLETE is received. */
+  playSound(audio: CompiledAudio): Promise<void> {
+    const executionId = this.screenStateManager.getCurrentExecutionId() ?? 'unknown'
+    const playId = postPlaySound(executionId, audio)
+    return createPlayCompleteRequest(this.pendingPlayComplete, playId)
   }
 
   /** Play a beep sound. */

--- a/src/core/execution/StatementRouter.ts
+++ b/src/core/execution/StatementRouter.ts
@@ -439,7 +439,7 @@ export class StatementRouter {
     } else if (singleCommandCst.children.playStatement) {
       const playStmtCst = getFirstCstNode(singleCommandCst.children.playStatement)
       if (playStmtCst) {
-        this.playExecutor.execute(playStmtCst, expandedStatement.lineNumber)
+        await this.playExecutor.execute(playStmtCst, expandedStatement.lineNumber)
       }
     } else if (singleCommandCst.children.viewStatement) {
       const viewStmtCst = getFirstCstNode(singleCommandCst.children.viewStatement)

--- a/src/core/execution/executors/PlayExecutor.ts
+++ b/src/core/execution/executors/PlayExecutor.ts
@@ -26,9 +26,10 @@ export class PlayExecutor {
 
   /**
    * Execute a PLAY statement from CST
-   * Plays music according to string data specification
+   * Plays music according to string data specification.
+   * Blocks (awaits) until audio playback completes on the main thread.
    */
-  execute(playStmtCst: CstNode, lineNumber?: number): void {
+  async execute(playStmtCst: CstNode, lineNumber?: number): Promise<void> {
     // 1. Get expression from CST
     const expressions = getCstNodes(playStmtCst.children.expression)
 
@@ -101,10 +102,9 @@ export class PlayExecutor {
       return
     }
 
-    // 4. Call device adapter to play compiled audio
-    // Device adapter just transmits the audio to main thread - no state management
+    // 4. Call device adapter to play compiled audio (blocks until playback completes)
     if (this.context.deviceAdapter?.playSound) {
-      this.context.deviceAdapter.playSound(compiledAudio)
+      await this.context.deviceAdapter.playSound(compiledAudio)
     }
 
     // 5. Debug output

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -154,10 +154,12 @@ export interface BasicDeviceAdapter {
 
   // === SOUND OUTPUT ===
   /**
-   * Play compiled audio
+   * Play compiled audio synchronously (blocking).
+   * Blocks until audio playback completes (main thread sends PLAY_SOUND_COMPLETE).
    * @param audio - Compiled audio with calculated frequencies and durations
+   * @returns Promise that resolves when playback finishes
    */
-  playSound?(audio: CompiledAudio): void
+  playSound?(audio: CompiledAudio): Promise<void>
 
   /**
    * Play a beep sound (BEEP statement)
@@ -321,6 +323,7 @@ export type ServiceWorkerMessageType =
   | 'REQUEST_INPUT'
   | 'INPUT_VALUE'
   | 'PLAY_SOUND'
+  | 'PLAY_SOUND_COMPLETE'
   | 'CLEAR_DISPLAY'
 
 // Execute message - sent from UI to service worker
@@ -569,6 +572,7 @@ export interface PlaySoundMessage extends ServiceWorkerMessage {
   data: {
     executionId: string
     musicString: string
+    playId: string
     events: Array<{
       frequency?: number
       duration: number
@@ -577,6 +581,15 @@ export interface PlaySoundMessage extends ServiceWorkerMessage {
       envelope: number
       volumeOrLength: number
     }>
+  }
+}
+
+// Play sound complete - sent from main to worker when PLAY audio finishes
+export interface PlaySoundCompleteMessage extends ServiceWorkerMessage {
+  type: 'PLAY_SOUND_COMPLETE'
+  data: {
+    executionId: string
+    playId: string
   }
 }
 
@@ -604,6 +617,7 @@ export type AnyServiceWorkerMessage =
   | RequestInputMessage
   | InputValueMessage
   | PlaySoundMessage
+  | PlaySoundCompleteMessage
 
 // Message handler interface for type-safe message handling
 export interface ServiceWorkerMessageHandler {

--- a/src/core/workers/WebWorkerInterpreter.ts
+++ b/src/core/workers/WebWorkerInterpreter.ts
@@ -15,6 +15,7 @@ import type {
   ExecuteMessage,
   InputValueMessage,
   OutputMessage,
+  PlaySoundCompleteMessage,
   ResultMessage,
   SetBgDataMessage,
   SetSharedAnimationBufferMessage,
@@ -98,6 +99,9 @@ class WebWorkerInterpreter {
           break
         case 'INPUT_VALUE':
           this.handleInputValue(message)
+          break
+        case 'PLAY_SOUND_COMPLETE':
+          this.handlePlaySoundComplete(message)
           break
         case 'CLEAR_DISPLAY':
           logWorker.debug('Handling CLEAR_DISPLAY message')
@@ -231,6 +235,12 @@ class WebWorkerInterpreter {
   handleInputValue(message: InputValueMessage) {
     if (this.webWorkerDeviceAdapter) {
       this.webWorkerDeviceAdapter.handleInputValueMessage(message)
+    }
+  }
+
+  handlePlaySoundComplete(message: PlaySoundCompleteMessage) {
+    if (this.webWorkerDeviceAdapter) {
+      this.webWorkerDeviceAdapter.handlePlaySoundCompleteMessage(message)
     }
   }
 

--- a/src/features/ide/composables/useBasicIdeMessageHandlers.ts
+++ b/src/features/ide/composables/useBasicIdeMessageHandlers.ts
@@ -228,15 +228,16 @@ export function handleProgressMessage(message: AnyServiceWorkerMessage, _context
 
 /**
  * Handle PLAY_SOUND message from web worker
- * Converts flat event array back to per-channel structure and plays via Web Audio API
+ * Converts flat event array back to per-channel structure and plays via Web Audio API.
+ * Sends PLAY_SOUND_COMPLETE back to the worker when audio finishes.
  */
-export function handlePlaySoundMessage(message: AnyServiceWorkerMessage, _context: MessageHandlerContext): void {
+export function handlePlaySoundMessage(message: AnyServiceWorkerMessage, context: MessageHandlerContext): void {
   if (message.type !== 'PLAY_SOUND') return
 
   const playSoundMessage = message
-  const { events } = playSoundMessage.data
+  const { events, executionId, playId } = playSoundMessage.data
 
-  logIdeMessages.debug('🎵 Handling PLAY_SOUND:', events.length, 'events')
+  logIdeMessages.debug('Handling PLAY_SOUND:', events.length, 'events', 'playId:', playId)
 
   // Initialize audio context on first use (requires user gesture)
   if (!audioPlayer.isInitialized.value) {
@@ -283,6 +284,22 @@ export function handlePlaySoundMessage(message: AnyServiceWorkerMessage, _contex
 
   // Play sequentially: next PLAY starts after current melody finishes (F-BASIC behavior)
   audioPlayer.playMusicSequential(channels)
+
+  // Schedule PLAY_SOUND_COMPLETE after total duration so the worker can resume execution
+  const totalDurationMs = audioPlayer.getTotalDurationMs(channels)
+  if (totalDurationMs > 0 && playId) {
+    setTimeout(() => {
+      const worker = context.webWorkerManager.worker
+      if (worker) {
+        worker.postMessage({
+          type: 'PLAY_SOUND_COMPLETE',
+          id: `play-complete-${Date.now()}`,
+          timestamp: Date.now(),
+          data: { executionId, playId },
+        })
+      }
+    }, totalDurationMs)
+  }
 }
 
 /**

--- a/src/features/ide/composables/useWebAudioPlayer.ts
+++ b/src/features/ide/composables/useWebAudioPlayer.ts
@@ -267,6 +267,8 @@ export function useWebAudioPlayer() {
     initialize,
     playMusic,
     playMusicSequential,
+    /** Total playback time (ms) for the given channels. */
+    getTotalDurationMs,
     stopAll,
     cleanup,
   }

--- a/test/core/devices/TestDeviceAdapter.test.ts
+++ b/test/core/devices/TestDeviceAdapter.test.ts
@@ -349,14 +349,14 @@ describe('TestDeviceAdapter', () => {
   // Sound
   // ---------------------------------------------------------------------------
   describe('sound', () => {
-    it('should capture playSound calls', () => {
+    it('should capture playSound calls', async () => {
       const adapter = createAdapter()
       const audio = {
         channels: [[
           { frequency: 440, duration: 500, channel: 0, duty: 2, envelope: 0, volumeOrLength: 15 },
         ]],
       }
-      adapter.playSound!(audio as never)
+      await adapter.playSound!(audio as never)
       expect(adapter.playSoundCalls.length).toBe(1)
     })
 


### PR DESCRIPTION
## Summary
- Fixes #187 (Step 2/5 of #179 — sync PLAY semantics)

## Changes
- Added `PLAY_SOUND_COMPLETE` message type and `PlaySoundCompleteMessage` interface
- Added `playId` to `PlaySoundMessage` for tracking completion
- `PlayExecutor.execute()` is now async — `await`s on `playSound()` until completion signal arrives
- `WebWorkerDeviceAdapter` manages pending play completion promises (resolves on PLAY_SOUND_COMPLETE)
- Main thread schedules `PLAY_SOUND_COMPLETE` via `setTimeout(getTotalDurationMs(channels))`
- Extracted `DevicePlayCompleteHelpers.ts` for promise lifecycle (mirrors DeviceInputRequestHelpers pattern)
- `StatementRouter` awaits PlayExecutor (matching INPUT/PAUSE/LINPUT pattern)
- `TestDeviceAdapter.playSound()` returns immediately resolved promise (no behavior change for tests)

## Architecture
Follows the existing INPUT executor pattern for async blocking:
1. Worker sends PLAY_SOUND with unique `playId`
2. Main thread plays audio and schedules completion message
3. Worker awaits promise → resolves when PLAY_SOUND_COMPLETE arrives
4. Execution continues after audio finishes

## Test plan
- [x] 2867 tests pass (including 18 PlayExecutor + 12 PlayIntegration tests)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes