### PR TITLE
feat: resolve #194 - add rename and delete actions with confirmation dialogs

### DIFF
--- a/src/features/ide/components/MyProgramsLibrary.vue
+++ b/src/features/ide/components/MyProgramsLibrary.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { ProgramData } from '@/core/types/program-types'
 import { useProgramLibrary } from '@/features/ide/composables/useProgramLibrary'
-import { GameButton, GameIconButton, GameInput, GameSelect } from '@/shared/components/ui'
+import { ConfirmDialog, GameButton, GameIconButton, GameInput, GameSelect } from '@/shared/components/ui'
 
 /**
  * MyProgramsLibrary component - List view for saved programs with search/sort.
  *
  * Shows all programs from IndexedDB via useProgramLibrary composable.
  * Supports search by name, sort by recently modified or alphabetical,
- * and displays an empty state when no programs are saved.
+ * inline rename, delete with confirmation, and displays an empty state
+ * when no programs are saved.
  */
 
 defineOptions({
@@ -21,7 +22,6 @@ defineOptions({
 const emit = defineEmits<{
   (e: 'close'): void
   (e: 'select', program: ProgramData): void
-  (e: 'delete', program: ProgramData): void
 }>()
 
 const { t } = useI18n()
@@ -30,6 +30,14 @@ const library = useProgramLibrary()
 // Search and sort state
 const searchQuery = ref<string | number>('')
 const sortKey = ref<string | number>('updatedAt')
+
+// Delete confirmation state
+const deleteTarget = ref<ProgramData | null>(null)
+
+// Rename inline edit state
+const editingId = ref<string | null>(null)
+const editingName = ref('')
+const renameInputRef = useTemplateRef<HTMLInputElement>('renameInputRef')
 
 // Sort options for the GameSelect dropdown
 const sortOptions = computed(() => [
@@ -80,11 +88,66 @@ function formatDate(timestamp: number): string {
 
 // Program action handlers
 function handleSelect(program: ProgramData): void {
+  if (editingId.value === program.id) return
   emit('select', program)
 }
 
-function handleDelete(program: ProgramData): void {
-  emit('delete', program)
+// --- Delete ---
+function handleDeleteClick(program: ProgramData): void {
+  deleteTarget.value = program
+}
+
+function handleDeleteConfirm(): void {
+  if (deleteTarget.value) {
+    void library.deleteProgram(deleteTarget.value.id)
+  }
+  deleteTarget.value = null
+}
+
+function handleDeleteCancel(): void {
+  deleteTarget.value = null
+}
+
+// --- Rename ---
+function handleRenameClick(program: ProgramData): void {
+  editingId.value = program.id
+  editingName.value = program.name
+  void nextTick(() => {
+    const input = renameInputRef.value
+    if (input) {
+      // focus/select may not be available in all environments (e.g. JSDOM)
+      input.focus?.()
+      input.select?.()
+    }
+  })
+}
+
+function handleRenameSubmit(): void {
+  const trimmed = editingName.value.trim()
+  if (editingId.value && trimmed) {
+    void library.renameProgram(editingId.value, trimmed)
+  }
+  editingId.value = null
+  editingName.value = ''
+}
+
+function handleRenameCancel(): void {
+  editingId.value = null
+  editingName.value = ''
+}
+
+function handleRenameBlur(): void {
+  handleRenameSubmit()
+}
+
+function handleRenameKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    handleRenameSubmit()
+  } else if (e.key === 'Escape') {
+    e.preventDefault()
+    handleRenameCancel()
+  }
 }
 
 function handleClose(): void {
@@ -154,25 +217,58 @@ function handleClose(): void {
             :key="program.id"
             class="my-programs-item"
           >
-            <button
-              type="button"
-              class="my-programs-item-button"
-              @click="handleSelect(program)"
-            >
-              <span class="my-programs-item-name">{{ program.name }}</span>
-              <span class="my-programs-item-date">{{ formatDate(program.updatedAt) }}</span>
-            </button>
+            <!-- Inline rename mode -->
+            <template v-if="editingId === program.id">
+              <input
+                ref="renameInputRef"
+                v-model="editingName"
+                type="text"
+                class="my-programs-item-rename-input"
+                :maxlength="100"
+                @keydown="handleRenameKeydown"
+                @blur="handleRenameBlur"
+              />
+            </template>
+            <!-- Normal display mode -->
+            <template v-else>
+              <button
+                type="button"
+                class="my-programs-item-button"
+                @click="handleSelect(program)"
+              >
+                <span class="my-programs-item-name">{{ program.name }}</span>
+                <span class="my-programs-item-date">{{ formatDate(program.updatedAt) }}</span>
+              </button>
+            </template>
+            <GameIconButton
+              type="default"
+              icon="mdi:pencil-outline"
+              size="small"
+              :title="t('ide.myPrograms.renameAriaLabel')"
+              class="my-programs-item-action"
+              @click="handleRenameClick(program)"
+            />
             <GameIconButton
               type="danger"
               icon="mdi:delete-outline"
               size="small"
               :title="t('ide.myPrograms.deleteAriaLabel')"
-              class="my-programs-item-delete"
-              @click="handleDelete(program)"
+              class="my-programs-item-action"
+              @click="handleDeleteClick(program)"
             />
           </li>
         </ul>
       </div>
+
+      <!-- Delete confirmation dialog -->
+      <ConfirmDialog
+        :visible="deleteTarget !== null"
+        :title="t('ide.myPrograms.deleteConfirmTitle')"
+        :message="t('ide.myPrograms.deleteConfirmMessage', { name: deleteTarget?.name ?? '' })"
+        :confirm-label="t('ide.myPrograms.deleteConfirmLabel')"
+        @confirm="handleDeleteConfirm"
+        @cancel="handleDeleteCancel"
+      />
 
       <!-- Footer -->
       <div class="my-programs-footer">
@@ -347,13 +443,29 @@ function handleClose(): void {
   flex-shrink: 0;
 }
 
-.my-programs-item-delete {
+.my-programs-item-rename-input {
+  flex: 1;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--base-solid-primary);
+  border-radius: 4px;
+  background: var(--game-surface-bg-start);
+  color: var(--game-text-primary);
+  font-size: 0.9rem;
+  outline: none;
+  min-width: 0;
+}
+
+.my-programs-item-rename-input:focus {
+  box-shadow: 0 0 0 2px var(--base-alpha-primary-30);
+}
+
+.my-programs-item-action {
   opacity: 0;
   transition: opacity 0.15s ease;
   flex-shrink: 0;
 }
 
-.my-programs-item:hover .my-programs-item-delete {
+.my-programs-item:hover .my-programs-item-action {
   opacity: 1;
 }
 

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -465,7 +465,11 @@
     "emptyState": "No saved programs yet. Save a program to see it here.",
     "noResults": "No programs match your search.",
     "errorState": "Failed to load programs.",
+    "renameAriaLabel": "Rename program",
     "deleteAriaLabel": "Delete program",
+    "deleteConfirmTitle": "Delete Program",
+    "deleteConfirmMessage": "Are you sure you want to delete \"{name}\"? This action cannot be undone.",
+    "deleteConfirmLabel": "Delete",
     "programCount": "No programs | {count} program | {count} programs"
   }
 }

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -465,7 +465,11 @@
     "emptyState": "保存されたプログラムはありません。プログラムを保存するとここに表示されます。",
     "noResults": "検索条件に一致するプログラムはありません。",
     "errorState": "プログラムの読み込みに失敗しました。",
+    "renameAriaLabel": "プログラム名を変更",
     "deleteAriaLabel": "プログラムを削除",
+    "deleteConfirmTitle": "プログラムの削除",
+    "deleteConfirmMessage": "「{name}」を削除してよろしいですか？この操作は元に戻せません。",
+    "deleteConfirmLabel": "削除",
     "programCount": "プログラムなし | {count}件のプログラム | {count}件のプログラム"
   }
 }

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -465,7 +465,11 @@
     "emptyState": "还没有保存的程序。保存一个程序即可在此处查看。",
     "noResults": "没有匹配的程序。",
     "errorState": "加载程序失败。",
+    "renameAriaLabel": "重命名程序",
     "deleteAriaLabel": "删除程序",
+    "deleteConfirmTitle": "删除程序",
+    "deleteConfirmMessage": "确定要删除「{name}」吗？此操作无法撤销。",
+    "deleteConfirmLabel": "删除",
     "programCount": "暂无程序 | {count} 个程序 | {count} 个程序"
   }
 }

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -465,7 +465,11 @@
     "emptyState": "還沒有儲存的程式。儲存一個程式即可在此處查看。",
     "noResults": "沒有符合的程式。",
     "errorState": "載入程式失敗。",
+    "renameAriaLabel": "重新命名程式",
     "deleteAriaLabel": "刪除程式",
+    "deleteConfirmTitle": "刪除程式",
+    "deleteConfirmMessage": "確定要刪除「{name}」嗎？此操作無法復原。",
+    "deleteConfirmLabel": "刪除",
     "programCount": "暫無程式 | {count} 個程式 | {count} 個程式"
   }
 }

--- a/test/ide/MyProgramsLibrary.actions.test.ts
+++ b/test/ide/MyProgramsLibrary.actions.test.ts
@@ -1,0 +1,299 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+
+import type { CompactBg, ProgramData } from '@/core/types/program-types'
+import MyProgramsLibrary from '@/features/ide/components/MyProgramsLibrary.vue'
+
+// Mock vue-i18n
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (params) return `${key}:${JSON.stringify(params)}`
+      return key
+    },
+  }),
+}))
+
+// Mock useProgramLibrary composable
+const mockPrograms = ref<ProgramData[]>([])
+const mockIsLoading = ref(false)
+const mockError = ref<Error | null>(null)
+const mockIsInitialized = ref(false)
+const mockListPrograms = vi.fn()
+const mockDeleteProgram = vi.fn()
+const mockRenameProgram = vi.fn()
+
+vi.mock('@/features/ide/composables/useProgramLibrary', () => ({
+  useProgramLibrary: () => ({
+    programs: { value: mockPrograms.value },
+    isLoading: { value: mockIsLoading.value },
+    error: { value: mockError.value },
+    isInitialized: { value: mockIsInitialized.value },
+    listPrograms: mockListPrograms,
+    getProgram: vi.fn(),
+    saveProgram: vi.fn(),
+    deleteProgram: mockDeleteProgram,
+    renameProgram: mockRenameProgram,
+    $reset: vi.fn(),
+  }),
+}))
+
+// Stub components (duplicated for test file independence)
+const gameInputStub = defineComponent({
+  props: ['modelValue', 'type', 'placeholder', 'clearable', 'size', 'disabled'],
+  emits: ['update:modelValue'],
+  template: '<input :value="modelValue" :placeholder="placeholder" class="game-input-stub" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+})
+
+const gameSelectStub = defineComponent({
+  props: ['modelValue', 'options', 'size', 'disabled', 'placeholder', 'width'],
+  emits: ['update:modelValue'],
+  template: '<select :value="modelValue" class="game-select-stub" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="opt in options" :key="opt.value" :value="opt.value">{{ opt.label }}</option></select>',
+})
+
+const gameButtonStub = defineComponent({
+  props: ['type', 'size', 'disabled', 'icon', 'loading'],
+  template: '<button :disabled="disabled" class="game-button-stub"><slot /></button>',
+})
+
+const gameIconButtonStub = defineComponent({
+  props: ['type', 'icon', 'size', 'title', 'disabled'],
+  emits: ['click'],
+  template: '<button :disabled="disabled" :title="title" class="game-icon-button-stub" @click="$emit(\'click\')" />',
+})
+
+const confirmDialogStub = defineComponent({
+  props: ['visible', 'title', 'message', 'confirmLabel', 'cancelLabel'],
+  emits: ['confirm', 'cancel'],
+  template: '<div v-if="visible" class="confirm-dialog-overlay"><div class="confirm-dialog"><h3 v-if="title">{{ title }}</h3><p v-if="message">{{ message }}</p><button class="confirm-dialog-btn-confirm" @click="$emit(\'confirm\')">Confirm</button><button class="confirm-dialog-btn-cancel" @click="$emit(\'cancel\')">Cancel</button></div></div>',
+})
+
+function createWrapper() {
+  return mount(MyProgramsLibrary, {
+    global: {
+      stubs: {
+        GameInput: gameInputStub,
+        GameSelect: gameSelectStub,
+        GameButton: gameButtonStub,
+        GameIconButton: gameIconButtonStub,
+        ConfirmDialog: confirmDialogStub,
+      },
+    },
+  })
+}
+
+function makeProgram(overrides: Partial<ProgramData> = {}): ProgramData {
+  const defaultBg: CompactBg = { format: 'sparse1', data: '', width: 28, height: 21 }
+  return {
+    id: 'test-id-1',
+    name: 'Test Program',
+    code: 'PRINT "HELLO"',
+    bg: defaultBg,
+    version: 1,
+    createdAt: 1000000,
+    updatedAt: 2000000,
+    ...overrides,
+  }
+}
+
+/** Find an icon button stub by its title prop */
+function findIconButtonByTitle(wrapper: ReturnType<typeof createWrapper>, title: string) {
+  return wrapper.findAllComponents(gameIconButtonStub).find((btn) => btn.props('title') === title)
+}
+
+describe('MyProgramsLibrary - Actions', () => {
+  let focusSpy: ReturnType<typeof vi.spyOn>
+  let selectSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // HTMLInputElement.focus/select may not be fully implemented in JSDOM
+    focusSpy = vi.spyOn(HTMLElement.prototype, 'focus').mockImplementation(() => {})
+    selectSpy = vi.spyOn(HTMLInputElement.prototype, 'select').mockImplementation(() => {})
+    if (!HTMLInputElement.prototype.focus) {
+      HTMLInputElement.prototype.focus = () => {}
+    }
+    if (!HTMLInputElement.prototype.select) {
+      HTMLInputElement.prototype.select = () => {}
+    }
+  })
+
+  afterEach(() => {
+    focusSpy.mockRestore()
+    selectSpy.mockRestore()
+  })
+
+  function resetMocks() {
+    mockPrograms.value = []
+    mockIsLoading.value = false
+    mockError.value = null
+    mockIsInitialized.value = true
+    mockListPrograms.mockClear()
+    mockDeleteProgram.mockClear()
+    mockRenameProgram.mockClear()
+  }
+
+  // --- Delete tests ---
+
+  it('shows confirm dialog when delete button is clicked', async () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+
+    expect(wrapper.find('.confirm-dialog-overlay').exists()).toBe(false)
+
+    const deleteBtn = findIconButtonByTitle(wrapper, 'ide.myPrograms.deleteAriaLabel')
+    expect(deleteBtn).toBeDefined()
+    deleteBtn!.vm.$emit('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.confirm-dialog-overlay').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('calls deleteProgram when delete is confirmed', async () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+
+    const deleteBtn = findIconButtonByTitle(wrapper, 'ide.myPrograms.deleteAriaLabel')
+    deleteBtn!.vm.$emit('click')
+    await wrapper.vm.$nextTick()
+
+    const confirmDialog = wrapper.findComponent(confirmDialogStub)
+    confirmDialog.vm.$emit('confirm')
+    await wrapper.vm.$nextTick()
+
+    expect(mockDeleteProgram).toHaveBeenCalledTimes(1)
+    expect(mockDeleteProgram).toHaveBeenCalledWith('1')
+    wrapper.unmount()
+  })
+
+  it('does not call deleteProgram when delete is cancelled', async () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+
+    const deleteBtn = findIconButtonByTitle(wrapper, 'ide.myPrograms.deleteAriaLabel')
+    deleteBtn!.vm.$emit('click')
+    await wrapper.vm.$nextTick()
+
+    const confirmDialog = wrapper.findComponent(confirmDialogStub)
+    confirmDialog.vm.$emit('cancel')
+    await wrapper.vm.$nextTick()
+
+    expect(mockDeleteProgram).not.toHaveBeenCalled()
+    expect(wrapper.find('.confirm-dialog-overlay').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  // --- Rename tests ---
+
+  it('shows inline rename input when rename button is clicked', async () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+
+    expect(wrapper.find('.my-programs-item-rename-input').exists()).toBe(false)
+
+    const renameBtn = findIconButtonByTitle(wrapper, 'ide.myPrograms.renameAriaLabel')
+    expect(renameBtn).toBeDefined()
+    renameBtn!.vm.$emit('click')
+    await wrapper.vm.$nextTick()
+
+    const renameInput = wrapper.find('.my-programs-item-rename-input')
+    expect(renameInput.exists()).toBe(true)
+    expect((renameInput.element as HTMLInputElement).value).toEqual('Program A')
+    wrapper.unmount()
+  })
+
+  it('calls renameProgram with trimmed name on Enter key', async () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+
+    const renameBtn = findIconButtonByTitle(wrapper, 'ide.myPrograms.renameAriaLabel')
+    renameBtn!.vm.$emit('click')
+    await wrapper.vm.$nextTick()
+
+    const renameInput = wrapper.find('.my-programs-item-rename-input')
+    await renameInput.setValue('  New Name  ')
+    await renameInput.trigger('keydown', { key: 'Enter' })
+    await wrapper.vm.$nextTick()
+
+    expect(mockRenameProgram).toHaveBeenCalledTimes(1)
+    expect(mockRenameProgram).toHaveBeenCalledWith('1', 'New Name')
+    wrapper.unmount()
+  })
+
+  it('calls renameProgram on blur', async () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+
+    const renameBtn = findIconButtonByTitle(wrapper, 'ide.myPrograms.renameAriaLabel')
+    renameBtn!.vm.$emit('click')
+    await wrapper.vm.$nextTick()
+
+    const renameInput = wrapper.find('.my-programs-item-rename-input')
+    await renameInput.setValue('Renamed')
+    await renameInput.trigger('blur')
+    await wrapper.vm.$nextTick()
+
+    expect(mockRenameProgram).toHaveBeenCalledTimes(1)
+    expect(mockRenameProgram).toHaveBeenCalledWith('1', 'Renamed')
+    wrapper.unmount()
+  })
+
+  it('does not call renameProgram when name is empty on Enter', async () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+
+    const renameBtn = findIconButtonByTitle(wrapper, 'ide.myPrograms.renameAriaLabel')
+    renameBtn!.vm.$emit('click')
+    await wrapper.vm.$nextTick()
+
+    const renameInput = wrapper.find('.my-programs-item-rename-input')
+    await renameInput.setValue('   ')
+    await renameInput.trigger('keydown', { key: 'Enter' })
+    await wrapper.vm.$nextTick()
+
+    expect(mockRenameProgram).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('cancels rename on Escape key without calling renameProgram', async () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+
+    const renameBtn = findIconButtonByTitle(wrapper, 'ide.myPrograms.renameAriaLabel')
+    renameBtn!.vm.$emit('click')
+    await wrapper.vm.$nextTick()
+
+    const renameInput = wrapper.find('.my-programs-item-rename-input')
+    await renameInput.setValue('Cancelled Name')
+    await renameInput.trigger('keydown', { key: 'Escape' })
+    await wrapper.vm.$nextTick()
+
+    expect(mockRenameProgram).not.toHaveBeenCalled()
+    expect(wrapper.find('.my-programs-item-rename-input').exists()).toBe(false)
+    expect(wrapper.find('.my-programs-item-name').text()).toEqual('Program A')
+    wrapper.unmount()
+  })
+
+  it('does not emit select when program is in rename mode', async () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+
+    const renameBtn = findIconButtonByTitle(wrapper, 'ide.myPrograms.renameAriaLabel')
+    renameBtn!.vm.$emit('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.my-programs-item-button').exists()).toBe(false)
+    expect(wrapper.emitted('select')).toBeUndefined()
+    wrapper.unmount()
+  })
+})

