### PR TITLE
refactor: resolve #340 - hide dev/test pages behind debug toggle

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -53,6 +53,7 @@ const routes: RouteRecordRaw[] = [
       showInNav: true,
       icon: 'mdi:code-tags',
       group: 'tools',
+      debug: true,
     },
   },
 
@@ -68,6 +69,7 @@ const routes: RouteRecordRaw[] = [
       showInNav: true,
       icon: 'mdi:speedometer',
       group: 'testing',
+      debug: true,
     },
   },
   {
@@ -79,6 +81,7 @@ const routes: RouteRecordRaw[] = [
       showInNav: true,
       icon: 'mdi:animation',
       group: 'testing',
+      debug: true,
     },
   },
   {
@@ -90,6 +93,7 @@ const routes: RouteRecordRaw[] = [
       showInNav: true,
       icon: 'mdi:sync',
       group: 'testing',
+      debug: true,
     },
   },
   {
@@ -101,6 +105,7 @@ const routes: RouteRecordRaw[] = [
       showInNav: true,
       icon: 'mdi:test-tube',
       group: 'testing',
+      debug: true,
     },
   },
   {
@@ -112,6 +117,7 @@ const routes: RouteRecordRaw[] = [
       showInNav: true,
       icon: 'mdi:music',
       group: 'testing',
+      debug: true,
     },
   },
 

--- a/src/router/types.d.ts
+++ b/src/router/types.d.ts
@@ -14,5 +14,7 @@ declare module 'vue-router' {
     parent?: string
     /** Whether this route requires authentication */
     requiresAuth?: boolean
+    /** Whether this route is only visible in debug mode */
+    debug?: boolean
   }
 }

--- a/src/shared/components/GameNavigation.vue
+++ b/src/shared/components/GameNavigation.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
 import { buildInfo } from '@/buildInfo'
+import { useDebugMode } from '@/shared/composables/useDebugMode'
 import { useLocale } from '@/shared/composables/useLocale'
 import { useSkin } from '@/shared/composables/useSkin'
 
