### PR TITLE
fix: resolve #270 - guard PLAY_SOUND_COMPLETE against zero totalDurationMs

### DIFF
--- a/src/features/ide/composables/useBasicIdeMessageHandlers.ts
+++ b/src/features/ide/composables/useBasicIdeMessageHandlers.ts
@@ -287,8 +287,8 @@ export function handlePlaySoundMessage(message: AnyServiceWorkerMessage, context
 
   // Schedule PLAY_SOUND_COMPLETE after total duration so the worker can resume execution
   const totalDurationMs = audioPlayer.getTotalDurationMs(channels)
-  if (totalDurationMs > 0 && playId) {
-    setTimeout(() => {
+  if (playId) {
+    const sendComplete = (): void => {
       const worker = context.webWorkerManager.worker
       if (worker) {
         worker.postMessage({
@@ -298,7 +298,12 @@ export function handlePlaySoundMessage(message: AnyServiceWorkerMessage, context
           data: { executionId, playId },
         })
       }
-    }, totalDurationMs)
+    }
+    if (totalDurationMs > 0) {
+      setTimeout(sendComplete, totalDurationMs)
+    } else {
+      sendComplete()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes #270

## Changes
- Extract `sendComplete()` helper for PLAY_SOUND_COMPLETE message
- When `totalDurationMs > 0`: schedule via `setTimeout` (existing behavior)
- When `totalDurationMs === 0`: send immediately instead of skipping
- Prevents worker hang on empty PLAY strings

## Dependencies
- Based on #187 branch (sync PLAY wakeup) — PR #268

## Test plan
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes