### PR TITLE
feat: resolve #339 - move Sprite Viewer into IDE as side panel

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -15,6 +15,7 @@ import CommandPalette from './components/CommandPalette.vue'
 import IdeBottomArea from './components/IdeBottomArea.vue'
 import IdeEditorPanel from './components/IdeEditorPanel.vue'
 import IdeOutputPanel from './components/IdeOutputPanel.vue'
+import IdeSpriteViewerPanel from './components/IdeSpriteViewerPanel.vue'
 import InputModal from './components/InputModal.vue'
 import SampleSelector from './components/SampleSelector.vue'
 import {
@@ -133,6 +134,7 @@ const sampleSelectorOpen = shallowRef(false)
 const commandPaletteOpen = shallowRef(false)
 const editorView = shallowRef<'code' | 'bg'>('code')
 const logLevelPanelOpen = shallowRef(false)
+const spriteViewerOpen = shallowRef(false)
 
 // Responsive toolbar - observe editor panel which expands with screen
 const editorPanelRef = useTemplateRef<HTMLDivElement>('editorPanelRef')
@@ -379,6 +381,7 @@ function toggleInputMode() {
             @clear="clearOutput"
             @toggle-debug="toggleDebugMode"
             @open-sample-selector="sampleSelectorOpen = true"
+            @open-sprite-viewer="spriteViewerOpen = true"
           />
         </div>
 
@@ -432,6 +435,12 @@ function toggleInputMode() {
           :commands="commandPaletteCommands"
           @close="closeCommandPalette"
           @execute="handleExecuteCommandFromPalette"
+        />
+
+        <!-- Sprite Viewer Side Panel -->
+        <IdeSpriteViewerPanel
+          v-if="spriteViewerOpen"
+          @close="spriteViewerOpen = false"
         />
       </Teleport>
     </div>

--- a/src/features/ide/components/IdeEditorPanel.vue
+++ b/src/features/ide/components/IdeEditorPanel.vue
@@ -30,6 +30,7 @@ const emit = defineEmits<{
   (e: 'clear'): void
   (e: 'toggleDebug'): void
   (e: 'openSampleSelector'): void
+  (e: 'openSpriteViewer'): void
 }>()
 
 const MonacoCodeEditor = defineAsyncComponent({
@@ -104,6 +105,13 @@ const useLiteEditor = computed(() => {
             {{ t('ide.samples.load') }}
           </GameButton>
         </template>
+        <GameIconButton
+          type="default"
+          icon="mdi:eye"
+          size="small"
+          :title="t('ide.spriteViewer.openTitle')"
+          @click="emit('openSpriteViewer')"
+        />
         <IdeControls
           :is-running="props.isRunning"
           :can-run="props.canRun"

--- a/src/features/ide/components/IdeSpriteViewerPanel.vue
+++ b/src/features/ide/components/IdeSpriteViewerPanel.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import ColorPaletteDisplay from '@/features/sprite-viewer/components/ColorPaletteDisplay.vue'
+import DefStatements from '@/features/sprite-viewer/components/DefStatements.vue'
+import PaletteCombinations from '@/features/sprite-viewer/components/PaletteCombinations.vue'
+import SpriteControls from '@/features/sprite-viewer/components/SpriteControls.vue'
+import SpriteGrid from '@/features/sprite-viewer/components/SpriteGrid.vue'
+import { provideSpriteViewerStore } from '@/features/sprite-viewer/composables/useSpriteViewerStore'
+import { GameIconButton } from '@/shared/components/ui'
+import GameIcon from '@/shared/components/ui/GameIcon.vue'
+
+/**
+ * IdeSpriteViewerPanel - Slide-out side panel for viewing character sprites.
+ * Embeds the sprite viewer components within the IDE context.
+ */
+defineOptions({
+  name: 'IdeSpriteViewerPanel',
+})
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const { t } = useI18n()
+
+// Provide the store to all child components
+provideSpriteViewerStore()
+
+const panelRef = useTemplateRef<HTMLDivElement>('panelRef')
+
+// Close on Escape key
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    emit('close')
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
+})
+
+function closePanel() {
+  emit('close')
+}
+</script>
+
+<template>
+  <div class="sprite-viewer-overlay" @click.self="closePanel">
+    <div
+      ref="panelRef"
+      class="sprite-viewer-panel"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="t('ide.spriteViewer.title')"
+    >
+      <div class="sprite-viewer-header">
+        <div class="sprite-viewer-title">
+          <GameIcon icon="mdi:eye" :size="20" />
+          <span>{{ t('ide.spriteViewer.title') }}</span>
+        </div>
+        <GameIconButton
+          type="default"
+          icon="mdi:close"
+          size="small"
+          :title="t('ide.spriteViewer.close')"
+          @click="closePanel"
+        />
+      </div>
+
+      <div class="sprite-viewer-content">
+        <SpriteControls />
+        <SpriteGrid />
+        <DefStatements />
+        <ColorPaletteDisplay />
+        <PaletteCombinations />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.sprite-viewer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  justify-content: flex-end;
+  background: var(--base-alpha-gray-00-60);
+  backdrop-filter: blur(2px);
+}
+
+.sprite-viewer-panel {
+  width: min(520px, 90vw);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border-left: 2px solid var(--game-surface-border);
+  background: var(--game-surface-bg-gradient);
+  box-shadow: -4px 0 16px var(--base-alpha-gray-00-40);
+}
+
+.sprite-viewer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--game-surface-border);
+  flex-shrink: 0;
+}
+
+.sprite-viewer-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--game-text-primary);
+}
+
+.sprite-viewer-content {
+  flex: 1 1 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -39,7 +39,7 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/features/sprite-viewer/CharacterSpriteViewerPage.vue'),
     meta: {
       title: 'Sprite Viewer',
-      showInNav: true,
+      showInNav: false,
       icon: 'mdi:eye',
       group: 'tools',
     },

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -471,5 +471,10 @@
     "deleteConfirmMessage": "Are you sure you want to delete \"{name}\"? This action cannot be undone.",
     "deleteConfirmLabel": "Delete",
     "programCount": "No programs | {count} program | {count} programs"
+  },
+  "spriteViewer": {
+    "title": "Sprite Viewer",
+    "openTitle": "Open Sprite Viewer",
+    "close": "Close"
   }
 }

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -471,5 +471,10 @@
     "deleteConfirmMessage": "「{name}」を削除してよろしいですか？この操作は元に戻せません。",
     "deleteConfirmLabel": "削除",
     "programCount": "プログラムなし | {count}件のプログラム | {count}件のプログラム"
