### PR TITLE
feat: resolve #195 - ensure My Programs library works with existing import/export .fbasic.json flow

### DIFF
--- a/src/features/ide/composables/useProgramLibrary.ts
+++ b/src/features/ide/composables/useProgramLibrary.ts
@@ -10,6 +10,8 @@
  * - Saving (creating or updating) a program
  * - Deleting a program
  * - Renaming a program
+ * - Importing programs from .fbasic.json files
+ * - Exporting programs as .fbasic.json files
  *
  * Complementary to useProgramStore which manages the *current* active program
  * in the editor. This composable manages the *library* of saved programs.
@@ -18,8 +20,9 @@
 import { readonly, ref, shallowRef } from 'vue'
 
 import { ProgramDB, ProgramNotFoundError } from '@/core/persistence/ProgramDB'
-import type { ProgramData } from '@/core/types/program-types'
+import type { ProgramData, ProgramExportFile } from '@/core/types/program-types'
 import { logComposable } from '@/shared/logger'
+import { isValidProgramFile, saveJsonFile } from '@/shared/utils/fileIO'
 
 // ============================================================================
 // Singleton State
@@ -197,6 +200,73 @@ async function renameProgram(id: string, newName: string): Promise<void> {
 }
 
 /**
+ * Import a program from a .fbasic.json file into the library.
+ *
+ * Validates the file format and creates a new library entry with a fresh id.
+ * The original id from the file is NOT preserved (to avoid collisions).
+ *
+ * @param data - Parsed JSON data from a .fbasic.json file
+ * @returns The id of the newly created library entry, or null if invalid
+ */
+async function importFromFile(data: unknown): Promise<string | null> {
+  if (!isValidProgramFile(data)) {
+    logComposable.error('[useProgramLibrary] Invalid program file format for import')
+    return null
+  }
+
+  const exportFile = data
+  const { name, code, bg } = exportFile.program
+
+  clearError()
+  isLoading.value = true
+  try {
+    const id = await saveProgram({
+      version: 1,
+      name,
+      code,
+      bg,
+    })
+    return id
+  } catch (err) {
+    setError(err, 'Failed to import program from file')
+    return null
+  } finally {
+    isLoading.value = false
+  }
+}
+
+/**
+ * Export a library program as a .fbasic.json file download.
+ *
+ * @param id - The library program id to export
+ * @throws Error if the program is not found
+ */
+async function exportToFile(id: string): Promise<void> {
+  clearError()
+  isLoading.value = true
+  try {
+    const db = await getDb()
+    const program = await db.getById(id)
+    if (!program) {
+      throw new ProgramNotFoundError(id)
+    }
+
+    const exportFile: ProgramExportFile = {
+      format: 'family-basic-program',
+      version: 1,
+      program,
+    }
+
+    await saveJsonFile(exportFile, `${program.name}.fbasic.json`)
+  } catch (err) {
+    setError(err, `Failed to export program ${id}`)
+    throw err
+  } finally {
+    isLoading.value = false
+  }
+}
+
+/**
  * Close the database connection and reset state.
  * Primarily useful for testing and cleanup.
  */
