### PR TITLE
refactor: resolve #324 - import directly from domain-specific type modules

### DIFF
--- a/src/core/animation/AnimationManager.ts
+++ b/src/core/animation/AnimationManager.ts
@@ -7,8 +7,8 @@ import { getSpriteSizeForMoveDefinition } from '@/core/animation/CharacterAnimat
 import { SHARED_DISPLAY_BUFFER_BYTES, SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import { SCREEN_DIMENSIONS } from '@/core/constants'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import type { MoveDefinition, MovementState } from '@/core/sprite/types'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 import { logWorker } from '@/shared/logger'
 
 const SYNC_ACK_WAIT_TIMEOUT_MS = 16

--- a/src/core/animation/bufferScreenOperations.ts
+++ b/src/core/animation/bufferScreenOperations.ts
@@ -7,7 +7,7 @@
  * These functions operate on typed array views created from the shared buffer.
  */
 
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 import { logCore } from '@/shared/logger'
 import { getCharacterByCode, getCodeByChar } from '@/shared/utils/backgroundLookup'
 

--- a/src/core/animation/sharedDisplayBufferAccessor.ts
+++ b/src/core/animation/sharedDisplayBufferAccessor.ts
@@ -16,7 +16,7 @@
  * @see {@link docs/reference/shared-display-buffer.md} for full buffer layout
  */
 
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 
 import {
   incrementSequence as incrementSequenceToOps,

--- a/src/core/animation/sharedDisplayBufferTypes.ts
+++ b/src/core/animation/sharedDisplayBufferTypes.ts
@@ -5,7 +5,7 @@
  * Extracted from sharedDisplayBufferAccessor.ts for modularity.
  */
 
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 
 import type { SyncCommandType } from './sharedDisplayBuffer'
 

--- a/src/core/devices/DeviceBgGraphicHelpers.ts
+++ b/src/core/devices/DeviceBgGraphicHelpers.ts
@@ -7,7 +7,7 @@
  * Handles: VIEW command (copy BG GRAPHIC data to background screen).
  */
 
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 import type { BgGridData } from '@/features/bg-editor/types'
 
 /**

--- a/src/core/devices/DeviceInputRequestHelpers.ts
+++ b/src/core/devices/DeviceInputRequestHelpers.ts
@@ -7,7 +7,7 @@
  * Handles: INPUT/LINPUT request/response lifecycle.
  */
 
-import type { InputValueMessage } from '@/core/interfaces'
+import type { InputValueMessage } from '@/core/types/worker-messages'
 
 // ============================================================================
 // Input Request State

--- a/src/core/devices/DevicePlayCompleteHelpers.ts
+++ b/src/core/devices/DevicePlayCompleteHelpers.ts
@@ -8,7 +8,7 @@
  * Pattern mirrors DeviceInputRequestHelpers (INPUT_VALUE).
  */
 
-import type { PlaySoundCompleteMessage } from '@/core/interfaces'
+import type { PlaySoundCompleteMessage } from '@/core/types/worker-messages'
 
 // ============================================================================
 // Play Complete State

--- a/src/core/devices/MessageHandler.ts
+++ b/src/core/devices/MessageHandler.ts
@@ -4,7 +4,8 @@
  * Handles messages from web workers and routes them appropriately.
  */
 
-import type { AnyServiceWorkerMessage, ExecutionResult, OutputMessage } from '@/core/interfaces'
+import type { ExecutionResult } from '@/core/types/execution-types'
+import type { AnyServiceWorkerMessage, OutputMessage } from '@/core/types/worker-messages'
 import { logIdeMessages } from '@/shared/logger'
 
 export interface PendingMessage {

--- a/src/core/devices/ScreenStateManager.ts
+++ b/src/core/devices/ScreenStateManager.ts
@@ -4,7 +4,8 @@
  * Manages screen buffer, cursor position, and screen-related operations.
  */
 
-import type { ScreenCell, ScreenUpdateMessage } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
+import type { ScreenUpdateMessage } from '@/core/types/worker-messages'
 import { BACKGROUND_PALETTES, SPRITE_PALETTES } from '@/shared/data/palette'
 import { logDevice } from '@/shared/logger'
 

--- a/src/core/devices/TestDeviceAdapter.ts
+++ b/src/core/devices/TestDeviceAdapter.ts
@@ -5,8 +5,8 @@
  * Provides controlled behavior for testing without external dependencies.
  */
 
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import type { CompiledAudio } from '@/core/sound/types'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 import { logDevice } from '@/shared/logger'
 
 import {

--- a/src/core/devices/WebWorkerDeviceAdapter.ts
+++ b/src/core/devices/WebWorkerDeviceAdapter.ts
@@ -6,16 +6,11 @@
  */
 
 import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
-import type {
-  AnyServiceWorkerMessage,
-  BasicDeviceAdapter,
-  ExecutionResult,
-  InputValueMessage,
-  InterpreterConfig,
-  PlaySoundCompleteMessage,
-} from '@/core/interfaces'
 import type { CompiledAudio } from '@/core/sound/types'
 import type { SpriteState } from '@/core/sprite/types'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
+import type { ExecutionResult, InterpreterConfig } from '@/core/types/execution-types'
+import type { AnyServiceWorkerMessage, InputValueMessage, PlaySoundCompleteMessage } from '@/core/types/worker-messages'
 import type { BgGridData } from '@/features/bg-editor/types'
 import { logWorker } from '@/shared/logger'
 

--- a/src/core/devices/WebWorkerManager.ts
+++ b/src/core/devices/WebWorkerManager.ts
@@ -6,14 +6,8 @@
  */
 
 import { DEFAULTS } from '@/core/constants'
-import type {
-  AnyServiceWorkerMessage,
-  ExecuteMessage,
-  ExecutionResult,
-  InterpreterConfig,
-  SetBgDataMessage,
-  StopMessage,
-} from '@/core/interfaces'
+import type { ExecutionResult, InterpreterConfig } from '@/core/types/execution-types'
+import type { AnyServiceWorkerMessage, ExecuteMessage, SetBgDataMessage, StopMessage } from '@/core/types/worker-messages'
 import { logWorker } from '@/shared/logger'
 
 export interface WebWorkerExecutionOptions {

--- a/src/core/evaluation/FunctionEvaluator.ts
+++ b/src/core/evaluation/FunctionEvaluator.ts
@@ -7,9 +7,9 @@
 
 import type { CstNode } from 'chevrotain'
 
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import { getCstNodes, getFirstCstNode, getFirstToken } from '@/core/parser/cst-helpers'
 import type { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 import { toNumber } from './StringFunctions'
 import {

--- a/src/core/execution/ExecutionEngine.ts
+++ b/src/core/execution/ExecutionEngine.ts
@@ -6,10 +6,11 @@
 
 import { DEFAULTS, ERROR_TYPES } from '@/core/constants'
 import { ExpressionEvaluator } from '@/core/evaluation/ExpressionEvaluator'
-import type { BasicDeviceAdapter, ExecutionResult } from '@/core/interfaces'
 import { DataService } from '@/core/services/DataService'
 import { VariableService } from '@/core/services/VariableService'
 import type { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
+import type { ExecutionResult } from '@/core/types/execution-types'
 
 import { StatementRouter } from './StatementRouter'
 

--- a/src/core/parser/FBasicParser.ts
+++ b/src/core/parser/FBasicParser.ts
@@ -7,7 +7,7 @@
 
 import type { CstNode } from 'chevrotain'
 
-import type { ParserInfo } from '@/core/interfaces'
+import type { ParserInfo } from '@/core/types/execution-types'
 
 import { parseWithChevrotain } from './FBasicChevrotainParser'
 import { normalizeLocationValue } from './normalizeLocationValue'

--- a/src/core/persistence/ProgramDB.ts
+++ b/src/core/persistence/ProgramDB.ts
@@ -8,7 +8,7 @@
  * Schema versioning: uses IDBDatabase versioning to handle future migrations.
  */
 
-import type { ProgramData } from '@/core/interfaces'
+import type { ProgramData } from '@/core/types/program-types'
 
 /** Database and store configuration */
 const DB_NAME = 'fbasic-ide'

--- a/src/core/services/VariableService.ts
+++ b/src/core/services/VariableService.ts
@@ -8,9 +8,9 @@ import type { CstNode } from 'chevrotain'
 import Decimal from 'decimal.js'
 
 import type { ExpressionEvaluator } from '@/core/evaluation/ExpressionEvaluator'
-import type { BasicVariable } from '@/core/interfaces'
 import type { ExecutionContext } from '@/core/state/ExecutionContext'
 import type { BasicArrayValue, BasicScalarValue } from '@/core/types/BasicTypes'
+import type { BasicVariable } from '@/core/types/state-types'
 
 export class VariableService {
   constructor(

--- a/src/core/state/ExecutionContext.ts
+++ b/src/core/state/ExecutionContext.ts
@@ -8,9 +8,11 @@ import type { AnimationManager } from '@/core/animation/AnimationManager'
 import { ERROR_TYPES } from '@/core/constants'
 import type { SoundService } from '@/core/execution/sound/SoundService'
 import type { ExpandedStatement } from '@/core/execution/statement-expander'
-import type { BasicDeviceAdapter, BasicError, BasicVariable, InterpreterConfig } from '@/core/interfaces'
 import type { SpriteStateManager } from '@/core/sprite/SpriteStateManager'
 import type { BasicArrayValue, BasicScalarValue } from '@/core/types/BasicTypes'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
+import type { InterpreterConfig } from '@/core/types/execution-types'
+import type { BasicError, BasicVariable } from '@/core/types/state-types'
 import { logInterpreter } from '@/shared/logger'
 
 export interface LoopState {

--- a/src/core/workers/WebWorkerInterpreter.ts
+++ b/src/core/workers/WebWorkerInterpreter.ts
@@ -8,22 +8,7 @@
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import { BasicInterpreter } from '@/core/BasicInterpreter'
 import { WebWorkerDeviceAdapter } from '@/core/devices/WebWorkerDeviceAdapter'
-import type {
-  AnyServiceWorkerMessage,
-  ClearDisplayMessage,
-  ErrorMessage,
-  ExecuteMessage,
-  InputValueMessage,
-  OutputMessage,
-  PlaySoundCompleteMessage,
-  ResultMessage,
-  SetBgDataMessage,
-  SetSharedAnimationBufferMessage,
-  SetSharedJoystickBufferMessage,
-  SetSharedKeyboardBufferMessage,
-  StopMessage,
-  StrigEventMessage,
-} from '@/core/interfaces'
+import type { AnyServiceWorkerMessage, ClearDisplayMessage, ErrorMessage, ExecuteMessage, InputValueMessage, OutputMessage, PlaySoundCompleteMessage, ResultMessage, SetBgDataMessage, SetSharedAnimationBufferMessage, SetSharedJoystickBufferMessage, SetSharedKeyboardBufferMessage, StopMessage, StrigEventMessage } from '@/core/types/worker-messages'
 import type { BgGridData } from '@/features/bg-editor/types'
 import { logWorker } from '@/shared/logger'
 

--- a/src/features/bg-editor/utils/bgCompression.ts
+++ b/src/features/bg-editor/utils/bgCompression.ts
@@ -6,7 +6,7 @@
  * - RLE format: for grids with >=30% fill (run-length encoding)
  */
 
-import type { CompactBg } from '@/core/interfaces'
+import type { CompactBg } from '@/core/types/program-types'
 import { logCore } from '@/shared/logger'
 
 import { BG_GRID, DEFAULT_BG_CHAR_CODE } from '../constants'

--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -4,14 +4,10 @@ import { useI18n } from 'vue-i18n'
 
 import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
-import type {
-  BasicVariable,
-  HighlighterInfo,
-  ParserInfo,
-  RequestInputMessage,
-  ScreenCell,
-} from '@/core/interfaces'
 import type { SpriteState } from '@/core/sprite/types'
+import type { HighlighterInfo, ParserInfo, ScreenCell } from '@/core/types/execution-types'
+import type { BasicVariable } from '@/core/types/state-types'
+import type { RequestInputMessage } from '@/core/types/worker-messages'
 import { GameLayout } from '@/shared/components/ui'
 import { useContainerWidth } from '@/shared/composables/useContainerWidth'
 

--- a/src/features/ide/components/IdeBottomArea.vue
+++ b/src/features/ide/components/IdeBottomArea.vue
@@ -2,8 +2,8 @@
 import { useTemplateRef } from 'vue'
 
 import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
-import type { ScreenCell } from '@/core/interfaces'
 import type { SpriteState } from '@/core/sprite/types'
+import type { ScreenCell } from '@/core/types/execution-types'
 
 import JoystickControl from './JoystickControl.vue'
 import StateInspector from './StateInspector.vue'

--- a/src/features/ide/components/IdeOutputPanel.vue
+++ b/src/features/ide/components/IdeOutputPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 
-import type { BasicVariable } from '@/core/interfaces'
+import type { BasicVariable } from '@/core/types/state-types'
 import { GameIconButton } from '@/shared/components/ui'
 
 import LogLevelPanel from './LogLevelPanel.vue'

--- a/src/features/ide/components/InputModal.vue
+++ b/src/features/ide/components/InputModal.vue
@@ -2,7 +2,7 @@
 import { nextTick, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import type { RequestInputMessage } from '@/core/interfaces'
+import type { RequestInputMessage } from '@/core/types/worker-messages'
 import { GameButton, GameInput } from '@/shared/components/ui'
 
 const props = defineProps<{

--- a/src/features/ide/components/RuntimeOutput.vue
+++ b/src/features/ide/components/RuntimeOutput.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
-import type { BasicVariable } from '@/core/interfaces'
+import type { BasicVariable } from '@/core/types/state-types'
 import { GameTabs } from '@/shared/components/ui'
 
 import DebugTab from './DebugTab.vue'

--- a/src/features/ide/components/Screen.vue
+++ b/src/features/ide/components/Screen.vue
@@ -2,7 +2,7 @@
 import Konva from 'konva'
 import { computed, onDeactivated, onUnmounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
 
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 import { useAnimationWorker } from '@/features/ide/composables/useAnimationWorker'
 import { preInitializeBackgroundTiles, renderBackgroundToCanvas, renderBackgroundToCanvasDirty } from '@/features/ide/composables/useCanvasBackgroundRenderer'
 import { initializeKonvaLayers, type KonvaScreenLayers, renderAllScreenLayers } from '@/features/ide/composables/useKonvaScreenRenderer'

--- a/src/features/ide/components/StateInspector.vue
+++ b/src/features/ide/components/StateInspector.vue
@@ -3,8 +3,8 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
-import type { ScreenCell } from '@/core/interfaces'
 import type { SpriteState } from '@/core/sprite/types'
+import type { ScreenCell } from '@/core/types/execution-types'
 import { GameBlock, GameTabPane, GameTabs } from '@/shared/components/ui'
 import { COLORS } from '@/shared/data/palette'
 

--- a/src/features/ide/components/VariablesTab.vue
+++ b/src/features/ide/components/VariablesTab.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import type { BasicVariable } from '@/core/interfaces'
+import type { BasicVariable } from '@/core/types/state-types'
 import { GameIcon, GameTabPane, GameTag } from '@/shared/components/ui'
 
 /**

--- a/src/features/ide/composables/messageHandlerContext.ts
+++ b/src/features/ide/composables/messageHandlerContext.ts
@@ -5,12 +5,9 @@ import type { Ref } from 'vue'
 
 import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
 import type { DecodedScreenState } from '@/core/animation/sharedDisplayBufferAccessor'
-import type {
-  AnyServiceWorkerMessage,
-  RequestInputMessage,
-  ScreenCell,
-} from '@/core/interfaces'
 import type { SpriteState } from '@/core/sprite/types'
+import type { ScreenCell } from '@/core/types/execution-types'
+import type { AnyServiceWorkerMessage, RequestInputMessage } from '@/core/types/worker-messages'
 
 import type { WebWorkerManager } from './useBasicIdeWebWorkerUtils'
 

--- a/src/features/ide/composables/screenHandlers.ts
+++ b/src/features/ide/composables/screenHandlers.ts
@@ -1,7 +1,8 @@
 /**
  * Screen-related message handlers for BASIC IDE web worker communication
  */
-import type { AnyServiceWorkerMessage, ScreenCell, ScreenUpdateMessage } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
+import type { AnyServiceWorkerMessage, ScreenUpdateMessage } from '@/core/types/worker-messages'
 import { clearBackgroundTileCache } from '@/features/ide/composables/useCanvasBackgroundRenderer'
 import { clearSpriteImageCache } from '@/features/ide/composables/useKonvaSpriteRenderer'
 import { setRuntimePaletteCombination } from '@/shared/data/palette'

--- a/src/features/ide/composables/useBasicIdeEditor.ts
+++ b/src/features/ide/composables/useBasicIdeEditor.ts
@@ -2,10 +2,10 @@
  * Editor: parser, highlighting, parse/validate, sample loading, capabilities.
  */
 
-import type { HighlighterInfo, ParserInfo } from '@/core/interfaces'
 import { FBasicParser } from '@/core/parser/FBasicParser'
 import { getSampleCode, getSampleCodeKeys } from '@/core/samples'
 import { getSampleBgData, hasSampleBgData } from '@/core/samples/sampleBgData'
+import type { HighlighterInfo, ParserInfo } from '@/core/types/execution-types'
 import { createEmptyGrid } from '@/features/bg-editor/composables/useBgGrid'
 import { logComposable } from '@/shared/logger'
 

--- a/src/features/ide/composables/useBasicIdeExecution.ts
+++ b/src/features/ide/composables/useBasicIdeExecution.ts
@@ -4,7 +4,7 @@
  */
 
 import { ERROR_MESSAGES, EXECUTION_LIMITS } from '@/core/constants'
-import type { BasicVariable } from '@/core/interfaces'
+import type { BasicVariable } from '@/core/types/state-types'
 import { ExecutionError } from '@/features/ide/errors/ExecutionError'
 import i18n from '@/shared/i18n'
 import { logComposable } from '@/shared/logger'

--- a/src/features/ide/composables/useBasicIdeMessageHandlers.ts
+++ b/src/features/ide/composables/useBasicIdeMessageHandlers.ts
@@ -3,8 +3,8 @@
  *
  * Use loglevel: log.getLogger('ide-messages').setLevel('debug') in console for verbose logs.
  */
-import type { AnyServiceWorkerMessage, ErrorMessage, ResultMessage } from '@/core/interfaces'
 import type { Note, Rest } from '@/core/sound/types'
+import type { AnyServiceWorkerMessage, ErrorMessage, ResultMessage } from '@/core/types/worker-messages'
 import { ExecutionError } from '@/features/ide/errors/ExecutionError'
 import { logComposable, logIdeMessages } from '@/shared/logger'
 

--- a/src/features/ide/composables/useBasicIdeScreenUtils.ts
+++ b/src/features/ide/composables/useBasicIdeScreenUtils.ts
@@ -4,7 +4,7 @@
 
 import type { Ref } from 'vue'
 
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 
 /**
  * Initialize screen buffer as full grid for proper reactivity

--- a/src/features/ide/composables/useBasicIdeState.ts
+++ b/src/features/ide/composables/useBasicIdeState.ts
@@ -5,10 +5,10 @@
 
 import { type Ref, ref, shallowRef } from 'vue'
 
-import type { BasicVariable } from '@/core/interfaces'
-import type { RequestInputMessage } from '@/core/interfaces'
-import type { ScreenCell } from '@/core/interfaces'
 import type { SpriteState } from '@/core/sprite/types'
+import type { ScreenCell } from '@/core/types/execution-types'
+import type { BasicVariable } from '@/core/types/state-types'
+import type { RequestInputMessage } from '@/core/types/worker-messages'
 
 import type { PendingSpriteAction } from './useBasicIdeMessageHandlers'
 import { initializeScreenBuffer } from './useBasicIdeScreenUtils'

--- a/src/features/ide/composables/useBasicIdeWebWorkerUtils.ts
+++ b/src/features/ide/composables/useBasicIdeWebWorkerUtils.ts
@@ -3,7 +3,8 @@
  */
 
 import { DEFAULTS, ERROR_MESSAGES } from '@/core/constants'
-import type { AnyServiceWorkerMessage, ExecutionResult } from '@/core/interfaces'
+import type { ExecutionResult } from '@/core/types/execution-types'
+import type { AnyServiceWorkerMessage } from '@/core/types/worker-messages'
 import { logComposable } from '@/shared/logger'
 
 export interface WebWorkerManager {

--- a/src/features/ide/composables/useBasicIdeWorkerIntegration.ts
+++ b/src/features/ide/composables/useBasicIdeWorkerIntegration.ts
@@ -2,7 +2,8 @@
  * Web worker integration: manager, message context, init/restart/send, joystick and input events.
  */
 
-import type { AnyServiceWorkerMessage, ExecutionResult } from '@/core/interfaces'
+import type { ExecutionResult } from '@/core/types/execution-types'
+import type { AnyServiceWorkerMessage } from '@/core/types/worker-messages'
 import { logComposable } from '@/shared/logger'
 
 import { handleWorkerMessage, type MessageHandlerContext } from './useBasicIdeMessageHandlers'

--- a/src/features/ide/composables/useCanvasBackgroundRenderer.ts
+++ b/src/features/ide/composables/useCanvasBackgroundRenderer.ts
@@ -4,7 +4,7 @@
  * 10-50x faster than Konva for this use case
  */
 
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 import { BACKGROUND_PALETTES, COLORS } from '@/shared/data/palette'
 import { getBackgroundItemByChar, getCharacterByCode } from '@/shared/utils/backgroundLookup'
 

--- a/src/features/ide/composables/useKonvaScreenRenderer.ts
+++ b/src/features/ide/composables/useKonvaScreenRenderer.ts
@@ -6,8 +6,8 @@
 import Konva from 'konva'
 
 import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
-import type { ScreenCell } from '@/core/interfaces'
 import type { SpriteState } from '@/core/sprite/types'
+import type { ScreenCell } from '@/core/types/execution-types'
 import { COLORS } from '@/shared/data/palette'
 import { logScreen } from '@/shared/logger'
 

--- a/src/features/ide/composables/useProgramLibrary.ts
+++ b/src/features/ide/composables/useProgramLibrary.ts
@@ -17,8 +17,8 @@
 
 import { readonly, ref, shallowRef } from 'vue'
 
-import type { ProgramData } from '@/core/interfaces'
 import { ProgramDB, ProgramNotFoundError } from '@/core/persistence/ProgramDB'
+import type { ProgramData } from '@/core/types/program-types'
 import { logComposable } from '@/shared/logger'
 
 // ============================================================================

--- a/src/features/ide/composables/useProgramStore.ts
+++ b/src/features/ide/composables/useProgramStore.ts
@@ -9,7 +9,7 @@
 import { useLocalStorage } from '@vueuse/core'
 import { readonly, ref } from 'vue'
 
-import type { ProgramData, ProgramExportFile } from '@/core/interfaces'
+import type { ProgramData, ProgramExportFile } from '@/core/types/program-types'
 import { createEmptyGrid } from '@/features/bg-editor/composables/useBgGrid'
 import type { BgGridData } from '@/features/bg-editor/types'
 import { compressBg, decompressBg } from '@/features/bg-editor/utils/bgCompression'

--- a/src/features/ide/composables/useScreenContext.ts
+++ b/src/features/ide/composables/useScreenContext.ts
@@ -7,8 +7,8 @@ import { inject, type InjectionKey, provide, type Ref } from 'vue'
 
 import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
 import type { DecodedScreenState, SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
-import type { ScreenCell } from '@/core/interfaces'
 import type { MovementState, SpriteState } from '@/core/sprite/types'
+import type { ScreenCell } from '@/core/types/execution-types'
 
 /**
  * Screen context: refs and callbacks for the CRT screen and sprites.

--- a/src/shared/utils/fileIO.ts
+++ b/src/shared/utils/fileIO.ts
@@ -4,7 +4,7 @@
  * Provides file save/load functionality for program management
  */
 
-import type { ProgramExportFile } from '@/core/interfaces'
+import type { ProgramExportFile } from '@/core/types/program-types'
 
 /**
  * Save data as a JSON file download

--- a/test/adapters/SharedBufferTestAdapter.ts
+++ b/test/adapters/SharedBufferTestAdapter.ts
@@ -13,7 +13,7 @@ import {
 } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import { TestDeviceAdapter } from '@/core/devices/TestDeviceAdapter'
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 
 /**
  * Configuration for shared buffer test adapter

--- a/test/core/animation/sharedDisplayBufferAccessor.test.ts
+++ b/test/core/animation/sharedDisplayBufferAccessor.test.ts
@@ -11,7 +11,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { SHARED_DISPLAY_BUFFER_BYTES } from '@/core/animation/sharedDisplayBuffer'
 import { SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 
 function createBuffer(): SharedArrayBuffer {
   return new SharedArrayBuffer(SHARED_DISPLAY_BUFFER_BYTES)

--- a/test/core/devices/DeviceBgGraphicHelpers.test.ts
+++ b/test/core/devices/DeviceBgGraphicHelpers.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { copyBgGraphicToScreenBuffer } from '@/core/devices/DeviceBgGraphicHelpers'
-import type { ScreenCell } from '@/core/interfaces'
+import type { ScreenCell } from '@/core/types/execution-types'
 import type { BgCell, ColorPattern } from '@/features/bg-editor/types'
 
 /**

--- a/test/core/devices/DeviceInputRequestHelpers.test.ts
+++ b/test/core/devices/DeviceInputRequestHelpers.test.ts
@@ -10,7 +10,7 @@ import {
   handleInputValueMessage,
   rejectAllInputRequests,
 } from '@/core/devices/DeviceInputRequestHelpers'
-import type { InputValueMessage } from '@/core/interfaces'
+import type { InputValueMessage } from '@/core/types/worker-messages'
 
 // Capture postMessage calls
 let capturedMessages: unknown[] = []

--- a/test/core/devices/DeviceOutputHelpers.test.ts
+++ b/test/core/devices/DeviceOutputHelpers.test.ts
@@ -12,8 +12,8 @@ import {
   postPlaySound,
   serializeAudioEvents,
 } from '@/core/devices/DeviceOutputHelpers'
-import type { PlaySoundMessage } from '@/core/interfaces'
 import type { CompiledAudio } from '@/core/sound/types'
+import type { PlaySoundMessage } from '@/core/types/worker-messages'
 
 // Mock logger
 vi.mock('@/shared/logger', () => ({

--- a/test/core/devices/DevicePlayCompleteHelpers.test.ts
+++ b/test/core/devices/DevicePlayCompleteHelpers.test.ts
@@ -9,7 +9,7 @@ import {
   handlePlaySoundCompleteMessage,
   rejectAllPlayCompleteRequests,
 } from '@/core/devices/DevicePlayCompleteHelpers'
-import type { PlaySoundCompleteMessage } from '@/core/interfaces'
+import type { PlaySoundCompleteMessage } from '@/core/types/worker-messages'
 
 /** Collected orphan promises that need cleanup to avoid unhandled rejection warnings */
 let orphanCleanups: Array<() => void> = []

--- a/test/core/persistence/ProgramDB.crud.test.ts
+++ b/test/core/persistence/ProgramDB.crud.test.ts
@@ -8,11 +8,11 @@ import 'fake-indexeddb/auto'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import type { ProgramData } from '@/core/interfaces'
 import {
   ProgramDB,
   ProgramNotFoundError,
 } from '@/core/persistence/ProgramDB'
+import type { ProgramData } from '@/core/types/program-types'
 
 // ============================================================================
 // Helpers

--- a/test/core/persistence/ProgramDB.lifecycle.test.ts
+++ b/test/core/persistence/ProgramDB.lifecycle.test.ts
@@ -8,11 +8,11 @@ import 'fake-indexeddb/auto'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import type { ProgramData } from '@/core/interfaces'
 import {
   ProgramDB,
   ProgramDBError,
 } from '@/core/persistence/ProgramDB'
+import type { ProgramData } from '@/core/types/program-types'
 
 // ============================================================================
 // Helpers

--- a/test/core/persistence/ProgramDB.search.test.ts
+++ b/test/core/persistence/ProgramDB.search.test.ts
@@ -8,8 +8,8 @@ import 'fake-indexeddb/auto'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import type { ProgramData } from '@/core/interfaces'
 import { ProgramDB } from '@/core/persistence/ProgramDB'
+import type { ProgramData } from '@/core/types/program-types'
 
 // ============================================================================
 // Helpers

--- a/test/core/services/DataService.test.ts
+++ b/test/core/services/DataService.test.ts
@@ -9,9 +9,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ERROR_TYPES } from '@/core/constants'
-import type { InterpreterConfig } from '@/core/interfaces'
 import { DataService } from '@/core/services/DataService'
 import { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { InterpreterConfig } from '@/core/types/execution-types'
 
 function createTestContext(config?: Partial<InterpreterConfig>): ExecutionContext {
   return new ExecutionContext({

--- a/test/core/services/VariableService.test.ts
+++ b/test/core/services/VariableService.test.ts
@@ -7,10 +7,10 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { InterpreterConfig } from '@/core/interfaces'
 import { VariableService } from '@/core/services/VariableService'
 import { ExecutionContext } from '@/core/state/ExecutionContext'
 import type { BasicScalarValue } from '@/core/types/BasicTypes'
+import type { InterpreterConfig } from '@/core/types/execution-types'
 
 function createTestContext(): ExecutionContext {
   const config: InterpreterConfig = {

--- a/test/core/state/ExecutionContext.test.ts
+++ b/test/core/state/ExecutionContext.test.ts
@@ -9,8 +9,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { ERROR_TYPES } from '@/core/constants'
 import type { ExpandedStatement } from '@/core/execution/statement-expander'
-import type { InterpreterConfig } from '@/core/interfaces'
 import { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { InterpreterConfig } from '@/core/types/execution-types'
 
 function createConfig(overrides: Partial<InterpreterConfig> = {}): InterpreterConfig {
   return {

--- a/test/demo/BasicDemo.test.ts
+++ b/test/demo/BasicDemo.test.ts
@@ -7,9 +7,9 @@
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest'
 
 import { BasicInterpreter } from '@/core/BasicInterpreter'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import { FBasicParser } from '@/core/parser/FBasicParser'
 import { getSampleCode } from '@/core/samples'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 describe('Family Basic IDE Demo Program', () => {
   let interpreter: BasicInterpreter

--- a/test/demo/PauseDemo.test.ts
+++ b/test/demo/PauseDemo.test.ts
@@ -8,9 +8,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BasicInterpreter } from '@/core/BasicInterpreter'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import { FBasicParser } from '@/core/parser/FBasicParser'
 import { getSampleCode } from '@/core/samples'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 describe('Pause Demo Program', () => {
   let interpreter: BasicInterpreter

--- a/test/devices/MessageHandler.test.ts
+++ b/test/devices/MessageHandler.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { MessageHandler, type PendingMessage } from '@/core/devices/MessageHandler'
-import type { AnyServiceWorkerMessage, ExecutionResult } from '@/core/interfaces'
+import type { ExecutionResult } from '@/core/types/execution-types'
+import type { AnyServiceWorkerMessage } from '@/core/types/worker-messages'
 
 function createResultMessage(id: string, data: ResultMessageData): AnyServiceWorkerMessage {
   return {

--- a/test/devices/WebWorkerDeviceAdapter.test.ts
+++ b/test/devices/WebWorkerDeviceAdapter.test.ts
@@ -15,7 +15,7 @@ import {
   setStickState,
 } from '@/core/devices/sharedJoystickBuffer'
 import { WebWorkerDeviceAdapter } from '@/core/devices/WebWorkerDeviceAdapter'
-import type { AnyServiceWorkerMessage } from '@/core/interfaces'
+import type { AnyServiceWorkerMessage } from '@/core/types/worker-messages'
 
 // Mock self.postMessage to capture messages
 let capturedMessages: AnyServiceWorkerMessage[] = []

--- a/test/evaluation/FunctionEvaluatorArithmetic.test.ts
+++ b/test/evaluation/FunctionEvaluatorArithmetic.test.ts
@@ -15,9 +15,9 @@ import { describe, expect, it } from 'vitest'
 
 import { TestDeviceAdapter } from '@/core/devices/TestDeviceAdapter'
 import { FunctionEvaluator } from '@/core/evaluation/FunctionEvaluator'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import { parseWithChevrotain } from '@/core/parser/FBasicChevrotainParser'
 import { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/test/evaluation/FunctionEvaluatorController.test.ts
+++ b/test/evaluation/FunctionEvaluatorController.test.ts
@@ -15,9 +15,9 @@ import { describe, expect, it } from 'vitest'
 
 import { TestDeviceAdapter } from '@/core/devices/TestDeviceAdapter'
 import { FunctionEvaluator } from '@/core/evaluation/FunctionEvaluator'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import { parseWithChevrotain } from '@/core/parser/FBasicChevrotainParser'
 import { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/test/evaluation/FunctionEvaluatorSpriteScreen.test.ts
+++ b/test/evaluation/FunctionEvaluatorSpriteScreen.test.ts
@@ -15,9 +15,9 @@ import { describe, expect, it } from 'vitest'
 
 import { TestDeviceAdapter } from '@/core/devices/TestDeviceAdapter'
 import { FunctionEvaluator } from '@/core/evaluation/FunctionEvaluator'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import { parseWithChevrotain } from '@/core/parser/FBasicChevrotainParser'
 import { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/test/evaluation/FunctionEvaluatorString.test.ts
+++ b/test/evaluation/FunctionEvaluatorString.test.ts
@@ -14,9 +14,9 @@ import { describe, expect, it } from 'vitest'
 
 import { TestDeviceAdapter } from '@/core/devices/TestDeviceAdapter'
 import { FunctionEvaluator } from '@/core/evaluation/FunctionEvaluator'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import { parseWithChevrotain } from '@/core/parser/FBasicChevrotainParser'
 import { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/test/evaluation/ScreenFunctions.test.ts
+++ b/test/evaluation/ScreenFunctions.test.ts
@@ -5,7 +5,7 @@
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest'
 
 import { BasicInterpreter } from '@/core/BasicInterpreter'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 describe('CSRLIN, POS, SCR$, BEEP Functions', () => {
   let interpreter: BasicInterpreter

--- a/test/executors/LinputExecutor.test.ts
+++ b/test/executors/LinputExecutor.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { BasicInterpreter } from '@/core/BasicInterpreter'
 import { TestDeviceAdapter } from '@/core/devices/TestDeviceAdapter'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 describe('LinputExecutor', () => {
   let interpreter: BasicInterpreter

--- a/test/executors/PrintExecutor.test.ts
+++ b/test/executors/PrintExecutor.test.ts
@@ -8,9 +8,9 @@ import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vites
 
 import { ExpressionEvaluator } from '@/core/evaluation/ExpressionEvaluator'
 import { PrintExecutor } from '@/core/execution/executors/PrintExecutor'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
 import { FBasicParser } from '@/core/parser/FBasicParser'
 import { ExecutionContext } from '@/core/state/ExecutionContext'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 import { parsePrintStatement } from '../test-helpers'
 

--- a/test/ide/useProgramLibrary.crud.test.ts
+++ b/test/ide/useProgramLibrary.crud.test.ts
@@ -11,8 +11,8 @@ import 'fake-indexeddb/auto'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import type { ProgramData } from '@/core/interfaces'
 import { ProgramNotFoundError } from '@/core/persistence/ProgramDB'
+import type { ProgramData } from '@/core/types/program-types'
 import { useProgramLibrary } from '@/features/ide/composables/useProgramLibrary'
 
 // ============================================================================

--- a/test/ide/useProgramLibrary.state.test.ts
+++ b/test/ide/useProgramLibrary.state.test.ts
@@ -10,7 +10,7 @@ import 'fake-indexeddb/auto'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import type { ProgramData } from '@/core/interfaces'
+import type { ProgramData } from '@/core/types/program-types'
 import { useProgramLibrary } from '@/features/ide/composables/useProgramLibrary'
 
 // ============================================================================

--- a/test/ide/useProgramStore.test.ts
+++ b/test/ide/useProgramStore.test.ts
@@ -4,7 +4,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ProgramData } from '@/core/interfaces'
+import type { ProgramData } from '@/core/types/program-types'
 import { createEmptyGrid } from '@/features/bg-editor/composables/useBgGrid'
 
 // Mock fileIO module

--- a/test/parser/ColonExecution.test.ts
+++ b/test/parser/ColonExecution.test.ts
@@ -5,7 +5,7 @@
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest'
 
 import { BasicInterpreter } from '@/core/BasicInterpreter'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 describe('Colon-Separated Statement Execution', () => {
   let interpreter: BasicInterpreter

--- a/test/parser/DataReadRestoreIntegration.test.ts
+++ b/test/parser/DataReadRestoreIntegration.test.ts
@@ -7,7 +7,7 @@
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest'
 
 import { BasicInterpreter } from '@/core/BasicInterpreter'
-import type { BasicDeviceAdapter } from '@/core/interfaces'
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
 
 describe('DATA/READ/RESTORE Integration', () => {
   let interpreter: BasicInterpreter


### PR DESCRIPTION
## Summary
- Fixes #324

## Changes
- Updated 71 files (43 source, 28 test) to import types from domain-specific modules instead of barrel file
- Each `import type { ... } from '@/core/interfaces'` replaced with one or more imports from `@/core/types/<domain>`
- Mapping: `state-types` (BasicVariable, BasicError, etc.), `device-types` (BasicDeviceAdapter), `execution-types` (InterpreterConfig, ExecutionResult, etc.), `worker-messages` (all message types), `program-types` (CompactBg, ProgramData, ProgramExportFile)
- `interfaces.ts` barrel re-export left unchanged for backward compatibility

## Test plan
- [x] TypeScript type-check passes
- [x] 3121 tests pass across 180 test files
- [x] ESLint passes
- [ ] CI passes