### PR TITLE
refactor: resolve #310 - rename rejectAllInputRequests to rejectAllPendingRequests

### DIFF
--- a/src/core/devices/WebWorkerDeviceAdapter.ts
+++ b/src/core/devices/WebWorkerDeviceAdapter.ts
@@ -419,8 +419,8 @@ export class WebWorkerDeviceAdapter implements BasicDeviceAdapter {
     handlePlayComplete(this.pendingPlayComplete, message)
   }
 
-  /** Reject all pending input requests. */
-  rejectAllInputRequests(reason: string = 'Execution stopped'): void {
+  /** Reject all pending input and play complete requests. */
+  rejectAllPendingRequests(reason: string = 'Execution stopped'): void {
     rejectAllInput(this.pendingInputRequests, reason)
     rejectAllPlayComplete(this.pendingPlayComplete, reason)
   }

--- a/src/core/workers/WebWorkerInterpreter.ts
+++ b/src/core/workers/WebWorkerInterpreter.ts
@@ -224,7 +224,7 @@ class WebWorkerInterpreter {
     })
     this.isRunning = false
     if (this.webWorkerDeviceAdapter) {
-      this.webWorkerDeviceAdapter.rejectAllInputRequests('Execution stopped')
+      this.webWorkerDeviceAdapter.rejectAllPendingRequests('Execution stopped')
     }
     if (this.interpreter) {
       logWorker.debug('Calling interpreter.stop()')


### PR DESCRIPTION
## Summary
- Fixes #310

## Changes
- Renamed `WebWorkerDeviceAdapter.rejectAllInputRequests()` to `rejectAllPendingRequests()` — the method also rejects play complete requests (since PR #268), not just input requests
- Updated call site in `WebWorkerInterpreter.ts`
- Updated JSDoc to mention both input and play complete requests

## Test plan
- [x] All 3005 tests pass
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes