### PR TITLE
fix: resolve #359 - balance showcase grid layout with uniform 2x2 grid

### DIFF
--- a/src/features/home/HomePage.vue
+++ b/src/features/home/HomePage.vue
@@ -62,32 +62,19 @@ const goToIde = () => {
           </div>
 
           <div class="showcase-grid">
-            <!-- Editor Spotlight - Large featured highlight -->
+            <!-- Editor -->
             <GameBlock
               title=""
               :hide-header="true"
               :no-hover-effect="true"
-              class="showcase-spotlight showcase-item"
+              class="showcase-item"
             >
-              <div class="spotlight-content">
-                <div class="spotlight-text">
-                  <div class="spotlight-icon">
-                    <GameIcon icon="mdi:code-braces" :size="36" />
-                  </div>
-                  <h3 class="showcase-item-title">{{ t('home.showcase.items.editor.title') }}</h3>
-                  <p class="showcase-item-desc">{{ t('home.showcase.items.editor.description') }}</p>
+              <div class="showcase-item-inner">
+                <div class="showcase-item-icon showcase-item-icon-editor">
+                  <GameIcon icon="mdi:code-braces" :size="32" />
                 </div>
-                <div class="spotlight-code">
-                  <div class="code-window">
-                    <div class="code-window-bar">
-                      <span class="code-dot code-dot-red"></span>
-                      <span class="code-dot code-dot-yellow"></span>
-                      <span class="code-dot code-dot-green"></span>
-                      <span class="code-window-title">HELLO.BAS</span>
-                    </div>
-                    <pre class="code-block"><code>{{ t('home.showcase.items.editor.code') }}</code></pre>
-                  </div>
-                </div>
+                <h3 class="showcase-item-title">{{ t('home.showcase.items.editor.title') }}</h3>
+                <p class="showcase-item-desc">{{ t('home.showcase.items.editor.description') }}</p>
               </div>
             </GameBlock>
 
@@ -96,7 +83,7 @@ const goToIde = () => {
               title=""
               :hide-header="true"
               :no-hover-effect="true"
-              class="showcase-side showcase-item"
+              class="showcase-item"
             >
               <div class="showcase-item-inner">
                 <div class="showcase-item-icon showcase-item-icon-sprites">
@@ -112,16 +99,14 @@ const goToIde = () => {
               title=""
               :hide-header="true"
               :no-hover-effect="true"
-              class="showcase-row-item showcase-item"
+              class="showcase-item"
             >
               <div class="showcase-item-inner">
                 <div class="showcase-item-icon showcase-item-icon-sound">
-                  <GameIcon icon="mdi:music-note" :size="28" />
+                  <GameIcon icon="mdi:music-note" :size="32" />
                 </div>
-                <div class="showcase-item-body">
-                  <h3 class="showcase-item-title">{{ t('home.showcase.items.sound.title') }}</h3>
-                  <p class="showcase-item-desc">{{ t('home.showcase.items.sound.description') }}</p>
-                </div>
+                <h3 class="showcase-item-title">{{ t('home.showcase.items.sound.title') }}</h3>
+                <p class="showcase-item-desc">{{ t('home.showcase.items.sound.description') }}</p>
               </div>
             </GameBlock>
 
@@ -130,19 +115,41 @@ const goToIde = () => {
               title=""
               :hide-header="true"
               :no-hover-effect="true"
-              class="showcase-row-item showcase-item"
+              class="showcase-item"
             >
               <div class="showcase-item-inner">
                 <div class="showcase-item-icon showcase-item-icon-samples">
-                  <GameIcon icon="mdi:gamepad-variant" :size="28" />
+                  <GameIcon icon="mdi:gamepad-variant" :size="32" />
                 </div>
-                <div class="showcase-item-body">
-                  <h3 class="showcase-item-title">{{ t('home.showcase.items.samples.title') }}</h3>
-                  <p class="showcase-item-desc">{{ t('home.showcase.items.samples.description') }}</p>
-                </div>
+                <h3 class="showcase-item-title">{{ t('home.showcase.items.samples.title') }}</h3>
+                <p class="showcase-item-desc">{{ t('home.showcase.items.samples.description') }}</p>
               </div>
             </GameBlock>
           </div>
+
+          <!-- Code Banner — full-width F-BASIC code preview -->
+          <GameBlock
+            title=""
+            :hide-header="true"
+            :no-hover-effect="true"
+            class="showcase-code-banner"
+          >
+            <div class="code-banner-content">
+              <div class="code-banner-label">
+                <GameIcon icon="mdi:code-braces" :size="18" />
+                <span>{{ t('home.showcase.items.editor.title') }}</span>
+              </div>
+              <div class="code-window">
+                <div class="code-window-bar">
+                  <span class="code-dot code-dot-red"></span>
+                  <span class="code-dot code-dot-yellow"></span>
+                  <span class="code-dot code-dot-green"></span>
+                  <span class="code-window-title">HELLO.BAS</span>
+                </div>
+                <pre class="code-block"><code>{{ t('home.showcase.items.editor.code') }}</code></pre>
+              </div>
+            </div>
+          </GameBlock>
         </section>
       </div>
     </div>

--- a/src/shared/styles/showcase.css
+++ b/src/shared/styles/showcase.css
@@ -2,8 +2,8 @@
  * Showcase Section Styles
  *
  * Styles for the home page feature showcase section,
- * including the asymmetric grid layout, code window,
- * and feature card styling.
+ * including a uniform 2x2 grid of feature cards
+ * and a full-width code preview banner.
  */
 
 /* ===== Showcase Section ===== */
@@ -40,37 +40,12 @@
   line-height: 1.5;
 }
 
-/* ===== Showcase Grid ===== */
+/* ===== Showcase Grid — Uniform 2x2 ===== */
 
 .showcase-grid {
   display: grid;
-  grid-template-columns: 1.4fr 1fr;
-  grid-template-rows: auto auto;
+  grid-template-columns: 1fr 1fr;
   gap: 1.5rem;
-}
-
-.showcase-spotlight {
-  grid-column: 1;
-  grid-row: 1;
-}
-
-.showcase-side {
-  grid-column: 2;
-  grid-row: 1;
-}
-
-.showcase-row-item {
-  grid-column: auto;
-  grid-row: 2;
-}
-
-/* Last row items split evenly */
-.showcase-row-item:nth-child(3) {
-  grid-column: 1;
-}
-
-.showcase-row-item:nth-child(4) {
-  grid-column: 2;
 }
 
 .showcase-item {
@@ -78,40 +53,117 @@
   overflow: hidden;
 }
 
-/* ===== Spotlight (Editor) ===== */
+/* ===== Feature Card Inner Layout ===== */
 
-.spotlight-content {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
+.showcase-item-inner {
   padding: 2rem;
-}
-
-.spotlight-text {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  height: 100%;
 }
 
-.spotlight-icon {
-  width: 64px;
-  height: 64px;
+.showcase-item-icon {
+  width: 56px;
+  height: 56px;
   border-radius: 12px;
-  background: var(--game-surface-bg-accent-gradient);
-  border: 2px solid var(--base-solid-primary);
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 0 20px var(--base-alpha-primary-30);
+  margin-bottom: 1.25rem;
+  border: 2px solid transparent;
+  box-shadow: 0 0 16px var(--base-alpha-primary-20);
   color: var(--base-solid-primary);
-  margin-bottom: 0.5rem;
+}
+
+.showcase-item-icon-editor {
+  background: linear-gradient(
+    135deg,
+    var(--base-solid-primary-10),
+    var(--base-solid-primary-20)
+  );
+  border-color: var(--base-solid-primary);
+}
+
+.showcase-item-icon-sprites {
+  background: linear-gradient(
+    135deg,
+    var(--base-solid-primary-10),
+    var(--base-solid-primary-20)
+  );
+  border-color: var(--base-solid-primary);
+}
+
+.showcase-item-icon-sound {
+  background: linear-gradient(
+    135deg,
+    var(--semantic-alpha-warning-10),
+    var(--semantic-alpha-warning-20)
+  );
+  border-color: var(--semantic-solid-warning);
+  color: var(--semantic-solid-warning);
+  box-shadow: 0 0 16px var(--semantic-alpha-warning-20);
+}
+
+.showcase-item-icon-samples {
+  background: linear-gradient(
+    135deg,
+    var(--semantic-alpha-success-10),
+    var(--semantic-alpha-success-20)
+  );
+  border-color: var(--semantic-solid-success);
+  color: var(--semantic-solid-success);
+  box-shadow: 0 0 16px var(--semantic-alpha-success-20);
+}
+
+/* ===== Shared Item Styles ===== */
+
+.showcase-item-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  font-family: var(--game-font-family-heading);
+  margin: 0 0 0.75rem;
+  text-shadow: 0 0 8px var(--game-accent-glow);
+}
+
+/* Light theme: use accent color, no glow */
+.light-theme .showcase-item-title {
+  color: var(--base-solid-primary);
+  text-shadow: none;
+}
+
+.showcase-item-desc {
+  font-size: 0.9rem;
+  color: var(--game-text-secondary);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ===== Code Banner — Full-Width Preview ===== */
+
+.showcase-code-banner {
+  margin-top: 1.5rem;
+  padding: 0;
+  overflow: hidden;
+}
+
+.code-banner-content {
+  padding: 1.5rem 2rem 2rem;
+}
+
+.code-banner-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--game-font-family-heading);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--game-text-tertiary);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 1rem;
 }
 
 /* ===== Code Window ===== */
-
-.spotlight-code {
-  flex: 1;
-}
 
 .code-window {
   background: var(--base-solid-gray-00);
@@ -174,91 +226,6 @@
   background: transparent;
 }
 
-/* ===== Side Item (Sprites) ===== */
-
-.showcase-item-inner {
-  padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-.showcase-side .showcase-item-inner {
-  justify-content: center;
-}
-
-.showcase-item-icon {
-  width: 56px;
-  height: 56px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 1.25rem;
-  border: 2px solid transparent;
-  box-shadow: 0 0 16px var(--base-alpha-primary-20);
-  color: var(--base-solid-primary);
-}
-
-.showcase-item-icon-sprites {
-  background: linear-gradient(135deg, var(--base-solid-primary-10), var(--base-solid-primary-20));
-  border-color: var(--base-solid-primary);
-}
-
-.showcase-item-icon-sound {
-  width: 48px;
-  height: 48px;
-  background: linear-gradient(135deg, var(--semantic-alpha-warning-10), var(--semantic-alpha-warning-20));
-  border-color: var(--semantic-solid-warning);
-  color: var(--semantic-solid-warning);
-  box-shadow: 0 0 16px var(--semantic-alpha-warning-20);
-}
-
-.showcase-item-icon-samples {
-  width: 48px;
-  height: 48px;
-  background: linear-gradient(135deg, var(--semantic-alpha-success-10), var(--semantic-alpha-success-20));
-  border-color: var(--semantic-solid-success);
-  color: var(--semantic-solid-success);
-  box-shadow: 0 0 16px var(--semantic-alpha-success-20);
-}
-
-/* ===== Row Items (Sound, Samples) ===== */
-
-.showcase-row-item .showcase-item-inner {
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 1.25rem;
-}
-
-.showcase-row-item .showcase-item-body {
-  flex: 1;
-  min-width: 0;
-}
-
-/* ===== Shared Item Styles ===== */
-
-.showcase-item-title {
-  font-size: 1.3rem;
-  font-weight: 700;
-  font-family: var(--game-font-family-heading);
-  margin: 0 0 0.75rem;
-  text-shadow: 0 0 8px var(--game-accent-glow);
-}
-
-/* Light theme: use accent color, no glow */
-.light-theme .showcase-item-title {
-  color: var(--base-solid-primary);
-  text-shadow: none;
-}
-
-.showcase-item-desc {
-  font-size: 0.9rem;
-  color: var(--game-text-secondary);
-  line-height: 1.6;
-  margin: 0;
-}
-
 /* ===== Responsive Design ===== */
 
 @media (width <= 768px) {
@@ -266,23 +233,16 @@
     grid-template-columns: 1fr;
   }
 
-  .showcase-spotlight,
-  .showcase-side,
-  .showcase-row-item:nth-child(3),
-  .showcase-row-item:nth-child(4) {
-    grid-column: 1;
-  }
-
-  .spotlight-content {
-    padding: 1.5rem;
-  }
-
   .showcase-title {
     font-size: 1.8rem;
   }
 
-  .showcase-row-item .showcase-item-inner {
-    flex-direction: column;
+  .showcase-item-inner {
+    padding: 1.5rem;
+  }
+
+  .code-banner-content {
+    padding: 1.25rem 1.5rem 1.5rem;
   }
 }
 
@@ -295,12 +255,11 @@
     font-size: 1rem;
   }
 
-  .spotlight-content {
-    gap: 1.5rem;
+  .showcase-item-inner {
     padding: 1.25rem;
   }
 
-  .showcase-item-inner {
-    padding: 1.25rem;
+  .code-banner-content {
+    padding: 1rem 1.25rem 1.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #359

## Changes
- Switch from asymmetric spotlight/side/row showcase layout to uniform 2x2 grid
- All 4 feature boxes (Editor, Sprites, Sound, Samples) now have identical internal structure (icon + title + description)
- Extract code window mockup into separate full-width code banner below grid
- Remove spotlight-specific, side-specific, and row-specific CSS overrides
- Unified icon sizing (56x56px) for consistent visual weight

## Test plan
- [x] Type-check passes
- [x] ESLint passes (0 errors, 0 warnings)
- [x] All 3167 unit tests pass
- [ ] CI passes