### PR TITLE
refactor: resolve #327 - internationalize hardcoded command palette strings in IdePage.vue

### DIFF
--- a/src/core/workers/WebWorkerInterpreter.ts
+++ b/src/core/workers/WebWorkerInterpreter.ts
@@ -250,7 +250,7 @@ class WebWorkerInterpreter {
     // Reset sound state when CLEAR is pressed
     this.webWorkerDeviceAdapter?.resetSoundState?.()
     // Reject pending play complete promises so PLAY executor doesn't hang
-    this.webWorkerDeviceAdapter?.rejectAllInputRequests?.('CLEAR pressed during PLAY')
+    this.webWorkerDeviceAdapter?.rejectAllPendingRequests?.('CLEAR pressed during PLAY')
   }
 
   handleStrigEvent(message: StrigEventMessage) {

--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, shallowRef, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
@@ -36,6 +37,8 @@ import { provideScreenContext } from './composables/useScreenContext'
 defineOptions({
   name: 'IdePage',
 })
+
+const { t } = useI18n()
 
 const isE2ELite =
   typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('e2e') === 'lite'
@@ -203,8 +206,8 @@ async function restartCode() {
 const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
   {
     id: 'run.start',
-    title: 'Run Program',
-    description: 'Execute the current BASIC program.',
+    title: t('ide.commandPalette.commands.runStart.title'),
+    description: t('ide.commandPalette.commands.runStart.description'),
     shortcut: 'Ctrl+Enter / Cmd+Enter',
     keywords: ['execute', 'start', 'run'],
     enabled: !isRunning.value,
@@ -214,8 +217,8 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
   },
   {
     id: 'run.stop',
-    title: 'Stop Program',
-    description: 'Stop the currently running program.',
+    title: t('ide.commandPalette.commands.runStop.title'),
+    description: t('ide.commandPalette.commands.runStop.description'),
     shortcut: 'Ctrl+Shift+Enter / Cmd+Shift+Enter',
     keywords: ['halt', 'stop'],
     enabled: isRunning.value,
@@ -223,8 +226,8 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
   },
   {
     id: 'run.restart',
-    title: 'Restart Program',
-    description: 'Stop and execute the current program again.',
+    title: t('ide.commandPalette.commands.runRestart.title'),
+    description: t('ide.commandPalette.commands.runRestart.description'),
     shortcut: 'Ctrl+Shift+R / Cmd+Shift+R',
     keywords: ['restart', 'rerun'],
     execute: () => {
@@ -233,15 +236,15 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
   },
   {
     id: 'run.clearOutput',
-    title: 'Clear Output',
-    description: 'Clear output, errors, variables, and screen state.',
+    title: t('ide.commandPalette.commands.runClearOutput.title'),
+    description: t('ide.commandPalette.commands.runClearOutput.description'),
     keywords: ['clear', 'output', 'screen'],
     execute: clearOutput,
   },
   {
     id: 'view.openSampleSelector',
-    title: 'Load Sample Program',
-    description: 'Open the sample selector.',
+    title: t('ide.commandPalette.commands.viewOpenSampleSelector.title'),
+    description: t('ide.commandPalette.commands.viewOpenSampleSelector.description'),
     keywords: ['sample', 'demo'],
     execute: () => {
       sampleSelectorOpen.value = true
@@ -249,8 +252,8 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
   },
   {
     id: 'view.openLogFilters',
-    title: 'Open Output Log Filters',
-    description: 'Open runtime output log-level controls.',
+    title: t('ide.commandPalette.commands.viewOpenLogFilters.title'),
+    description: t('ide.commandPalette.commands.viewOpenLogFilters.description'),
     keywords: ['output', 'logs', 'filters'],
     execute: () => {
       logLevelPanelOpen.value = true
@@ -258,8 +261,8 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
   },
   {
     id: 'view.switchToCode',
-    title: 'Switch To Code Editor',
-    description: 'Show the Monaco code editor panel.',
+    title: t('ide.commandPalette.commands.viewSwitchToCode.title'),
+    description: t('ide.commandPalette.commands.viewSwitchToCode.description'),
     keywords: ['code', 'editor'],
     execute: () => {
       editorView.value = 'code'
@@ -267,8 +270,8 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
   },
   {
     id: 'view.switchToBgEditor',
-    title: 'Switch To BG Editor',
-    description: 'Show the BG editor panel.',
+    title: t('ide.commandPalette.commands.viewSwitchToBgEditor.title'),
+    description: t('ide.commandPalette.commands.viewSwitchToBgEditor.description'),
     keywords: ['bg', 'background', 'editor'],
     execute: () => {
       editorView.value = 'bg'
@@ -276,16 +279,16 @@ const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
   },
   {
     id: 'input.toggleMode',
-    title: 'Toggle Input Mode',
-    description: 'Switch between joystick and keyboard input mode.',
+    title: t('ide.commandPalette.commands.inputToggleMode.title'),
+    description: t('ide.commandPalette.commands.inputToggleMode.description'),
     shortcut: 'F9',
     keywords: ['input', 'keyboard', 'joystick'],
     execute: toggleInputMode,
   },
   {
     id: 'debug.toggle',
-    title: 'Toggle Debug Mode',
-    description: 'Enable or disable runtime debug output.',
+    title: t('ide.commandPalette.commands.debugToggle.title'),
+    description: t('ide.commandPalette.commands.debugToggle.description'),
     keywords: ['debug'],
     execute: toggleDebugMode,
   },

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -341,7 +341,49 @@
     "searchPlaceholder": "Type a command...",
     "searchLabel": "Search commands",
     "commandsLabel": "Commands",
-    "noMatches": "No matching commands"
+    "noMatches": "No matching commands",
+    "commands": {
+      "runStart": {
+        "title": "Run Program",
+        "description": "Execute the current BASIC program."
+      },
+      "runStop": {
+        "title": "Stop Program",
+        "description": "Stop the currently running program."
+      },
+      "runRestart": {
+        "title": "Restart Program",
+        "description": "Stop and execute the current program again."
+      },
+      "runClearOutput": {
+        "title": "Clear Output",
+        "description": "Clear output, errors, variables, and screen state."
+      },
+      "viewOpenSampleSelector": {
+        "title": "Load Sample Program",
+        "description": "Open the sample selector."
+      },
+      "viewOpenLogFilters": {
+        "title": "Open Output Log Filters",
+        "description": "Open runtime output log-level controls."
+      },
+      "viewSwitchToCode": {
+        "title": "Switch To Code Editor",
+        "description": "Show the Monaco code editor panel."
+      },
+      "viewSwitchToBgEditor": {
+        "title": "Switch To BG Editor",
+        "description": "Show the BG editor panel."
+      },
+      "inputToggleMode": {
+        "title": "Toggle Input Mode",
+        "description": "Switch between joystick and keyboard input mode."
+      },
+      "debugToggle": {
+        "title": "Toggle Debug Mode",
+        "description": "Enable or disable runtime debug output."
+      }
+    }
   },
   "ideOutputPanel": {
     "closeLogLevels": "Close log levels",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -341,7 +341,49 @@
     "searchPlaceholder": "コマンドを入力...",
     "searchLabel": "コマンドを検索",
     "commandsLabel": "コマンド",
-    "noMatches": "一致するコマンドがありません"
+    "noMatches": "一致するコマンドがありません",
+    "commands": {
+      "runStart": {
+        "title": "プログラムを実行",
+        "description": "現在のBASICプログラムを実行します。"
+      },
+      "runStop": {
+        "title": "プログラムを停止",
+        "description": "現在実行中のプログラムを停止します。"
+      },
+      "runRestart": {
+        "title": "プログラムを再実行",
+        "description": "現在のプログラムを停止して再度実行します。"
+      },
+      "runClearOutput": {
+        "title": "出力をクリア",
+        "description": "出力、エラー、変数、画面状態をクリアします。"
+      },
+      "viewOpenSampleSelector": {
+        "title": "サンプルプログラムを読み込む",
+        "description": "サンプルセレクターを開きます。"
+      },
+      "viewOpenLogFilters": {
+        "title": "出力ログフィルターを開く",
+        "description": "ランタイム出力のログレベル制御を開きます。"
+      },
+      "viewSwitchToCode": {
+        "title": "コードエディターに切り替え",
+        "description": "Monacoコードエディターパネルを表示します。"
+      },
+      "viewSwitchToBgEditor": {
+        "title": "BGエディターに切り替え",
+        "description": "BGエディターパネルを表示します。"
+      },
+      "inputToggleMode": {
+        "title": "入力モードを切り替え",
+        "description": "ジョイスティックとキーボードの入力モードを切り替えます。"
+      },
+      "debugToggle": {
+        "title": "デバッグモードを切り替え",
+        "description": "ランタイムデバッグ出力の有効/無効を切り替えます。"
+      }
+    }
   },
   "ideOutputPanel": {
     "closeLogLevels": "ログレベルを閉じる",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -341,7 +341,49 @@
     "searchPlaceholder": "输入命令...",
     "searchLabel": "搜索命令",
     "commandsLabel": "命令",
-    "noMatches": "没有匹配的命令"
+    "noMatches": "没有匹配的命令",
+    "commands": {
+      "runStart": {
+        "title": "运行程序",
+        "description": "执行当前的 BASIC 程序。"
+      },
+      "runStop": {
+        "title": "停止程序",
+        "description": "停止当前正在运行的程序。"
+      },
+      "runRestart": {
+        "title": "重新运行程序",
+        "description": "停止并重新执行当前程序。"
+      },
+      "runClearOutput": {
+        "title": "清除输出",
+        "description": "清除输出、错误、变量和屏幕状态。"
+      },
+      "viewOpenSampleSelector": {
+        "title": "加载示例程序",
+        "description": "打开示例选择器。"
+      },
+      "viewOpenLogFilters": {
+        "title": "打开输出日志筛选器",
+        "description": "打开运行时输出的日志级别控制。"
+      },
+      "viewSwitchToCode": {
+        "title": "切换到代码编辑器",
+        "description": "显示 Monaco 代码编辑面板。"
+      },
+      "viewSwitchToBgEditor": {
+        "title": "切换到 BG 编辑器",
+        "description": "显示 BG 编辑面板。"
+      },
+      "inputToggleMode": {
+        "title": "切换输入模式",
+        "description": "在手柄和键盘输入模式之间切换。"
+      },
+      "debugToggle": {
+        "title": "切换调试模式",
+        "description": "启用或禁用运行时调试输出。"
+      }
+    }
   },
   "ideOutputPanel": {
     "closeLogLevels": "关闭日志级别",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -341,7 +341,49 @@
     "searchPlaceholder": "輸入命令...",
     "searchLabel": "搜尋命令",
     "commandsLabel": "命令",
-    "noMatches": "沒有符合的命令"
+    "noMatches": "沒有符合的命令",
+    "commands": {
+      "runStart": {
+        "title": "執行程式",
+        "description": "執行目前的 BASIC 程式。"
+      },
+      "runStop": {
+        "title": "停止程式",
+        "description": "停止目前正在執行的程式。"
+      },
+      "runRestart": {
+        "title": "重新執行程式",
+        "description": "停止並重新執行目前的程式。"
+      },
+      "runClearOutput": {
+        "title": "清除輸出",
+        "description": "清除輸出、錯誤、變數和螢幕狀態。"
+      },
+      "viewOpenSampleSelector": {
+        "title": "載入範例程式",
+        "description": "開啟範例選擇器。"
+      },
+      "viewOpenLogFilters": {
+        "title": "開啟輸出日誌篩選器",
+        "description": "開啟執行時輸出的日誌級別控制。"
+      },
+      "viewSwitchToCode": {
+        "title": "切換到程式碼編輯器",
+        "description": "顯示 Monaco 程式碼編輯面板。"
+      },
+      "viewSwitchToBgEditor": {
+        "title": "切換到 BG 編輯器",
+        "description": "顯示 BG 編輯面板。"
+      },
+      "inputToggleMode": {
+        "title": "切換輸入模式",
+        "description": "在搖桿和鍵盤輸入模式之間切換。"
+      },
+      "debugToggle": {
+        "title": "切換除錯模式",
+        "description": "啟用或停用執行時除錯輸出。"
+      }
+    }
   },
   "ideOutputPanel": {
     "closeLogLevels": "關閉日誌級別",


### PR DESCRIPTION
## Summary
- Fixes #327

## Changes
- Added `useI18n` import and `t()` calls to `IdePage.vue` for all 20 command palette strings (10 titles + 10 descriptions)
- Added `commandPalette.commands` i18n keys to all 4 locale files (en, ja, zh-CN, zh-TW)
- Also fixed missed `rejectAllInputRequests` → `rejectAllPendingRequests` rename from PR #310

## Test plan
- [x] Type-check passes
- [x] ESLint passes
- [x] 175 test files, 3121 tests — all passing
- [ ] CI passes