### PR TITLE
refactor: resolve #280 - extract hardcoded sprite count constant

### DIFF
--- a/src/core/animation/bufferSpriteOperations.ts
+++ b/src/core/animation/bufferSpriteOperations.ts
@@ -53,7 +53,7 @@ export function writeSpriteStateToView(
  * Sets all sprites to inactive, invisible, with characterType = -1 (uninitialized).
  */
 export function clearAllSprites(spriteView: Float64Array): void {
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < MAX_SPRITES; i++) {
     writeSpriteStateToView(spriteView, i, 0, 0, false, false, 0, 0, 0, 0, 0, 0, -1, 0)
   }
 }
@@ -214,7 +214,7 @@ export function readAllMovementStates(
     }
   }> = []
 
-  for (let actionNumber = 0; actionNumber < 8; actionNumber++) {
+  for (let actionNumber = 0; actionNumber < MAX_SPRITES; actionNumber++) {
     const characterType = readCharacterType(actionNumber)
     // characterType = -1 means uninitialized (no DEF MOVE)
     // characterType >= 0 means a valid DEF MOVE exists

--- a/src/core/animation/sharedDisplayBuffer.ts
+++ b/src/core/animation/sharedDisplayBuffer.ts
@@ -17,7 +17,9 @@
 // SPRITE SECTION CONSTANTS
 // ============================================================================
 
-export const MAX_SPRITES = 8
+import { SCREEN_DIMENSIONS } from '@/core/constants'
+
+export const MAX_SPRITES = SCREEN_DIMENSIONS.SPRITE_COUNT
 // 12 floats per sprite: x, y, isActive, isVisible, frameIndex, remainingDistance, totalDistance,
 // direction, speed, priority, characterType, colorCombination
 export const FLOATS_PER_SPRITE = 12

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -186,6 +186,8 @@ export const SCREEN_DIMENSIONS = {
     DEFAULT_X: 128,
     DEFAULT_Y: 120,
   },
+  /** Number of sprite slots (0 to SPRITE_COUNT-1). Hardware limit for F-BASIC. */
+  SPRITE_COUNT: 8,
 } as const
 
 // Color patterns and codes

--- a/src/core/sprite/SpriteStateManager.ts
+++ b/src/core/sprite/SpriteStateManager.ts
@@ -3,10 +3,12 @@
  * Manages sprite definitions and states for DEF SPRITE and SPRITE commands
  */
 
+import { SCREEN_DIMENSIONS } from '@/core/constants'
+
 import type { DefSpriteDefinition, SpriteState } from './types'
 
 /**
- * SpriteStateManager - Manages 8 sprite slots (0-7)
+ * SpriteStateManager - Manages sprite slots (0 to SPRITE_COUNT-1)
  * Handles sprite definitions, positions, visibility, and priority
  */
 export class SpriteStateManager {
@@ -14,8 +16,8 @@ export class SpriteStateManager {
   private spriteEnabled = false
 
   constructor() {
-    // Initialize 8 sprite slots
-    for (let i = 0; i < 8; i++) {
+    // Initialize sprite slots
+    for (let i = 0; i < SCREEN_DIMENSIONS.SPRITE_COUNT; i++) {
       this.spriteStates.set(i, {
         spriteNumber: i,
         x: 0,
@@ -117,7 +119,7 @@ export class SpriteStateManager {
   clear(): void {
     this.spriteStates.clear()
     // Reinitialize
-    for (let i = 0; i < 8; i++) {
+    for (let i = 0; i < SCREEN_DIMENSIONS.SPRITE_COUNT; i++) {
       this.spriteStates.set(i, {
         spriteNumber: i,
         x: 0,


### PR DESCRIPTION
## Summary
- Fixes #280 — extracts hardcoded `8` sprite count into `SCREEN_DIMENSIONS.SPRITE_COUNT` in `src/core/constants.ts`

## Changes
- `src/core/constants.ts` — Added `SPRITE_COUNT: 8` to `SCREEN_DIMENSIONS` object
- `src/core/sprite/SpriteStateManager.ts` — Replaced 2 hardcoded `8` values with `SCREEN_DIMENSIONS.SPRITE_COUNT`
- `src/core/animation/sharedDisplayBuffer.ts` — Changed `MAX_SPRITES = 8` to `MAX_SPRITES = SCREEN_DIMENSIONS.SPRITE_COUNT`
- `src/core/animation/bufferSpriteOperations.ts` — Replaced 2 remaining hardcoded `8` values with existing `MAX_SPRITES` import

## Test plan
- [x] 2998 tests pass (no test changes, pure refactor)
- [x] Type-check: clean
- [x] ESLint: clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)