### PR TITLE
refactor: resolve #271 - replace Date.now()-based IDs with crypto.randomUUID()

### DIFF
--- a/src/core/devices/DeviceOutputHelpers.ts
+++ b/src/core/devices/DeviceOutputHelpers.ts
@@ -26,7 +26,7 @@ export function postOutputMessage(
   logFn(`${outputType === 'print' ? 'Print' : outputType} output:`, output)
   self.postMessage({
     type: 'OUTPUT',
-    id: `${outputType}-${Date.now()}`,
+    id: `${outputType}-${crypto.randomUUID()}`,
     timestamp: Date.now(),
     data: { executionId, output, outputType, timestamp: Date.now() },
   })
@@ -76,7 +76,7 @@ export function buildPlaySoundMessage(
   musicString?: string,
   playId?: string
 ) {
-  const id = playId ?? `play-sound-${Date.now()}`
+  const id = playId ?? crypto.randomUUID()
   return {
     type: 'PLAY_SOUND' as const,
     id,


### PR DESCRIPTION
## Summary
- Fixes #271
- Replaces `Date.now()`-based IDs in PLAY_SOUND and OUTPUT messages with `crypto.randomUUID()` for guaranteed uniqueness

## Changes
- `src/core/devices/DeviceOutputHelpers.ts`: Two `Date.now()` calls replaced with `crypto.randomUUID()`
  - Output message IDs: `${outputType}-${Date.now()}` → `${outputType}-${crypto.randomUUID()}`
  - PLAY_SOUND playId: `play-sound-${Date.now()}` → `crypto.randomUUID()`
- Follows existing pattern from `src/core/persistence/ProgramDB.ts`

## Test plan
- [x] 2955 tests pass (including 12 DeviceOutputHelpers tests)
- [x] Type-check: clean
- [x] ESLint: clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)