### PR TITLE
fix: resolve #314 - replace invalid L command in PLAY strings with explicit note lengths

### DIFF
--- a/src/core/samples/programs/music/bgplay-demo.bas
+++ b/src/core/samples/programs/music/bgplay-demo.bas
@@ -59,6 +59,6 @@
 590 REM --- Subroutine: Sound Effect (PLAY blocks briefly) ---
 600 REM PLAY is used for short sound effects because
 610 REM we WANT the brief pause for dramatic effect
-620 PLAY "T255O5L16CCC"
+620 PLAY "T255O5C1C1C1"
 630 LOCATE 0,7:PRINT "SFX!  ";
 640 RETURN

--- a/src/core/samples/programs/music/play-demo.bas
+++ b/src/core/samples/programs/music/play-demo.bas
@@ -9,7 +9,7 @@
 90 PAUSE 30
 100 REM Eighth-note scale (faster)
 110 PRINT "Eighth notes:"
-120 PLAY "T120L8O2CDEFGABO3C"
+120 PLAY "T120O2C3D3E3F3G3A3B3O3C3"
 130 PAUSE 30
 140 REM Half notes (slow)
 150 PRINT "Half notes:"


### PR DESCRIPTION
## Summary
- Fixes #314

## Changes
- `play-demo.bas` line 120: Replaced `"T120L8O2CDEFGABO3C"` with `"T120O2C3D3E3F3G3A3B3O3C3"` — each note uses explicit length code 3 (eighth note)
- `bgplay-demo.bas` line 620: Replaced `"T255O5L16CCC"` with `"T255O5C1C1C1"` — each note uses explicit length code 1 (sixteenth note)

## Deviation from issue
The issue suggested `C5C5C5` for bgplay-demo.bas, but length code 5 is a quarter note (1/4), not sixteenth (1/16). Length code 1 (1/16) is the correct F-BASIC equivalent of L16.

## Test plan
- [x] Targeted tests pass (music tests: 3005 total)
- [x] Type-check clean
- [ ] CI passes