--- a/test/ide/MyProgramsLibrary.test.ts
+++ b/test/ide/MyProgramsLibrary.test.ts
@@ -61,6 +61,12 @@ const gameIconButtonStub = defineComponent({
   template: '<button :disabled="disabled" :title="title" class="game-icon-button-stub" @click="$emit(\'click\')" />',
 })
 
+const confirmDialogStub = defineComponent({
+  props: ['visible', 'title', 'message', 'confirmLabel', 'cancelLabel'],
+  emits: ['confirm', 'cancel'],
+  template: '<div v-if="visible" class="confirm-dialog-overlay"><div class="confirm-dialog"><h3 v-if="title">{{ title }}</h3><p v-if="message">{{ message }}</p><button class="confirm-dialog-btn-confirm" @click="$emit(\'confirm\')">Confirm</button><button class="confirm-dialog-btn-cancel" @click="$emit(\'cancel\')">Cancel</button></div></div>',
+})
+
 function createWrapper() {
   return mount(MyProgramsLibrary, {
     global: {
@@ -69,6 +75,7 @@ function createWrapper() {
         GameSelect: gameSelectStub,
         GameButton: gameButtonStub,
         GameIconButton: gameIconButtonStub,
+        ConfirmDialog: confirmDialogStub,
       },
     },
   })
@@ -89,7 +96,6 @@ function makeProgram(overrides: Partial<ProgramData> = {}): ProgramData {
 }
 
 describe('MyProgramsLibrary', () => {
-  // Helper to reset mocks between tests
   function resetMocks() {
     mockPrograms.value = []
     mockIsLoading.value = false
@@ -133,8 +139,6 @@ describe('MyProgramsLibrary', () => {
     resetMocks()
     const wrapper = createWrapper()
     await wrapper.find('.my-programs-overlay').trigger('click.self')
-    // .self modifier is handled by Vue, not test-utils trigger
-    // We verify the handler exists on the overlay element
     expect(wrapper.find('.my-programs-overlay').exists()).toBe(true)
     wrapper.unmount()
   })
@@ -191,20 +195,6 @@ describe('MyProgramsLibrary', () => {
     wrapper.unmount()
   })
 
-  it('emits delete when delete button is clicked', async () => {
-    resetMocks()
-    const program = makeProgram({ id: '1', name: 'Program A' })
-    mockPrograms.value = [program]
-    const wrapper = createWrapper()
-    const deleteBtn = wrapper.findComponent(gameIconButtonStub)
-    expect(deleteBtn.exists()).toBe(true)
-    deleteBtn.vm.$emit('click')
-    await wrapper.vm.$nextTick()
-    expect(wrapper.emitted('delete')).toHaveLength(1)
-    expect(wrapper.emitted('delete')![0]).toEqual([program])
-    wrapper.unmount()
-  })
-
   it('renders search input with placeholder', () => {
     resetMocks()
     const wrapper = createWrapper()
@@ -246,8 +236,7 @@ describe('MyProgramsLibrary', () => {
       makeProgram({ id: '2', name: 'Apple', updatedAt: 3000 }),
     ]
     const wrapper = createWrapper()
-    const select = wrapper.find('.game-select-stub')
-    await select.setValue('name')
+    await wrapper.find('.game-select-stub').setValue('name')
     const items = wrapper.findAll('.my-programs-item')
     expect(items[0]!.find('.my-programs-item-name').text()).toEqual('Apple')
     expect(items[1]!.find('.my-programs-item-name').text()).toEqual('Banana')
@@ -262,8 +251,7 @@ describe('MyProgramsLibrary', () => {
       makeProgram({ id: '3', name: 'Hello Game' }),
     ]
     const wrapper = createWrapper()
-    const input = wrapper.find('.game-input-stub')
-    await input.setValue('hello')
+    await wrapper.find('.game-input-stub').setValue('hello')
     const items = wrapper.findAll('.my-programs-item')
     expect(items.length).toEqual(2)
     expect(items[0]!.find('.my-programs-item-name').text()).toEqual('Hello World')
@@ -275,8 +263,7 @@ describe('MyProgramsLibrary', () => {
     resetMocks()
     mockPrograms.value = [makeProgram({ id: '1', name: 'Hello World' })]
     const wrapper = createWrapper()
-    const input = wrapper.find('.game-input-stub')
-    await input.setValue('nonexistent')
+    await wrapper.find('.game-input-stub').setValue('nonexistent')
     expect(wrapper.findAll('.my-programs-item').length).toEqual(0)
     expect(wrapper.find('.my-programs-state-text').text()).toEqual('ide.myPrograms.noResults')
     wrapper.unmount()
@@ -289,18 +276,27 @@ describe('MyProgramsLibrary', () => {
       makeProgram({ id: '2', name: 'B' }),
     ]
     const wrapper = createWrapper()
-    const count = wrapper.find('.my-programs-count')
-    expect(count.exists()).toBe(true)
-    expect(count.text()).toContain('ide.myPrograms.programCount')
+    expect(wrapper.find('.my-programs-count').text()).toContain('ide.myPrograms.programCount')
     wrapper.unmount()
   })
 
   it('emits close when cancel button is clicked', async () => {
     resetMocks()
     const wrapper = createWrapper()
-    const cancelButton = wrapper.find('.my-programs-footer .game-button-stub')
-    await cancelButton.trigger('click')
+    await wrapper.find('.my-programs-footer .game-button-stub').trigger('click')
     expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('renders both rename and delete action buttons per program item', () => {
+    resetMocks()
+    mockPrograms.value = [makeProgram({ id: '1', name: 'Program A' })]
+    const wrapper = createWrapper()
+    const iconButtons = wrapper.findAllComponents(gameIconButtonStub)
+    expect(iconButtons.length).toEqual(2)
+    const titles = iconButtons.map((btn) => btn.props('title'))
+    expect(titles).toContain('ide.myPrograms.renameAriaLabel')
+    expect(titles).toContain('ide.myPrograms.deleteAriaLabel')
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #194

## Changes
- **Rename**: inline edit mode — click rename button to show text input, Enter saves, Escape cancels, blur saves
- **Delete**: confirmation dialog using existing `ConfirmDialog` component before calling `library.deleteProgram()`
- Removed `delete` emit — deletion now handled internally via composable
- 9 new tests in `MyProgramsLibrary.actions.test.ts` covering rename (inline input, save, cancel, empty rejection, select blocking) and delete (confirm dialog, confirm action, cancel action)
- i18n keys added to all 4 locales

## Test plan
- [x] 28 tests pass (19 existing + 9 new)
- [x] 3149 total tests pass
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes