### PR TITLE
feat: resolve #190 - add BGPLAY sample program demonstrating fire-and-forget audio

### DIFF
--- a/src/core/samples/index.ts
+++ b/src/core/samples/index.ts
@@ -53,6 +53,7 @@ import joystick from './programs/interactive/joystick.bas?raw'
 // Interactive
 import spriteInteractive from './programs/interactive/sprite-interactive.bas?raw'
 import musicArpeggio from './programs/music/arpeggio.bas?raw'
+import musicBgplayDemo from './programs/music/bgplay-demo.bas?raw'
 import musicHappyBirthday from './programs/music/happy-birthday.bas?raw'
 import musicJingleBells from './programs/music/jingle-bells.bas?raw'
 import musicLoopDemo from './programs/music/loop-demo.bas?raw'
@@ -368,6 +369,11 @@ export const SAMPLE_CODES: Record<string, SampleCode> = {
     key: 'musicRocknRouge',
     category: 'music',
     code: musicRocknRouge,
+  },
+  musicBgplayDemo: {
+    key: 'musicBgplayDemo',
+    category: 'music',
+    code: musicBgplayDemo,
   },
 }
 

--- a/src/core/samples/programs/music/bgplay-demo.bas
+++ b/src/core/samples/programs/music/bgplay-demo.bas
@@ -1,0 +1,64 @@
+10 REM * BGPLAY Demo - Background Music & Sound Effects *
+20 REM BGPLAY starts music in the background and returns
+30 REM immediately (fire-and-forget). Your program keeps
+40 REM running while the music plays!
+50 REM In contrast, PLAY blocks until the music finishes.
+60 REM
+70 CLS
+80 PRINT "=== BGPLAY Demo ==="
+90 PRINT "Background music + game loop"
+100 PRINT ""
+110 REM
+120 REM --- Part 1: PLAY vs BGPLAY comparison ---
+130 REM
+140 PRINT "1) PLAY (blocks):"
+150 PRINT "  Playing... (wait for it)";
+160 PLAY "T120O3C5E5G5O4C5"
+170 PRINT " Done!"
+180 PRINT ""
+190 PRINT "2) BGPLAY (fire-and-forget):"
+200 PRINT "  Music started!";
+210 BGPLAY "T120O3C5E5G5O4C5"
+220 PRINT " But I can print right away!"
+230 PAUSE 30
+240 REM Wait for background music to finish before continuing
+250 PRINT ""
+260 REM
+270 REM --- Part 2: Background music during a game loop ---
+280 REM
+290 CLS
+300 PRINT "=== Game Loop + BGPLAY ==="
+310 PRINT "Sprite moves while music plays"
+320 PRINT "Press A = sound effect"
+330 PRINT "Press START = exit"
+340 PRINT ""
+350 REM
+360 REM Start background music (simple melody)
+370 BGPLAY "T100O2C10E10G10O3C10O2B10G10E10C10"
+380 REM
+390 REM Game loop - sprite bounces left and right
+400 X=5
+410 D=1
+420 REM Check for START button (bit 0)
+430 T=STRIG(0)
+440 IF (T AND 1)=1 THEN 560
+450 REM Check for A button (bit 3) - sound effect
+460 IF (T AND 8)=8 THEN GOSUB 600
+470 REM Move sprite position marker
+480 PRINT AT(X,6);"*";
+490 PRINT AT(X-D,6);" ";
+500 X=X+D
+510 IF X>=18 THEN D=-1
+520 IF X<=1 THEN D=1
+530 PAUSE 5
+540 GOTO 420
+550 REM
+560 PRINT AT(0,8);"Goodbye!"
+570 END
+580 REM
+590 REM --- Subroutine: Sound Effect (PLAY blocks briefly) ---
+600 REM PLAY is used for short sound effects because
+610 REM we WANT the brief pause for dramatic effect
+620 PLAY "T255O5L16CCC"
+630 PRINT AT(0,7);"SFX!  ";
+640 RETURN

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -269,6 +269,10 @@
       "musicRocknRouge": {
         "name": "Rock'n Rouge (Seiko Matsuda)",
         "description": "Japanese pop song with 3-channel harmony - demonstrates complex PLAY with GOTO loops (from F-BASIC Manual p.37-38)"
+      },
+      "musicBgplayDemo": {
+        "name": "BGPLAY Demo",
+        "description": "Fire-and-forget background music with game loop - demonstrates BGPLAY vs PLAY and non-blocking sound effects"
       }
     }
   },

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -269,6 +269,10 @@
       "musicRocknRouge": {
         "name": "ロックン・ルージュ（松田聖子）",
         "description": "3チャンネルハーモニー付き日本語ポップス - GOTOループを使った複雑なPLAYをデモ（F-BASICマニュアル p.37-38より）"
+      },
+      "musicBgplayDemo": {
+        "name": "BGPLAY デモ",
+        "description": "バックグラウンド音楽とゲームループ - BGPLAYとPLAYの違いとノンブロッキング効果音をデモ"
       }
     }
   },

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -269,6 +269,10 @@
       "musicRocknRouge": {
         "name": "Rock'n Rouge（松田圣子）",
         "description": "带三声道和声的日语流行歌曲 - 演示使用 GOTO 循环的复杂 PLAY（来自F-BASIC手册第37-38页）"
+      },
+      "musicBgplayDemo": {
+        "name": "BGPLAY 演示",
+        "description": "即发即弃的背景音乐与游戏循环 - 演示 BGPLAY 与 PLAY 的区别以及非阻塞音效"
       }
     }
   },

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -269,6 +269,10 @@
       "musicRocknRouge": {
         "name": "Rock'n Rouge（松田聖子）",
         "description": "帶三聲道和聲的日語流行歌曲 - 示範使用 GOTO 迴圈的複雜 PLAY（來自F-BASIC手冊第37-38頁）"
+      },
+      "musicBgplayDemo": {
+        "name": "BGPLAY 示範",
+        "description": "即發即棄的背景音樂與遊戲迴圈 - 示範 BGPLAY 與 PLAY 的區別以及非阻塞音效"
       }
     }
   },

--- a/test/integration/SampleDisplaySnapshot.test.ts
+++ b/test/integration/SampleDisplaySnapshot.test.ts
@@ -78,6 +78,7 @@ const SNAPSHOT_COVERAGE_OPT_OUTS: SnapshotCoverageOptOuts = {
   musicLoopDemo: 'Audio-focused looping sample; deterministic stop checkpoint pending',
   musicFurElise2Ch: 'Audio-focused sample; display state not primary output',
   musicRocknRouge: 'Audio-focused sample; display state not primary output',
+  musicBgplayDemo: 'Audio-focused sample; display state not primary output',
 }
 
 describe('Sample Display Snapshot Integration', () => {


### PR DESCRIPTION
## Summary
- Fixes #190 (Step 5/5 of #179 — BGPLAY sample program)

## Changes
- New sample program `bgplay-demo.bas` demonstrating BGPLAY fire-and-forget audio
- Part 1: Side-by-side PLAY vs BGPLAY comparison
- Part 2: Game loop with background music via BGPLAY
- Registered sample in `src/core/samples/index.ts`
- Added i18n keys in all 4 locales (en, ja, zh-CN, zh-TW)
- Added snapshot test skip entry for `SampleDisplaySnapshot.test.ts`

## Test plan
- [x] 2868 tests pass
- [x] Type-check clean
- [x] CI passes