### PR TITLE
feat: resolve #343 - apply retro-futuristic visual styling and animations to home page

### DIFF
--- a/src/features/home/HomePage.vue
+++ b/src/features/home/HomePage.vue
@@ -14,6 +14,7 @@ import {
  * HomePage component - The home/landing page of the application.
  * Displays a hero section with branding, a GET-STARTED CTA button,
  * and a feature showcase section highlighting key IDE capabilities.
+ * Features retro-futuristic visual styling inspired by Family Computer heritage.
  */
 defineOptions({
   name: 'HomePage',
@@ -29,128 +30,162 @@ const goToIde = () => {
 
 <template>
   <GameLayout>
-    <div class="home-content">
-      <!-- Hero Section -->
-      <HeroSection
-        :title="t('home.hero.title')"
-        :subtitle="t('home.hero.subtitle')"
-        :description="t('home.hero.description')"
-        icon="mdi:monitor"
-      >
-        <GameButton
-          type="primary"
-          size="large"
-          icon="mdi:arrow-right"
-          icon-position="right"
-          class="hero-cta"
-          @click="goToIde"
+    <div class="home-page">
+      <!-- Ambient background effects -->
+      <div class="home-bg-glow" aria-hidden="true" />
+
+      <div class="home-content">
+        <!-- Hero Section -->
+        <HeroSection
+          :title="t('home.hero.title')"
+          :subtitle="t('home.hero.subtitle')"
+          :description="t('home.hero.description')"
+          icon="mdi:monitor"
         >
-          {{ t('home.hero.cta') }}
-        </GameButton>
-      </HeroSection>
-
-      <!-- Showcase Section -->
-      <section class="showcase-section">
-        <div class="showcase-header">
-          <h2 class="showcase-title">{{ t('home.showcase.title') }}</h2>
-          <p class="showcase-subtitle">{{ t('home.showcase.subtitle') }}</p>
-        </div>
-
-        <div class="showcase-grid">
-          <!-- Editor Spotlight - Large featured highlight -->
-          <GameBlock
-            title=""
-            :hide-header="true"
-            :no-hover-effect="true"
-            class="showcase-spotlight showcase-item"
+          <GameButton
+            type="primary"
+            size="large"
+            icon="mdi:arrow-right"
+            icon-position="right"
+            class="hero-cta"
+            @click="goToIde"
           >
-            <div class="spotlight-content">
-              <div class="spotlight-text">
-                <div class="spotlight-icon">
-                  <GameIcon icon="mdi:code-braces" :size="36" />
-                </div>
-                <h3 class="showcase-item-title">{{ t('home.showcase.items.editor.title') }}</h3>
-                <p class="showcase-item-desc">{{ t('home.showcase.items.editor.description') }}</p>
-              </div>
-              <div class="spotlight-code">
-                <div class="code-window">
-                  <div class="code-window-bar">
-                    <span class="code-dot code-dot-red"></span>
-                    <span class="code-dot code-dot-yellow"></span>
-                    <span class="code-dot code-dot-green"></span>
-                    <span class="code-window-title">HELLO.BAS</span>
+            {{ t('home.hero.cta') }}
+          </GameButton>
+        </HeroSection>
+
+        <!-- Showcase Section -->
+        <section class="showcase-section">
+          <div class="showcase-header">
+            <h2 class="showcase-title">{{ t('home.showcase.title') }}</h2>
+            <p class="showcase-subtitle">{{ t('home.showcase.subtitle') }}</p>
+          </div>
+
+          <div class="showcase-grid">
+            <!-- Editor Spotlight - Large featured highlight -->
+            <GameBlock
+              title=""
+              :hide-header="true"
+              :no-hover-effect="true"
+              class="showcase-spotlight showcase-item"
+            >
+              <div class="spotlight-content">
+                <div class="spotlight-text">
+                  <div class="spotlight-icon">
+                    <GameIcon icon="mdi:code-braces" :size="36" />
                   </div>
-                  <pre class="code-block"><code>{{ t('home.showcase.items.editor.code') }}</code></pre>
+                  <h3 class="showcase-item-title">{{ t('home.showcase.items.editor.title') }}</h3>
+                  <p class="showcase-item-desc">{{ t('home.showcase.items.editor.description') }}</p>
+                </div>
+                <div class="spotlight-code">
+                  <div class="code-window">
+                    <div class="code-window-bar">
+                      <span class="code-dot code-dot-red"></span>
+                      <span class="code-dot code-dot-yellow"></span>
+                      <span class="code-dot code-dot-green"></span>
+                      <span class="code-window-title">HELLO.BAS</span>
+                    </div>
+                    <pre class="code-block"><code>{{ t('home.showcase.items.editor.code') }}</code></pre>
+                  </div>
                 </div>
               </div>
-            </div>
-          </GameBlock>
+            </GameBlock>
 
-          <!-- Sprite & Graphics -->
-          <GameBlock
-            title=""
-            :hide-header="true"
-            :no-hover-effect="true"
-            class="showcase-side showcase-item"
-          >
-            <div class="showcase-item-inner">
-              <div class="showcase-item-icon showcase-item-icon-sprites">
-                <GameIcon icon="mdi:ghost" :size="32" />
+            <!-- Sprite & Graphics -->
+            <GameBlock
+              title=""
+              :hide-header="true"
+              :no-hover-effect="true"
+              class="showcase-side showcase-item"
+            >
+              <div class="showcase-item-inner">
+                <div class="showcase-item-icon showcase-item-icon-sprites">
+                  <GameIcon icon="mdi:ghost" :size="32" />
+                </div>
+                <h3 class="showcase-item-title">{{ t('home.showcase.items.sprites.title') }}</h3>
+                <p class="showcase-item-desc">{{ t('home.showcase.items.sprites.description') }}</p>
               </div>
-              <h3 class="showcase-item-title">{{ t('home.showcase.items.sprites.title') }}</h3>
-              <p class="showcase-item-desc">{{ t('home.showcase.items.sprites.description') }}</p>
-            </div>
-          </GameBlock>
+            </GameBlock>
 
-          <!-- Sound & Music -->
-          <GameBlock
-            title=""
-            :hide-header="true"
-            :no-hover-effect="true"
-            class="showcase-row-item showcase-item"
-          >
-            <div class="showcase-item-inner">
-              <div class="showcase-item-icon showcase-item-icon-sound">
-                <GameIcon icon="mdi:music-note" :size="28" />
+            <!-- Sound & Music -->
+            <GameBlock
+              title=""
+              :hide-header="true"
+              :no-hover-effect="true"
+              class="showcase-row-item showcase-item"
+            >
+              <div class="showcase-item-inner">
+                <div class="showcase-item-icon showcase-item-icon-sound">
+                  <GameIcon icon="mdi:music-note" :size="28" />
+                </div>
+                <div class="showcase-item-body">
+                  <h3 class="showcase-item-title">{{ t('home.showcase.items.sound.title') }}</h3>
+                  <p class="showcase-item-desc">{{ t('home.showcase.items.sound.description') }}</p>
+                </div>
               </div>
-              <div class="showcase-item-body">
-                <h3 class="showcase-item-title">{{ t('home.showcase.items.sound.title') }}</h3>
-                <p class="showcase-item-desc">{{ t('home.showcase.items.sound.description') }}</p>
-              </div>
-            </div>
-          </GameBlock>
+            </GameBlock>
 
-          <!-- Sample Programs -->
-          <GameBlock
-            title=""
-            :hide-header="true"
-            :no-hover-effect="true"
-            class="showcase-row-item showcase-item"
-          >
-            <div class="showcase-item-inner">
-              <div class="showcase-item-icon showcase-item-icon-samples">
-                <GameIcon icon="mdi:gamepad-variant" :size="28" />
+            <!-- Sample Programs -->
+            <GameBlock
+              title=""
+              :hide-header="true"
+              :no-hover-effect="true"
+              class="showcase-row-item showcase-item"
+            >
+              <div class="showcase-item-inner">
+                <div class="showcase-item-icon showcase-item-icon-samples">
+                  <GameIcon icon="mdi:gamepad-variant" :size="28" />
+                </div>
+                <div class="showcase-item-body">
+                  <h3 class="showcase-item-title">{{ t('home.showcase.items.samples.title') }}</h3>
+                  <p class="showcase-item-desc">{{ t('home.showcase.items.samples.description') }}</p>
+                </div>
               </div>
-              <div class="showcase-item-body">
-                <h3 class="showcase-item-title">{{ t('home.showcase.items.samples.title') }}</h3>
-                <p class="showcase-item-desc">{{ t('home.showcase.items.samples.description') }}</p>
-              </div>
-            </div>
-          </GameBlock>
-        </div>
-      </section>
+            </GameBlock>
+          </div>
+        </section>
+      </div>
     </div>
   </GameLayout>
 </template>
 
 <style scoped>
-.home-content {
+.home-page {
+  position: relative;
   max-width: 1400px;
   margin: 0 auto;
   width: 100%;
   padding: 0 2rem 2rem;
 }
 
+.home-content {
+  position: relative;
+  z-index: 1;
+  animation:
+    home-fade-in-up
+    var(--home-entrance-duration, 0.6s)
+    var(--home-entrance-easing, cubic-bezier(0.16, 1, 0.3, 1))
+    0.3s both;
+}
+
+/* Ambient background glow — radial gradient behind hero */
+.home-bg-glow {
+  position: absolute;
+  top: -20%;
+  left: 50%;
+  width: 120%;
+  height: 80%;
+  transform: translateX(-50%);
+  background: radial-gradient(
+    ellipse at center,
+    var(--home-glow-subtle, var(--base-alpha-primary-20)) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* CTA button — retro glow animation */
 .hero-cta {
   margin-top: 2.5rem;
   min-width: 220px;
@@ -159,295 +194,40 @@ const goToIde = () => {
   letter-spacing: 2px;
   font-weight: 700;
   font-family: var(--game-font-family-heading);
+  animation:
+    home-fade-in-up
+    var(--home-entrance-duration, 0.6s)
+    var(--home-entrance-easing, cubic-bezier(0.16, 1, 0.3, 1))
+    0.5s both,
+    home-cta-glow 3s ease-in-out infinite;
+  animation-fill-mode: both, none;
 }
 
-/* ===== Showcase Section ===== */
-
-.showcase-section {
-  padding: 0 0 4rem;
+.hero-cta:hover {
+  animation: none;
+  box-shadow:
+    0 0 30px var(--home-glow-intensity, var(--base-alpha-primary-50)),
+    0 4px 8px var(--base-alpha-gray-00-40),
+    inset 0 1px 0 var(--base-alpha-gray-100-10);
+  transform: translateY(-2px);
+  transition: all 0.2s ease;
 }
 
-.showcase-header {
-  text-align: center;
-  margin-bottom: 3rem;
-}
-
-.showcase-title {
-  font-size: 2.2rem;
-  font-weight: 700;
-  font-family: var(--game-font-family-heading);
-  color: var(--base-solid-primary);
-  text-shadow: 0 0 16px var(--game-accent-glow);
-  margin: 0 0 0.75rem;
-  letter-spacing: 2px;
-}
-
-/* Light theme: use accent color, no glow */
-.light-theme .showcase-title {
-  color: var(--base-solid-primary);
-  text-shadow: none;
-}
-
-.showcase-subtitle {
-  font-size: 1.1rem;
-  color: var(--game-text-tertiary);
-  margin: 0;
-  line-height: 1.5;
-}
-
-/* ===== Showcase Grid ===== */
-
-.showcase-grid {
-  display: grid;
-  grid-template-columns: 1.4fr 1fr;
-  grid-template-rows: auto auto;
-  gap: 1.5rem;
-}
-
-.showcase-spotlight {
-  grid-column: 1;
-  grid-row: 1;
-}
-
-.showcase-side {
-  grid-column: 2;
-  grid-row: 1;
-}
-
-.showcase-row-item {
-  grid-column: auto;
-  grid-row: 2;
-}
-
-/* Last row items split evenly */
-.showcase-row-item:nth-child(3) {
-  grid-column: 1;
-}
-
-.showcase-row-item:nth-child(4) {
-  grid-column: 2;
-}
-
-.showcase-item {
-  padding: 0;
-  overflow: hidden;
-}
-
-/* ===== Spotlight (Editor) ===== */
-
-.spotlight-content {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  padding: 2rem;
-}
-
-.spotlight-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.spotlight-icon {
-  width: 64px;
-  height: 64px;
-  border-radius: 12px;
-  background: var(--game-surface-bg-accent-gradient);
-  border: 2px solid var(--base-solid-primary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 0 20px var(--base-alpha-primary-30);
-  color: var(--base-solid-primary);
-  margin-bottom: 0.5rem;
-}
-
-/* ===== Code Window ===== */
-
-.spotlight-code {
-  flex: 1;
-}
-
-.code-window {
-  background: var(--base-solid-gray-00);
-  border: 1px solid var(--base-solid-gray-30);
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: inset 0 2px 8px var(--base-alpha-gray-00-40);
-}
-
-.code-window-bar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0.5rem 0.75rem;
-  background: var(--base-solid-gray-10);
-  border-bottom: 1px solid var(--base-solid-gray-20);
-}
-
-.code-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
-.code-dot-red {
-  background: var(--semantic-solid-danger);
-}
-
-.code-dot-yellow {
-  background: var(--semantic-solid-warning);
-}
-
-.code-dot-green {
-  background: var(--semantic-solid-success);
-}
-
-.code-window-title {
-  margin-left: 0.5rem;
-  font-size: 0.7rem;
-  color: var(--game-text-tertiary);
-  font-family: var(--game-font-family-mono);
-  letter-spacing: 1px;
-}
-
-.code-block {
-  margin: 0;
-  padding: 1rem 1.25rem;
-  font-family: var(--game-font-family-mono);
-  font-size: 0.8rem;
-  line-height: 1.7;
-  color: var(--base-solid-primary);
-  overflow-x: auto;
-  white-space: pre;
-}
-
-.code-block code {
-  font-family: inherit;
-  font-size: inherit;
-  color: inherit;
-  background: transparent;
-}
-
-/* ===== Side Item (Sprites) ===== */
-
-.showcase-item-inner {
-  padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-.showcase-side .showcase-item-inner {
-  justify-content: center;
-}
-
-.showcase-item-icon {
-  width: 56px;
-  height: 56px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 1.25rem;
-  border: 2px solid transparent;
-  box-shadow: 0 0 16px var(--base-alpha-primary-20);
-  color: var(--base-solid-primary);
-}
-
-.showcase-item-icon-sprites {
-  background: linear-gradient(135deg, var(--base-solid-primary-10), var(--base-solid-primary-20));
-  border-color: var(--base-solid-primary);
-}
-
-.showcase-item-icon-sound {
-  width: 48px;
-  height: 48px;
-  background: linear-gradient(135deg, var(--semantic-alpha-warning-10), var(--semantic-alpha-warning-20));
-  border-color: var(--semantic-solid-warning);
-  color: var(--semantic-solid-warning);
-  box-shadow: 0 0 16px var(--semantic-alpha-warning-20);
-}
-
-.showcase-item-icon-samples {
-  width: 48px;
-  height: 48px;
-  background: linear-gradient(135deg, var(--semantic-alpha-success-10), var(--semantic-alpha-success-20));
-  border-color: var(--semantic-solid-success);
-  color: var(--semantic-solid-success);
-  box-shadow: 0 0 16px var(--semantic-alpha-success-20);
-}
-
-/* ===== Row Items (Sound, Samples) ===== */
-
-.showcase-row-item .showcase-item-inner {
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 1.25rem;
-}
-
-.showcase-row-item .showcase-item-body {
-  flex: 1;
-  min-width: 0;
-}
-
-/* ===== Shared Item Styles ===== */
-
-.showcase-item-title {
-  font-size: 1.3rem;
-  font-weight: 700;
-  font-family: var(--game-font-family-heading);
-  margin: 0 0 0.75rem;
-  text-shadow: 0 0 8px var(--game-accent-glow);
-}
-
-/* Light theme: use accent color, no glow */
-.light-theme .showcase-item-title {
-  color: var(--base-solid-primary);
-  text-shadow: none;
-}
-
-.showcase-item-desc {
-  font-size: 0.9rem;
-  color: var(--game-text-secondary);
-  line-height: 1.6;
-  margin: 0;
-}
-
-/* ===== Responsive Design ===== */
-
+/* Responsive design */
 @media (width <= 768px) {
-  .home-content {
+  .home-page {
     padding: 0 1.5rem 1.5rem;
+  }
+
+  .home-bg-glow {
+    width: 160%;
+    top: -10%;
   }
 
   .hero-cta {
     min-width: 180px;
     font-size: 1rem;
     padding: 0.875rem 2rem;
-  }
-
-  .showcase-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .showcase-spotlight,
-  .showcase-side,
-  .showcase-row-item:nth-child(3),
-  .showcase-row-item:nth-child(4) {
-    grid-column: 1;
-  }
-
-  .spotlight-content {
-    padding: 1.5rem;
-  }
-
-  .showcase-title {
-    font-size: 1.8rem;
-  }
-
-  .showcase-row-item .showcase-item-inner {
-    flex-direction: column;
   }
 }
 
@@ -457,22 +237,7 @@ const goToIde = () => {
     font-size: 0.9rem;
     padding: 0.75rem 1.5rem;
   }
-
-  .showcase-title {
-    font-size: 1.5rem;
-  }
-
-  .showcase-subtitle {
-    font-size: 1rem;
-  }
-
-  .spotlight-content {
-    gap: 1.5rem;
-    padding: 1.25rem;
-  }
-
-  .showcase-item-inner {
-    padding: 1.25rem;
-  }
 }
 </style>
+
+<style src="@/shared/styles/showcase.css" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import './shared/styles/fonts'
 import './shared/styles/theme.css'
 import './shared/styles/utilities.css'
 import './shared/styles/skins/index.css'
+import './shared/styles/retro-home.css'
 
 import { createApp } from 'vue'
 import VueKonva from 'vue-konva'

--- a/src/shared/components/ui/HeroSection.vue
+++ b/src/shared/components/ui/HeroSection.vue
@@ -17,10 +17,18 @@ withDefaults(defineProps<Props>(), {
 
 <template>
   <div class="hero-section">
+    <!-- Scan line sweep overlay -->
+    <div class="hero-scanline-sweep" aria-hidden="true" />
+
+    <!-- Pixel grid background -->
+    <div class="hero-pixel-grid" aria-hidden="true" />
+
     <div class="hero-content">
       <h1 class="hero-title">
-        <GameIcon v-if="icon" :icon="icon" :size="80" class="hero-icon" />
-        {{ title }}
+        <span v-if="icon" class="hero-icon-wrapper">
+          <GameIcon :icon="icon" :size="80" class="hero-icon" />
+        </span>
+        <span class="hero-title-text">{{ title }}</span>
       </h1>
       <p v-if="subtitle" class="hero-subtitle">{{ subtitle }}</p>
       <p v-if="description" class="hero-description">{{ description }}</p>
@@ -31,14 +39,23 @@ withDefaults(defineProps<Props>(), {
 
 <style scoped>
 .hero-section {
+  position: relative;
   text-align: center;
   padding: 4rem 2rem;
   margin-bottom: 4rem;
+  overflow: hidden;
 }
 
 .hero-content {
+  position: relative;
+  z-index: 1;
   max-width: 800px;
   margin: 0 auto;
+  animation:
+    home-fade-in-up
+    var(--home-entrance-duration, 0.6s)
+    var(--home-entrance-easing, cubic-bezier(0.16, 1, 0.3, 1))
+    both;
 }
 
 .hero-title {
@@ -55,10 +72,21 @@ withDefaults(defineProps<Props>(), {
     0 4px 8px var(--base-alpha-gray-00-80);
   letter-spacing: 3px;
   margin: 0 0 1.5rem;
+  animation: home-glow-pulse 4s ease-in-out infinite;
+}
+
+.hero-icon-wrapper {
+  display: inline-flex;
+  align-items: center;
+  animation: home-icon-float 3s ease-in-out infinite;
 }
 
 .hero-icon {
   filter: drop-shadow(0 0 12px var(--game-accent-glow));
+}
+
+.hero-title-text {
+  display: inline-block;
 }
 
 .hero-subtitle {
@@ -66,6 +94,11 @@ withDefaults(defineProps<Props>(), {
   color: var(--game-text-secondary);
   margin: 0 0 1rem;
   font-weight: 500;
+  animation:
+    home-fade-in-up
+    var(--home-entrance-duration, 0.6s)
+    var(--home-entrance-easing, cubic-bezier(0.16, 1, 0.3, 1))
+    0.1s both;
 }
 
 .hero-description {
@@ -73,32 +106,77 @@ withDefaults(defineProps<Props>(), {
   color: var(--game-text-tertiary);
   line-height: 1.6;
   margin: 0;
+  animation:
+    home-fade-in-up
+    var(--home-entrance-duration, 0.6s)
+    var(--home-entrance-easing, cubic-bezier(0.16, 1, 0.3, 1))
+    0.2s both;
+}
+
+/* Scan line sweep — thin horizontal line moving down */
+.hero-scanline-sweep {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--home-glow-subtle, var(--base-alpha-primary-20)) 20%,
+    var(--home-glow-intensity, var(--base-alpha-primary-50)) 50%,
+    var(--home-glow-subtle, var(--base-alpha-primary-20)) 80%,
+    transparent 100%
+  );
+  animation: home-scanline-sweep 8s linear infinite;
+  pointer-events: none;
+  z-index: 2;
+  opacity: 0.6;
+}
+
+/* Pixel grid background — subtle retro texture */
+.hero-pixel-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--home-pixel-grid-color, var(--base-alpha-gray-100-10)) 1px, transparent 1px),
+    linear-gradient(90deg, var(--home-pixel-grid-color, var(--base-alpha-gray-100-10)) 1px, transparent 1px);
+  background-size: 24px 24px;
+  animation: home-pixel-shimmer 6s ease-in-out infinite;
+  pointer-events: none;
+  z-index: 0;
 }
 
 /* Responsive design */
 @media (width <= 768px) {
-  .hero-title {
-    font-size: 2.5rem;
+  .hero-section {
+    padding: 3rem 1.5rem;
+    margin-bottom: 3rem;
   }
 
-  .hero-icon {
-    /* Icon size handled by GameIcon size prop */
+  .hero-title {
+    font-size: 2.5rem;
   }
 
   .hero-subtitle {
     font-size: 1.25rem;
   }
+
+  .hero-pixel-grid {
+    background-size: 16px 16px;
+  }
 }
 
 @media (width <= 480px) {
+  .hero-section {
+    padding: 2rem 1rem;
+    margin-bottom: 2rem;
+  }
+
   .hero-title {
     font-size: 2rem;
     flex-direction: column;
     gap: 0.5rem;
-  }
-
-  .hero-icon {
-    /* Icon size handled by GameIcon size prop - adjust via size prop if needed */
   }
 }
 </style>

--- a/src/shared/styles/retro-home.css
+++ b/src/shared/styles/retro-home.css
@@ -1,0 +1,135 @@
+/**
+ * Retro-Futuristic Home Page Styles
+ *
+ * Design tokens and animations for the home page,
+ * inspired by Family Computer / Famicom heritage meets modern web design.
+ *
+ * All colors reference theme.css variables via relative color syntax.
+ * Animations use GPU-accelerated properties (transform, opacity) for performance.
+ */
+
+
+/* Home-Page Design Tokens */
+
+.home-page {
+    --home-glow-intensity: var(--base-alpha-primary-50);
+    --home-glow-subtle: var(--base-alpha-primary-20);
+    --home-scanline-color: var(--base-alpha-gray-00-10);
+    --home-pixel-grid-color: var(--base-alpha-gray-100-10);
+    --home-overlay-dark: var(--base-alpha-gray-00-60);
+    --home-entrance-duration: 0.6s;
+    --home-entrance-easing: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+
+/* Keyframe Animations */
+
+
+/* Subtle glow pulse for title text — keeps text readable */
+
+@keyframes home-glow-pulse {
+    0%,
+    100% {
+        text-shadow:
+            0 0 20px var(--game-accent-glow),
+            0 4px 8px var(--base-alpha-gray-00-80);
+        filter: brightness(1);
+    }
+
+    50% {
+        text-shadow:
+            0 0 30px var(--game-accent-glow),
+            0 0 60px var(--home-glow-subtle),
+            0 4px 8px var(--base-alpha-gray-00-80);
+        filter: brightness(1.05);
+    }
+}
+
+
+/* Horizontal scan line sweep — moves top to bottom */
+
+@keyframes home-scanline-sweep {
+    0% {
+        transform: translateY(-100%);
+    }
+
+    100% {
+        transform: translateY(100vh);
+    }
+}
+
+
+/* Pixel shimmer effect — subtle opacity flicker */
+
+@keyframes home-pixel-shimmer {
+    0%,
+    100% {
+        opacity: 0.03;
+    }
+
+    50% {
+        opacity: 0.08;
+    }
+}
+
+
+/* Entrance animation — slide up with fade in */
+
+@keyframes home-fade-in-up {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+
+/* CTA button glow animation */
+
+@keyframes home-cta-glow {
+    0%,
+    100% {
+        box-shadow:
+            0 0 10px var(--home-glow-subtle),
+            0 2px 4px var(--base-alpha-gray-00-30),
+            inset 0 1px 0 var(--base-alpha-gray-100-10);
+    }
+
+    50% {
+        box-shadow:
+            0 0 25px var(--home-glow-intensity),
+            0 2px 4px var(--base-alpha-gray-00-30),
+            inset 0 1px 0 var(--base-alpha-gray-100-10);
+    }
+}
+
+
+/* Icon float — gentle up/down for hero icon */
+
+@keyframes home-icon-float {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+
+    50% {
+        transform: translateY(-6px);
+    }
+}
+
+
+/* Respect reduced-motion preferences */
+
+@media (prefers-reduced-motion: reduce) {
+    .home-page *,
+    .home-page *::before,
+    .home-page *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}

--- a/src/shared/styles/showcase.css
+++ b/src/shared/styles/showcase.css
@@ -1,0 +1,306 @@
+/**
+ * Showcase Section Styles
+ *
+ * Styles for the home page feature showcase section,
+ * including the asymmetric grid layout, code window,
+ * and feature card styling.
+ */
+
+/* ===== Showcase Section ===== */
+
+.showcase-section {
+  padding: 0 0 4rem;
+}
+
+.showcase-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.showcase-title {
+  font-size: 2.2rem;
+  font-weight: 700;
+  font-family: var(--game-font-family-heading);
+  color: var(--base-solid-primary);
+  text-shadow: 0 0 16px var(--game-accent-glow);
+  margin: 0 0 0.75rem;
+  letter-spacing: 2px;
+}
+
+/* Light theme: use accent color, no glow */
+.light-theme .showcase-title {
+  color: var(--base-solid-primary);
+  text-shadow: none;
+}
+
+.showcase-subtitle {
+  font-size: 1.1rem;
+  color: var(--game-text-tertiary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ===== Showcase Grid ===== */
+
+.showcase-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  grid-template-rows: auto auto;
+  gap: 1.5rem;
+}
+
+.showcase-spotlight {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.showcase-side {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.showcase-row-item {
+  grid-column: auto;
+  grid-row: 2;
+}
+
+/* Last row items split evenly */
+.showcase-row-item:nth-child(3) {
+  grid-column: 1;
+}
+
+.showcase-row-item:nth-child(4) {
+  grid-column: 2;
+}
+
+.showcase-item {
+  padding: 0;
+  overflow: hidden;
+}
+
+/* ===== Spotlight (Editor) ===== */
+
+.spotlight-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem;
+}
+
+.spotlight-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spotlight-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+  background: var(--game-surface-bg-accent-gradient);
+  border: 2px solid var(--base-solid-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 20px var(--base-alpha-primary-30);
+  color: var(--base-solid-primary);
+  margin-bottom: 0.5rem;
+}
+
+/* ===== Code Window ===== */
+
+.spotlight-code {
+  flex: 1;
+}
+
+.code-window {
+  background: var(--base-solid-gray-00);
+  border: 1px solid var(--base-solid-gray-30);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: inset 0 2px 8px var(--base-alpha-gray-00-40);
+}
+
+.code-window-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0.5rem 0.75rem;
+  background: var(--base-solid-gray-10);
+  border-bottom: 1px solid var(--base-solid-gray-20);
+}
+
+.code-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.code-dot-red {
+  background: var(--semantic-solid-danger);
+}
+
+.code-dot-yellow {
+  background: var(--semantic-solid-warning);
+}
+
+.code-dot-green {
+  background: var(--semantic-solid-success);
+}
+
+.code-window-title {
+  margin-left: 0.5rem;
+  font-size: 0.7rem;
+  color: var(--game-text-tertiary);
+  font-family: var(--game-font-family-mono);
+  letter-spacing: 1px;
+}
+
+.code-block {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  font-family: var(--game-font-family-mono);
+  font-size: 0.8rem;
+  line-height: 1.7;
+  color: var(--base-solid-primary);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.code-block code {
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  background: transparent;
+}
+
+/* ===== Side Item (Sprites) ===== */
+
+.showcase-item-inner {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.showcase-side .showcase-item-inner {
+  justify-content: center;
+}
+
+.showcase-item-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  border: 2px solid transparent;
+  box-shadow: 0 0 16px var(--base-alpha-primary-20);
+  color: var(--base-solid-primary);
+}
+
+.showcase-item-icon-sprites {
+  background: linear-gradient(135deg, var(--base-solid-primary-10), var(--base-solid-primary-20));
+  border-color: var(--base-solid-primary);
+}
+
+.showcase-item-icon-sound {
+  width: 48px;
+  height: 48px;
+  background: linear-gradient(135deg, var(--semantic-alpha-warning-10), var(--semantic-alpha-warning-20));
+  border-color: var(--semantic-solid-warning);
+  color: var(--semantic-solid-warning);
+  box-shadow: 0 0 16px var(--semantic-alpha-warning-20);
+}
+
+.showcase-item-icon-samples {
+  width: 48px;
+  height: 48px;
+  background: linear-gradient(135deg, var(--semantic-alpha-success-10), var(--semantic-alpha-success-20));
+  border-color: var(--semantic-solid-success);
+  color: var(--semantic-solid-success);
+  box-shadow: 0 0 16px var(--semantic-alpha-success-20);
+}
+
+/* ===== Row Items (Sound, Samples) ===== */
+
+.showcase-row-item .showcase-item-inner {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.showcase-row-item .showcase-item-body {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ===== Shared Item Styles ===== */
+
+.showcase-item-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  font-family: var(--game-font-family-heading);
+  margin: 0 0 0.75rem;
+  text-shadow: 0 0 8px var(--game-accent-glow);
+}
+
+/* Light theme: use accent color, no glow */
+.light-theme .showcase-item-title {
+  color: var(--base-solid-primary);
+  text-shadow: none;
+}
+
+.showcase-item-desc {
+  font-size: 0.9rem;
+  color: var(--game-text-secondary);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ===== Responsive Design ===== */
+
+@media (width <= 768px) {
+  .showcase-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .showcase-spotlight,
+  .showcase-side,
+  .showcase-row-item:nth-child(3),
+  .showcase-row-item:nth-child(4) {
+    grid-column: 1;
+  }
+
+  .spotlight-content {
+    padding: 1.5rem;
+  }
+
+  .showcase-title {
+    font-size: 1.8rem;
+  }
+
+  .showcase-row-item .showcase-item-inner {
+    flex-direction: column;
+  }
+}
+
+@media (width <= 480px) {
+  .showcase-title {
+    font-size: 1.5rem;
+  }
+
+  .showcase-subtitle {
+    font-size: 1rem;
+  }
+
+  .spotlight-content {
+    gap: 1.5rem;
+    padding: 1.25rem;
+  }
+
+  .showcase-item-inner {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #343 (Step 6 of 6 for #336)

## Changes
- Add `retro-home.css` with design tokens and 6 keyframe animations (glow-pulse, scanline-sweep, pixel-shimmer, fade-in-up, cta-glow, icon-float)
- Enhance HeroSection with scan line sweep, pixel grid background, title glow pulse, icon float animation
- Add ambient glow, staggered entrance animations, and CTA glow effect to HomePage
- `prefers-reduced-motion` media query for accessibility

## Test plan
- [ ] Type-check passes
- [ ] Lint passes
- [ ] All 3167 unit tests pass
- [ ] E2E smoke tests pass
- [ ] Visual review of home page animations