### PR TITLE
fix: resolve #301 - swap bg-items and printable-area sample code assignments

### DIFF
--- a/src/core/samples/index.ts
+++ b/src/core/samples/index.ts
@@ -168,7 +168,8 @@ export const SAMPLE_CODES: Record<string, SampleCode> = {
   bgItems: {
     key: 'bgItems',
     category: 'screen',
-    code: bgItems,
+    bgKey: 'layerBox',
+    code: printableArea,
   },
   bgView: {
     key: 'bgView',
@@ -201,8 +202,7 @@ export const SAMPLE_CODES: Record<string, SampleCode> = {
   printableArea: {
     key: 'printableArea',
     category: 'screen',
-    bgKey: 'layerBox',
-    code: printableArea,
+    code: bgItems,
   },
 
   // === SPRITES ===


### PR DESCRIPTION
## Summary
- Fixes #301

## Changes
- Swapped `code` values between `bgItems` and `printableArea` entries in `src/core/samples/index.ts`
- Moved `bgKey: 'layerBox'` to the correct entry (BG overlap demo)
- Now "BG Items" shows the BG overlap demo and "Printable Area" shows the character printing code

## Test plan
- [x] Targeted tests pass (3005 tests)
- [x] Type-check passes
- [ ] CI passes