@@ -27,7 +28,8 @@ defineOptions({
 const { t } = useI18n()
 const { currentSkin, setSkin, availableSkins } = useSkin()
 const { currentLocale, setLocale, availableLocales } = useLocale()
-const { groupedRoutes } = useNavigationRoutes()
+const { isDebugEnabled, toggleDebugMode } = useDebugMode()
+const { groupedRoutes } = useNavigationRoutes(isDebugEnabled)
 
 const route = useRoute()
 const router = useRouter()
@@ -190,6 +192,13 @@ const handleLocaleChange = (localeValue: string | number) => {
         </div>
       </div>
       <div class="nav-controls">
+        <button
+          :class="['debug-toggle', { active: isDebugEnabled }]"
+          :title="t('navigation.debug.toggleTitle')"
+          @click="toggleDebugMode"
+        >
+          <GameIcon :icon="isDebugEnabled ? 'mdi:bug' : 'mdi:bug-outline'" size="small" />
+        </button>
         <div class="build-number" title="Build number - increments on each build and hot reload">
           #{{ buildInfo.buildNumber }}
         </div>
@@ -270,6 +279,32 @@ const handleLocaleChange = (localeValue: string | number) => {
   border: 1px solid var(--game-surface-border);
   border-radius: 4px;
   white-space: nowrap;
+}
+
+.debug-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: var(--base-alpha-gray-100-10);
+  border: 1px solid var(--game-surface-border);
+  border-radius: 4px;
+  color: var(--game-text-tertiary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.debug-toggle:hover {
+  border-color: var(--base-solid-primary);
+  color: var(--game-text-secondary);
+}
+
+.debug-toggle.active {
+  color: var(--base-solid-primary);
+  border-color: var(--base-solid-primary);
+  background: var(--base-alpha-gray-100-10);
 }
 
 /* Nav button styles */

--- a/src/shared/components/composables/useNavigationRoutes.ts
+++ b/src/shared/components/composables/useNavigationRoutes.ts
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { RouteRecordNormalized } from 'vue-router'
 import { useRouter } from 'vue-router'
@@ -30,6 +30,7 @@ const getItemKey = (routeName: string): string => {
     KonvaSpriteTest: 'konvaSpriteTest',
     PositionSyncLoadTest: 'positionSyncLoadTest',
     PrintVsSpritesTest: 'printVsSpritesTest',
+    SoundTest: 'soundTest',
   }
   return nameMap[routeName] ?? routeName.toLowerCase()
 }
@@ -39,8 +40,10 @@ const getItemKey = (routeName: string): string => {
  *
  * Filters routes with `meta.showInNav === true` and groups them
  * by `meta.group` (main, tools, testing).
+ *
+ * Routes with `meta.debug === true` are only included when `isDebugEnabled` is true.
  */
-export function useNavigationRoutes() {
+export function useNavigationRoutes(isDebugEnabled: Ref<boolean>) {
   const { t } = useI18n()
   const router = useRouter()
 
@@ -50,6 +53,13 @@ export function useNavigationRoutes() {
     router
       .getRoutes()
       .filter((r: RouteRecordNormalized) => r.meta.showInNav === true)
+      .filter((r: RouteRecordNormalized) => {
+        // Hide debug-only routes when debug mode is off
+        if (r.meta.debug === true && !isDebugEnabled.value) {
+          return false
+        }
+        return true
+      })
       .forEach((r: RouteRecordNormalized) => {
         const group = (r.meta.group as 'main' | 'tools' | 'testing') ?? 'main'
         const itemKey = getItemKey(String(r.name))

--- a/src/shared/composables/useDebugMode.ts
+++ b/src/shared/composables/useDebugMode.ts
@@ -1,0 +1,57 @@
+/**
+ * Debug Mode Composable
+ *
+ * Provides a reactive debug mode toggle backed by localStorage and URL param.
+ * When debug mode is active, dev/test pages are shown in navigation.
+ */
+
+import { useLocalStorage } from '@vueuse/core'
+import { computed } from 'vue'
+
+const DEBUG_STORAGE_KEY = 'fbasic-debug-mode'
+
+/**
+ * Check if debug mode is enabled via URL parameter
+ */
+function isDebugUrlParam(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  return params.get('debug') === 'true'
+}
+
+/**
+ * Composable for managing debug mode state.
+ *
+ * Debug mode can be enabled via:
+ * - localStorage key `fbasic-debug-mode` set to `true`
+ * - URL parameter `?debug=true`
+ *
+ * The state is persisted to localStorage so it survives page reloads.
+ */
+export function useDebugMode() {
+  const isEnabled = useLocalStorage<boolean>(DEBUG_STORAGE_KEY, isDebugUrlParam(), {
+    serializer: {
+      read: (value: string): boolean => value === 'true',
+      write: (value: boolean): string => String(value),
+    },
+  })
+
+  // Also enable if URL param is present (takes precedence on first load)
+  if (typeof window !== 'undefined' && isDebugUrlParam()) {
+    isEnabled.value = true
+  }
+
+  const isDebugEnabled = computed(() => isEnabled.value)
+
+  const toggleDebugMode = () => {
+    isEnabled.value = !isEnabled.value
+  }
+
+  return {
+    isDebugEnabled,
+    toggleDebugMode,
+  }
+}

--- a/src/shared/i18n/locales/en/navigation.json
+++ b/src/shared/i18n/locales/en/navigation.json
@@ -5,6 +5,9 @@
     "tools": "Development Tools",
     "testing": "Testing & Diagnostics"
   },
+  "debug": {
+    "toggleTitle": "Toggle debug mode — show dev/test pages"
+  },
   "items": {
     "home": {
       "name": "Home",
@@ -37,6 +40,10 @@
     "printVsSpritesTest": {
       "name": "PRINT Test",
       "description": "PRINT vs Sprites Test"
+    },
+    "soundTest": {
+      "name": "Sound Test",
+      "description": "Sound System Test"
     }
   }
 }

--- a/src/shared/i18n/locales/ja/navigation.json
+++ b/src/shared/i18n/locales/ja/navigation.json
@@ -5,6 +5,9 @@
     "tools": "開発ツール",
     "testing": "テスト＆診断"
   },
+  "debug": {
+    "toggleTitle": "デバッグモード切替 — 開発/テストページを表示"
+  },
   "items": {
     "home": {
       "name": "ホーム",
@@ -37,6 +40,10 @@
     "printVsSpritesTest": {
       "name": "PRINTテスト",
       "description": "PRINT対スプライトテスト"
+    },
+    "soundTest": {
+      "name": "サウンドテスト",
+      "description": "サウンドシステムテスト"
     }
   }
 }

--- a/src/shared/i18n/locales/zh-CN/navigation.json
+++ b/src/shared/i18n/locales/zh-CN/navigation.json
@@ -5,6 +5,9 @@
     "tools": "开发工具",
     "testing": "测试与诊断"
   },
+  "debug": {
+    "toggleTitle": "切换调试模式 — 显示开发/测试页面"
+  },
   "items": {
     "home": {
       "name": "首页",
@@ -37,6 +40,10 @@
     "printVsSpritesTest": {
       "name": "PRINT 测试",
       "description": "PRINT 对比精灵测试"
+    },
+    "soundTest": {
+      "name": "声音测试",
+      "description": "声音系统测试"
     }
   }
 }

--- a/src/shared/i18n/locales/zh-TW/navigation.json
+++ b/src/shared/i18n/locales/zh-TW/navigation.json
@@ -5,6 +5,9 @@
     "tools": "開發工具",
     "testing": "測試與診斷"
   },
+  "debug": {
+    "toggleTitle": "切換除錯模式 — 顯示開發/測試頁面"
+  },
   "items": {
     "home": {
       "name": "首頁",
@@ -37,6 +40,10 @@
     "printVsSpritesTest": {
       "name": "PRINT 測試",
       "description": "PRINT 對比精靈測試"
+    },
+    "soundTest": {
+      "name": "聲音測試",
+      "description": "聲音系統測試"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #340 — hides dev/test pages behind debug mode toggle (Step 3 of 6 for #336)

## Changes
- New `useDebugMode` composable — reactive `isDebugEnabled` ref persisted to localStorage (`fbasic-debug-mode`), auto-enabled via `?debug=true` URL param
- Bug-icon toggle button in navigation bar to enable/disable debug mode
- Added `debug: true` meta to 6 dev/test routes (Monaco Editor, Performance Diagnostics, Konva Test, Position Sync Load Test, Print vs Sprites Test, Sound Test)
- Navigation filters out `debug: true` routes when debug mode is off
- Dev routes remain accessible via direct URL regardless of debug mode
- Added `debug.toggleTitle` and `soundTest` i18n keys across 4 locales

## Test plan
- [ ] Type-check passes
- [ ] All 3167 tests pass
- [ ] Navigation shows only Home and IDE by default
- [ ] Clicking bug icon reveals dev/test page dropdowns
- [ ] `?debug=true` URL param auto-enables debug mode
- [ ] Debug mode persists across page reloads