@@ -242,6 +312,8 @@ export function useProgramLibrary() {
     saveProgram,
     deleteProgram,
     renameProgram,
+    importFromFile,
+    exportToFile,
 
     // Testing / cleanup
     $reset,

--- a/src/features/ide/composables/useProgramStore.ts
+++ b/src/features/ide/composables/useProgramStore.ts
@@ -4,6 +4,9 @@
  * Central state management for the Program Management System.
  * Uses singleton pattern with module-level state (same pattern as useBgEditorState).
  * Auto-persists to localStorage using VueUse's useLocalStorage.
+ *
+ * Integrates with useProgramLibrary so that import/export operations
+ * also update the program library in IndexedDB.
  */
 
 import { useLocalStorage } from '@vueuse/core'
@@ -16,6 +19,8 @@ import { compressBg, decompressBg } from '@/features/bg-editor/utils/bgCompressi
 import { logComposable } from '@/shared/logger'
 import { isValidProgramFile, loadJsonFile, saveJsonFile } from '@/shared/utils/fileIO'
 import { generateProgramId, generateSessionId } from '@/shared/utils/id'
+
+import { useProgramLibrary } from './useProgramLibrary'
 
 // ============================================================================
 // Module-level Singleton State
@@ -108,7 +113,7 @@ function setBg(bg: BgGridData): void {
 
 /**
  * Save the current program to file
- * Persists to localStorage and triggers file download
+ * Persists to localStorage, saves to library, and triggers file download
  */
 async function save(): Promise<void> {
   if (!currentProgram.value) return
@@ -122,6 +127,28 @@ async function save(): Promise<void> {
 
   // Download file
   await saveJsonFile(exportFile, `${currentProgram.value.name}.fbasic.json`)
+
+  // Save to program library (create or update)
+  try {
+    const library = useProgramLibrary()
+    const programId = await library.saveProgram({
+      id: currentProgram.value.id,
+      version: currentProgram.value.version,
+      name: currentProgram.value.name,
+      code: currentProgram.value.code,
+      bg: currentProgram.value.bg,
+    })
+    // Update the current program's id to match the library entry
+    if (currentProgram.value.id !== programId) {
+      currentProgram.value = {
+        ...currentProgram.value,
+        id: programId,
+      }
+    }
+  } catch (err) {
+    // Library save failure should not block the file export
+    logComposable.error('[useProgramStore] Failed to save to library:', err)
+  }
 
   // Mark as saved
   isDirty.value = false
@@ -148,6 +175,7 @@ async function saveAs(name: string): Promise<void> {
 
 /**
  * Open a program from file
+ * Loads into the editor and also adds to the program library
  */
 async function open(): Promise<boolean> {
   try {
@@ -165,6 +193,15 @@ async function open(): Promise<boolean> {
 
     const exportFile = data
     loadProgram(exportFile.program)
+
+    // Also import to the library (non-blocking - failures are logged but don't affect UX)
+    try {
+      const library = useProgramLibrary()
+      await library.importFromFile(data)
+    } catch (err) {
+      logComposable.error('[useProgramStore] Failed to import to library:', err)
+    }
+
     return true
   } catch (error) {
     logComposable.error('[useProgramStore] Failed to open program:', error)

--- a/test/ide/MyProgramsLibrary.test.ts
+++ b/test/ide/MyProgramsLibrary.test.ts
@@ -33,6 +33,8 @@ vi.mock('@/features/ide/composables/useProgramLibrary', () => ({
     saveProgram: vi.fn(),
     deleteProgram: vi.fn(),
     renameProgram: vi.fn(),
+    importFromFile: vi.fn(),
+    exportToFile: vi.fn(),
     $reset: vi.fn(),
   }),
 }))

--- a/test/ide/useProgramLibrary.import-export.test.ts
+++ b/test/ide/useProgramLibrary.import-export.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Tests for useProgramLibrary composable - import/export operations
+ *
+ * Covers: importFromFile, exportToFile, and validation/round-trip scenarios.
+ *
+ * Uses fake-indexeddb to simulate IndexedDB in the test environment.
+ */
+
+import 'fake-indexeddb/auto'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProgramExportFile } from '@/core/interfaces'
+import { useProgramLibrary } from '@/features/ide/composables/useProgramLibrary'
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+// Mock fileIO to avoid triggering real file downloads during tests
+vi.mock('@/shared/utils/fileIO', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const original = (await importOriginal()) as {
+    isValidProgramFile: (data: unknown) => data is ProgramExportFile
+    loadJsonFile: () => Promise<unknown>
+    saveJsonFile: (data: object, filename: string) => Promise<void>
+  }
+  return {
+    isValidProgramFile: original.isValidProgramFile,
+    loadJsonFile: original.loadJsonFile,
+    saveJsonFile: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Create a valid ProgramExportFile for testing */
+function createExportFile(overrides: Partial<ProgramExportFile['program']> = {}): ProgramExportFile {
+  return {
+    format: 'family-basic-program',
+    version: 1,
+    program: {
+      version: 1,
+      id: 'original-file-id',
+      name: 'Imported Program',
+      code: '10 PRINT "HELLO"',
+      bg: {
+        format: 'sparse1',
+        data: '',
+        width: 28 as const,
+        height: 21 as const,
+      },
+      createdAt: 1000,
+      updatedAt: 2000,
+      ...overrides,
+    },
+  }
+}
+
+/** Delete the test database to ensure isolation */
+function deleteDatabase(): Promise<void> {
+  return new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase('fbasic-ide')
+    request.onsuccess = () => resolve()
+    request.onerror = () => resolve()
+  })
+}
+
+// ============================================================================
+// Test Suite
+// ============================================================================
+
+describe('useProgramLibrary import/export', () => {
+  beforeEach(async () => {
+    useProgramLibrary().$reset()
+    await deleteDatabase()
+  })
+
+  afterEach(async () => {
+    useProgramLibrary().$reset()
+    await deleteDatabase()
+  })
+
+  // --------------------------------------------------------------------------
+  // importFromFile
+  // --------------------------------------------------------------------------
+
+  describe('importFromFile', () => {
+    it('imports a valid .fbasic.json file and returns new id', async () => {
+      const library = useProgramLibrary()
+      const exportFile = createExportFile()
+
+      const id = await library.importFromFile(exportFile)
+
+      expect(id).toBeDefined()
+      expect(typeof id).toBe('string')
+      expect(id!.length).toBeGreaterThan(0)
+    })
+
+    it('creates a new id (not the original file id)', async () => {
+      const library = useProgramLibrary()
+      const exportFile = createExportFile({ id: 'original-file-id' })
+
+      const id = await library.importFromFile(exportFile)
+
+      expect(id).toBeDefined()
+      expect(id).not.toEqual('original-file-id')
+    })
+
+    it('preserves program content from the file', async () => {
+      const library = useProgramLibrary()
+      const exportFile = createExportFile({
+        name: 'My Game',
+        code: '10 PRINT "WORLD"',
+      })
+
+      const id = await library.importFromFile(exportFile)
+      const program = await library.getProgram(id!)
+
+      expect(program).toBeDefined()
+      expect(program!.name).toEqual('My Game')
+      expect(program!.code).toEqual('10 PRINT "WORLD"')
+    })
+
+    it('adds imported program to the programs list', async () => {
+      const library = useProgramLibrary()
+      const exportFile = createExportFile({ name: 'Imported' })
+
+      await library.importFromFile(exportFile)
+
+      expect(library.programs.value).toHaveLength(1)
+      expect(library.programs.value[0]?.name).toEqual('Imported')
+    })
+
+    it('returns null for invalid data (missing format)', async () => {
+      const library = useProgramLibrary()
+
+      const id = await library.importFromFile({ version: 1, program: {} })
+
+      expect(id).toBeNull()
+    })
+
+    it('returns null for invalid data (null)', async () => {
+      const library = useProgramLibrary()
+
+      const id = await library.importFromFile(null)
+
+      expect(id).toBeNull()
+    })
+
+    it('returns null for invalid data (wrong format field)', async () => {
+      const library = useProgramLibrary()
+
+      const id = await library.importFromFile({
+        format: 'other-format',
+        version: 1,
+        program: { name: 'Test', code: '' },
+      })
+
+      expect(id).toBeNull()
+    })
+
+    it('returns null for non-object data', async () => {
+      const library = useProgramLibrary()
+
+      const id = await library.importFromFile('not an object')
+
+      expect(id).toBeNull()
+    })
+
+    it('sets isLoading during import', async () => {
+      const library = useProgramLibrary()
+      const exportFile = createExportFile()
+
+      const promise = library.importFromFile(exportFile)
+      expect(library.isLoading.value).toBe(true)
+
+      await promise
+      expect(library.isLoading.value).toBe(false)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // exportToFile
+  // --------------------------------------------------------------------------
+
+  describe('exportToFile', () => {
+    it('exports a saved program as .fbasic.json file', async () => {
+      const { saveJsonFile } = await import('@/shared/utils/fileIO')
+      const library = useProgramLibrary()
+
+      const id = await library.saveProgram({
+        version: 1,
+        name: 'Export Test',
+        code: '10 PRINT "EXPORT"',
+        bg: {
+          format: 'sparse1',
+          data: '',
+          width: 28 as const,
+          height: 21 as const,
+        },
+      })
+
+      await library.exportToFile(id)
+
+      expect(saveJsonFile).toHaveBeenCalledTimes(1)
+      const callArgs = (saveJsonFile as ReturnType<typeof vi.fn>).mock.calls[0]!
+      expect(callArgs[1]).toEqual('Export Test.fbasic.json')
+    })
+
+    it('exports correct ProgramExportFile structure', async () => {
+      const { saveJsonFile } = await import('@/shared/utils/fileIO')
+      const library = useProgramLibrary()
+
+      const id = await library.saveProgram({
+        version: 1,
+        name: 'Structure Test',
+        code: '20 PRINT "STRUCT"',
+        bg: {
+          format: 'sparse1',
+          data: '0,0,65,1;',
+          width: 28 as const,
+          height: 21 as const,
+        },
+      })
+
+      await library.exportToFile(id)
+
+      const savedData = (saveJsonFile as ReturnType<typeof vi.fn>).mock.calls[0]![0] as ProgramExportFile
+      expect(savedData.format).toEqual('family-basic-program')
+      expect(savedData.version).toEqual(1)
+      expect(savedData.program.name).toEqual('Structure Test')
+      expect(savedData.program.code).toEqual('20 PRINT "STRUCT"')
+      expect(savedData.program.bg.data).toEqual('0,0,65,1;')
+      expect(savedData.program.id).toEqual(id)
+    })
+
+    it('throws ProgramNotFoundError for non-existent id', async () => {
+      const library = useProgramLibrary()
+
+      await expect(library.exportToFile('ghost-id')).rejects.toThrow()
+      expect(library.error.value).toBeDefined()
+    })
+
+    it('sets isLoading during export', async () => {
+      const library = useProgramLibrary()
+
+      const id = await library.saveProgram({
+        version: 1,
+        name: 'Loading Test',
+        code: '10 TEST',
+        bg: {
+          format: 'sparse1',
+          data: '',
+          width: 28 as const,
+          height: 21 as const,
+        },
+      })
+
+      const promise = library.exportToFile(id)
+      expect(library.isLoading.value).toBe(true)
+
+      await promise
+      expect(library.isLoading.value).toBe(false)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Round-trip
+  // --------------------------------------------------------------------------
+
+  describe('import-export round-trip', () => {
+    it('program can be imported then exported with same content', async () => {
+      const { saveJsonFile } = await import('@/shared/utils/fileIO')
+      const library = useProgramLibrary()
+
+      const originalFile = createExportFile({
+        name: 'Round Trip',
+        code: '30 PRINT "ROUND TRIP"',
+        bg: {
+          format: 'sparse1',
+          data: '1,1,66,2;',
+          width: 28 as const,
+          height: 21 as const,
+        },
+      })
+
+      // Import
+      const importedId = await library.importFromFile(originalFile)
+      expect(importedId).toBeDefined()
+
+      // Export
+      await library.exportToFile(importedId!)
+
+      // Verify exported content matches original program data
+      const exported = (saveJsonFile as ReturnType<typeof vi.fn>).mock.calls[0]![0] as ProgramExportFile
+      expect(exported.program.name).toEqual('Round Trip')
+      expect(exported.program.code).toEqual('30 PRINT "ROUND TRIP"')
+      expect(exported.program.bg.data).toEqual('1,1,66,2;')
+      // The id should be the new library id, not the original file id
+      expect(exported.program.id).toEqual(importedId)
+      expect(exported.program.id).not.toEqual('original-file-id')
+    })
+  })
+})

--- a/test/ide/useProgramStore.test.ts
+++ b/test/ide/useProgramStore.test.ts
@@ -20,6 +20,27 @@ vi.mock('@/shared/utils/id', () => ({
   generateSessionId: vi.fn().mockReturnValue('sess-test1234'),
 }))
 
+// Mock useProgramLibrary module
+const mockSaveProgram = vi.fn().mockResolvedValue('library-id-123')
+const mockImportFromFile = vi.fn().mockResolvedValue('library-import-id')
+
+vi.mock('@/features/ide/composables/useProgramLibrary', () => ({
+  useProgramLibrary: () => ({
+    programs: { value: [] },
+    isLoading: { value: false },
+    error: { value: null },
+    isInitialized: { value: false },
+    listPrograms: vi.fn(),
+    getProgram: vi.fn(),
+    saveProgram: mockSaveProgram,
+    deleteProgram: vi.fn(),
+    renameProgram: vi.fn(),
+    importFromFile: mockImportFromFile,
+    exportToFile: vi.fn(),
+    $reset: vi.fn(),
+  }),
+}))
+
 // Clear localStorage before each test
 beforeEach(() => {
   localStorage.clear()
@@ -191,5 +212,98 @@ describe('useProgramStore', () => {
 
     expect(saveJsonFile).toHaveBeenCalled()
     expect(store.isDirty.value).toBe(false)
+  })
+
+  // --------------------------------------------------------------------------
+  // Library integration
+  // --------------------------------------------------------------------------
+
+  describe('library integration', () => {
+    it('should save to library on save()', async () => {
+      const { useProgramStore } = await import('@/features/ide/composables/useProgramStore')
+      const store = useProgramStore()
+
+      const testProgram: ProgramData = {
+        version: 1,
+        id: 'lib-save-test-id',
+        name: 'Library Save Test',
+        code: '',
+        bg: {
+          format: 'sparse1',
+          data: '',
+          width: 28,
+          height: 21,
+        },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }
+      store.loadProgram(testProgram)
+
+      await store.save()
+
+      expect(mockSaveProgram).toHaveBeenCalledTimes(1)
+      // Verify saveProgram was called with the program data
+      const savedData = mockSaveProgram.mock.calls[0]![0] as ProgramData
+      expect(savedData.id).toEqual('lib-save-test-id')
+      expect(savedData.name).toEqual('Library Save Test')
+    })
+
+    it('should import to library on open() with valid file', async () => {
+      const { isValidProgramFile, loadJsonFile } = await import('@/shared/utils/fileIO')
+      const { useProgramStore } = await import('@/features/ide/composables/useProgramStore')
+
+      // Mock valid file load
+      const mockFileData = {
+        format: 'family-basic-program',
+        version: 1,
+        program: {
+          version: 1,
+          id: 'file-id',
+          name: 'Opened Program',
+          code: '10 PRINT "OPENED"',
+          bg: { format: 'sparse1', data: '', width: 28, height: 21 },
+          createdAt: 1000,
+          updatedAt: 2000,
+        },
+      }
+      vi.mocked(loadJsonFile).mockResolvedValueOnce(mockFileData)
+      vi.mocked(isValidProgramFile).mockReturnValueOnce(true)
+
+      const store = useProgramStore()
+      const success = await store.open()
+
+      expect(success).toBe(true)
+      expect(mockImportFromFile).toHaveBeenCalledTimes(1)
+      expect(mockImportFromFile).toHaveBeenCalledWith(mockFileData)
+    })
+
+    it('should not import to library when open() is cancelled', async () => {
+      const { loadJsonFile } = await import('@/shared/utils/fileIO')
+      const { useProgramStore } = await import('@/features/ide/composables/useProgramStore')
+
+      // Mock cancelled file picker
+      vi.mocked(loadJsonFile).mockResolvedValueOnce(null)
+
+      const store = useProgramStore()
+      const success = await store.open()
+
+      expect(success).toBe(false)
+      expect(mockImportFromFile).not.toHaveBeenCalled()
+    })
+
+    it('should not import to library when file is invalid', async () => {
+      const { isValidProgramFile, loadJsonFile } = await import('@/shared/utils/fileIO')
+      const { useProgramStore } = await import('@/features/ide/composables/useProgramStore')
+
+      // Mock invalid file
+      vi.mocked(loadJsonFile).mockResolvedValueOnce({ some: 'data' })
+      vi.mocked(isValidProgramFile).mockReturnValueOnce(false)
+
+      const store = useProgramStore()
+      const success = await store.open()
+
+      expect(success).toBe(false)
+      expect(mockImportFromFile).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #195

## Changes
- Added `importFromFile()` to `useProgramLibrary` — validates .fbasic.json data and creates new library entry with fresh id
- Added `exportToFile()` to `useProgramLibrary` — looks up program in IndexedDB and triggers .fbasic.json download
- Integrated `useProgramStore.save()` with library — file export also persists to IndexedDB
- Integrated `useProgramStore.open()` with library — file import also adds to IndexedDB
- Library failures are caught/logged but don't block the existing import/export UX (no breaking changes)
- 14 new tests for import/export + 4 new tests for store integration

## Test plan
- [x] 94 tests pass across affected files
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes