### PR TITLE
refactor: resolve #274 - reduce WebWorkerDeviceAdapter.ts from 504 to under 500 lines

### DIFF
--- a/src/core/devices/DeviceOutputHelpers.ts
+++ b/src/core/devices/DeviceOutputHelpers.ts
@@ -110,6 +110,11 @@ export function postPlaySound(executionId: string, audio: CompiledAudio): string
   return message.data.playId
 }
 
+/** Post a PLAY_SOUND message for background (non-blocking) playback. Used by BGPLAY. */
+export function postPlaySoundBackground(executionId: string, audio: CompiledAudio): void {
+  postPlaySound(executionId, audio)
+}
+
 /** Post a BEEP message to main thread. */
 export function postBeep(executionId: string): void {
   logWorker.debug('Playing beep')

--- a/src/core/devices/WebWorkerDeviceAdapter.ts
+++ b/src/core/devices/WebWorkerDeviceAdapter.ts
@@ -12,7 +12,6 @@ import type {
   ExecutionResult,
   InputValueMessage,
   InterpreterConfig,
-  OutputMessage,
   PlaySoundCompleteMessage,
 } from '@/core/interfaces'
 import type { CompiledAudio } from '@/core/sound/types'
@@ -36,7 +35,7 @@ import {
   handleInputValueMessage as handleInputValue,
   rejectAllInputRequests as rejectAllInput,
 } from './DeviceInputRequestHelpers'
-import { postBeep, postOutputMessage, postPlaySound } from './DeviceOutputHelpers'
+import { postBeep, postOutputMessage, postPlaySound, postPlaySoundBackground } from './DeviceOutputHelpers'
 import { createPlayCompleteRequest, handlePlaySoundCompleteMessage as handlePlayComplete, rejectAllPlayCompleteRequests as rejectAllPlayComplete } from './DevicePlayCompleteHelpers'
 import {
   getSpritePosition as getSpritePositionFromHelper,
@@ -449,15 +448,13 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
 
   /** Play compiled audio synchronously. Blocks until PLAY_SOUND_COMPLETE is received. */
   playSound(audio: CompiledAudio): Promise<void> {
-    const executionId = this.screenStateManager.getCurrentExecutionId() ?? 'unknown'
-    const playId = postPlaySound(executionId, audio)
+    const playId = postPlaySound(this.screenStateManager.getCurrentExecutionId() ?? 'unknown', audio)
     return createPlayCompleteRequest(this.pendingPlayComplete, playId)
   }
 
   /** Play compiled audio in background (non-blocking). Used by BGPLAY statement. */
   playSoundBackground(audio: CompiledAudio): void {
-    const executionId = this.screenStateManager.getCurrentExecutionId() ?? 'unknown'
-    postPlaySound(executionId, audio)
+    postPlaySoundBackground(this.screenStateManager.getCurrentExecutionId() ?? 'unknown', audio)
   }
 
   /** Play a beep sound. */
@@ -486,14 +483,10 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
 
   private handleWorkerMessage(message: AnyServiceWorkerMessage): void {
     this.messageHandler.handleWorkerMessage(message, outputMessage => {
-      this.handleOutputMessage(outputMessage)
-    })
-  }
-
-  private handleOutputMessage(message: OutputMessage): void {
-    logWorker.debug('Handling OUTPUT message:', {
-      outputType: message.data.outputType,
-      outputLength: message.data.output.length,
+      logWorker.debug('Handling OUTPUT message:', {
+        outputType: outputMessage.data.outputType,
+        outputLength: outputMessage.data.output.length,
+      })
     })
   }
 


### PR DESCRIPTION
## Summary
- Fixes #274
- Reduces WebWorkerDeviceAdapter.ts from 504 to 497 lines (7 under limit)

## Changes
- **`DeviceOutputHelpers.ts`** (+4 lines): Added `postPlaySoundBackground()` helper for fire-and-forget BGPLAY audio dispatch
- **`WebWorkerDeviceAdapter.ts`** (-7 lines): Extracted `playSoundBackground()` body to helper, inlined `handleOutputMessage()`, streamlined `playSound()`

## Test plan
- [x] 2955 tests pass (including 27 WebWorkerDeviceAdapter + 12 DeviceOutputHelpers)
- [x] Type-check: clean
- [x] ESLint: clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)