### PR TITLE
fix: resolve #306 - auto-focus input field when INPUT modal becomes visible

### DIFF
--- a/src/features/ide/components/InputModal.vue
+++ b/src/features/ide/components/InputModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { nextTick, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { RequestInputMessage } from '@/core/interfaces'
@@ -15,6 +15,11 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const inputValue = ref<string | number>('')
+const formRef = useTemplateRef<HTMLFormElement>('formRef')
+
+function focusInput(): void {
+  formRef.value?.querySelector<HTMLInputElement>('input')?.focus()
+}
 
 const submit = () => {
   const req = props.pendingRequest
@@ -34,8 +39,11 @@ const cancel = () => {
 
 watch(
   () => props.pendingRequest,
-  () => {
+  (request) => {
     inputValue.value = ''
+    if (request) {
+      void nextTick(() => focusInput())
+    }
   },
 )
 </script>
@@ -52,7 +60,7 @@ watch(
       <p id="input-modal-prompt" class="input-modal-prompt">
         {{ pendingRequest.prompt }}
       </p>
-      <form class="input-modal-form" @submit.prevent="submit">
+      <form ref="formRef" class="input-modal-form" @submit.prevent="submit">
         <GameInput
           v-model="inputValue"
           type="text"

--- a/test/ide/InputModal.test.ts
+++ b/test/ide/InputModal.test.ts
@@ -190,4 +190,48 @@ describe('InputModal', () => {
     expect(form.exists()).toBe(true)
     wrapper.unmount()
   })
+
+  it('auto-focuses the input field when modal becomes visible', async () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: null },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    expect(wrapper.find('[data-testid="game-input"]').exists()).toBe(false)
+
+    await wrapper.setProps({ pendingRequest: createPendingRequest() })
+    await nextTick()
+    await nextTick()
+
+    const input = wrapper.find('[data-testid="game-input"]').element as HTMLInputElement
+    expect(focusSpy).toHaveBeenCalledWith()
+    expect(focusSpy.mock.instances).toContain(input)
+    focusSpy.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('re-focuses the input field when pendingRequest changes', async () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: createPendingRequest({ requestId: 'req-1' }) },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+    await nextTick()
+    await nextTick()
+    focusSpy.mockClear()
+
+    // Change the request — input should be re-focused
+    await wrapper.setProps({ pendingRequest: createPendingRequest({ requestId: 'req-2' }) })
+    await nextTick()
+    await nextTick()
+
+    const newInput = wrapper.find('[data-testid="game-input"]').element as HTMLInputElement
+    expect(focusSpy).toHaveBeenCalledWith()
+    expect(focusSpy.mock.instances).toContain(newInput)
+    focusSpy.mockRestore()
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes #306

## Changes
- Added `focusInput()` helper using `useTemplateRef('formRef')` to query the inner `<input>` and call `.focus()`
- Extended `pendingRequest` watcher to call `nextTick(() => focusInput())` when modal becomes visible
- Follows the same pattern as `CommandPalette.vue` and `ConfirmDialog.vue`
- Added 2 tests: auto-focus on first show and re-focus on subsequent requests

## Test plan
- [x] Targeted tests pass (13 InputModal tests, 3007 total)
- [x] Type-check passes
- [ ] CI passes