### PR TITLE
fix: resolve #303 - reject pending play complete requests on CLEAR

### DIFF
--- a/src/core/workers/WebWorkerInterpreter.ts
+++ b/src/core/workers/WebWorkerInterpreter.ts
@@ -249,6 +249,8 @@ class WebWorkerInterpreter {
     this.webWorkerDeviceAdapter?.clearAllSpritePositions?.()
     // Reset sound state when CLEAR is pressed
     this.webWorkerDeviceAdapter?.resetSoundState?.()
+    // Reject pending play complete promises so PLAY executor doesn't hang
+    this.webWorkerDeviceAdapter?.rejectAllInputRequests?.('CLEAR pressed during PLAY')
   }
 
   handleStrigEvent(message: StrigEventMessage) {


### PR DESCRIPTION
## Summary
- Fixes #303

## Changes
- Added `rejectAllInputRequests('CLEAR pressed during PLAY')` call in `WebWorkerInterpreter.handleClearDisplay()`
- This rejects both pending input requests AND pending play complete promises, preventing the interpreter hang

## Test plan
- [x] Targeted tests pass (3005 tests)
- [x] Type-check passes
- [ ] CI passes