+  },
+  "spriteViewer": {
+    "title": "スプライトビューアー",
+    "openTitle": "スプライトビューアーを開く",
+    "close": "閉じる"
   }
 }

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -471,5 +471,10 @@
     "deleteConfirmMessage": "确定要删除「{name}」吗？此操作无法撤销。",
     "deleteConfirmLabel": "删除",
     "programCount": "暂无程序 | {count} 个程序 | {count} 个程序"
+  },
+  "spriteViewer": {
+    "title": "精灵查看器",
+    "openTitle": "打开精灵查看器",
+    "close": "关闭"
   }
 }

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -471,5 +471,10 @@
     "deleteConfirmMessage": "確定要刪除「{name}」嗎？此操作無法復原。",
     "deleteConfirmLabel": "刪除",
     "programCount": "暫無程式 | {count} 個程式 | {count} 個程式"
+  },
+  "spriteViewer": {
+    "title": "精靈檢視器",
+    "openTitle": "開啟精靈檢視器",
+    "close": "關閉"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #339 — moves Sprite Viewer into IDE as a slide-out side panel (Step 2 of 6 for #336)

## Changes
- Created `IdeSpriteViewerPanel.vue` — slide-out side panel embedding sprite viewer components within IDE context
- Added `mdi:eye` toolbar button in `IdeEditorPanel` to open/close the panel
- Integrated panel into `IdePage.vue` with `spriteViewerOpen` state
- Hidden Sprite Viewer from top-level navigation (`showInNav: false` in router)
- Route remains accessible via direct URL for backward compatibility
- Added `spriteViewer` i18n keys across all 4 locales (en, ja, zh-CN, zh-TW)

## Test plan
- [ ] Type-check passes
- [ ] CI passes
- [ ] Sprite Viewer accessible via eye icon in IDE toolbar
- [ ] Panel slides in from right, closes on Escape/backdrop click
- [ ] Sprite Viewer no longer appears in top-level navigation