### PR TITLE
refactor: resolve #355 - split MyProgramsLibrary.vue from 485 to under 500 lines

### DIFF
--- a/src/features/ide/components/MyProgramsLibrary.vue
+++ b/src/features/ide/components/MyProgramsLibrary.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, useTemplateRef } from 'vue'
+import { nextTick, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { ProgramData } from '@/core/types/program-types'
+import { useLibraryFilter } from '@/features/ide/composables/useLibraryFilter'
 import { useProgramLibrary } from '@/features/ide/composables/useProgramLibrary'
 import { ConfirmDialog, GameButton, GameIconButton, GameInput, GameSelect } from '@/shared/components/ui'
 
@@ -27,9 +28,15 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const library = useProgramLibrary()
 
-// Search and sort state
-const searchQuery = ref<string | number>('')
-const sortKey = ref<string | number>('updatedAt')
+// Filter/sort logic delegated to composable
+const {
+  searchQuery,
+  sortKey,
+  sortOptions,
+  displayedPrograms,
+  hasNoResults,
+  isEmpty,
+} = useLibraryFilter(library.programs, library.isInitialized)
 
 // Delete confirmation state
 const deleteTarget = ref<ProgramData | null>(null)
@@ -39,46 +46,9 @@ const editingId = ref<string | null>(null)
 const editingName = ref('')
 const renameInputRef = useTemplateRef<HTMLInputElement>('renameInputRef')
 
-// Sort options for the GameSelect dropdown
-const sortOptions = computed(() => [
-  { label: t('ide.myPrograms.sort.recentlyModified'), value: 'updatedAt' as const },
-  { label: t('ide.myPrograms.sort.alphabetical'), value: 'name' as const },
-])
-
 // Load programs on mount
 onMounted(() => {
   void library.listPrograms()
-})
-
-// Filtered and sorted programs
-const displayedPrograms = computed(() => {
-  let result = [...library.programs.value]
-
-  // Filter by search query
-  const query = String(searchQuery.value).trim().toLowerCase()
-  if (query) {
-    result = result.filter((p) => p.name.toLowerCase().includes(query))
-  }
-
-  // Sort
-  const sort = sortKey.value as 'updatedAt' | 'name'
-  result.sort((a, b) => {
-    if (sort === 'updatedAt') {
-      return b.updatedAt - a.updatedAt
-    }
-    return a.name.localeCompare(b.name)
-  })
-
-  return result
-})
-
-// Whether the "no results" state is from filtering (vs truly empty library)
-const hasNoResults = computed(() => {
-  return String(searchQuery.value).trim() !== '' && displayedPrograms.value.length === 0
-})
-
-const isEmpty = computed(() => {
-  return library.isInitialized.value && library.programs.value.length === 0 && !String(searchQuery.value).trim()
 })
 
 // Format timestamp to locale string

--- a/src/features/ide/composables/useLibraryFilter.ts
+++ b/src/features/ide/composables/useLibraryFilter.ts
@@ -1,0 +1,92 @@
+/**
+ * useLibraryFilter composable
+ *
+ * Manages search, sort, and filtering logic for the program library.
+ * Encapsulates reactive state for search queries and sort keys, and
+ * exposes computed properties for the filtered/sorted program list
+ * and display-state flags (empty, no results).
+ *
+ * Used by MyProgramsLibrary to keep the component focused on
+ * presentation and action handling.
+ */
+
+import type { ComputedRef, Ref } from 'vue'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { ProgramData } from '@/core/types/program-types'
+
+export type SortKey = 'updatedAt' | 'name'
+
+export interface UseLibraryFilterReturn {
+  /** Current search query (reactive, two-way bindable) */
+  searchQuery: Ref<string | number>
+  /** Current sort key (reactive, two-way bindable) */
+  sortKey: Ref<string | number>
+  /** Sort options for the GameSelect dropdown */
+  sortOptions: ComputedRef<Array<{ label: string; value: SortKey }>>
+  /** Programs filtered by search and sorted by sortKey */
+  displayedPrograms: ComputedRef<ProgramData[]>
+  /** True when filtering yields zero results (search is non-empty) */
+  hasNoResults: ComputedRef<boolean>
+  /** True when library is initialized but has zero programs (no search active) */
+  isEmpty: ComputedRef<boolean>
+}
+
+/**
+ * Provides filter/sort logic for a program library list.
+ *
+ * @param programs - Reactive ref holding the full program list
+ * @param isInitialized - Reactive ref indicating whether the library has loaded
+ * @returns Filter state and computed derived lists
+ */
+export function useLibraryFilter(
+  programs: Ref<readonly ProgramData[]>,
+  isInitialized: Ref<boolean>,
+): UseLibraryFilterReturn {
+  const { t } = useI18n()
+
+  const searchQuery = ref<string | number>('')
+  const sortKey = ref<string | number>('updatedAt')
+
+  const sortOptions = computed(() => [
+    { label: t('ide.myPrograms.sort.recentlyModified'), value: 'updatedAt' as const },
+    { label: t('ide.myPrograms.sort.alphabetical'), value: 'name' as const },
+  ])
+
+  const displayedPrograms = computed(() => {
+    let result = [...programs.value]
+
+    const query = String(searchQuery.value).trim().toLowerCase()
+    if (query) {
+      result = result.filter((p) => p.name.toLowerCase().includes(query))
+    }
+
+    const sort = sortKey.value as SortKey
+    result.sort((a, b) => {
+      if (sort === 'updatedAt') {
+        return b.updatedAt - a.updatedAt
+      }
+      return a.name.localeCompare(b.name)
+    })
+
+    return result
+  })
+
+  const hasNoResults = computed(() => {
+    return String(searchQuery.value).trim() !== '' && displayedPrograms.value.length === 0
+  })
+
+  const isEmpty = computed(() => {
+    return isInitialized.value && programs.value.length === 0 && !String(searchQuery.value).trim()
+  })
+
+  return {
+    searchQuery,
+    sortKey,
+    sortOptions,
+    displayedPrograms,
+    hasNoResults,
+    isEmpty,
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #355

## Changes
- Extract `useLibraryFilter` composable (92 lines) — search/sort reactive state, sort options, displayedPrograms/hasNoResults/isEmpty computed properties
- Reduce MyProgramsLibrary.vue from 485 → 455 lines
- No behavior change — pure refactor by responsibility decomposition

## Test plan
- [x] All 3167 unit tests pass (including MyProgramsLibrary tests)
- [x] TypeScript type-check clean
- [x] ESLint clean
- [ ] CI passes