### PR TITLE
fix: resolve #365 - make sprite viewer responsive for 520px side panel

### DIFF
--- a/src/features/ide/components/IdeSpriteViewerPanel.vue
+++ b/src/features/ide/components/IdeSpriteViewerPanel.vue
@@ -131,5 +131,15 @@ function closePanel() {
   flex-direction: column;
   gap: 1rem;
   padding: 1rem;
+
+  /* Compact-mode custom properties for child components */
+  --sprite-color-box-size: 26px;
+  --sprite-color-box-font-size: 0.6rem;
+  --sprite-color-box-gap: 4px;
+  --sprite-palette-min-width: 100%;
+  --sprite-palette-group-padding: 0.75rem;
+  --sprite-combination-min-width: 140px;
+  --sprite-combination-wrapper-min-width: 32px;
+  --sprite-combination-wrapper-height: 32px;
 }
 </style>

--- a/src/features/sprite-viewer/components/ColorBox.vue
+++ b/src/features/sprite-viewer/components/ColorBox.vue
@@ -88,7 +88,7 @@ const backgroundColorValue = computed(() => color.value)
 }
 
 .color-box-code {
-  font-size: 0.875rem;
+  font-size: var(--sprite-color-box-font-size, 0.875rem);
   font-weight: 600;
   color: var(--base-solid-gray-100);
   text-shadow: 1px 1px 2px var(--base-alpha-gray-00-80);

--- a/src/features/sprite-viewer/components/ColorPaletteDisplay.vue
+++ b/src/features/sprite-viewer/components/ColorPaletteDisplay.vue
@@ -31,7 +31,7 @@ const { t } = useI18n()
 .palette-container {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--sprite-color-box-gap, 8px);
   max-width: 100%;
   overflow-x: auto;
   padding: 8px 0;
@@ -40,12 +40,12 @@ const { t } = useI18n()
 .palette-row {
   display: grid;
   grid-template-columns: repeat(16, 1fr);
-  gap: 8px;
+  gap: var(--sprite-color-box-gap, 8px);
   min-width: fit-content;
 }
 
 .palette-color-wrapper {
-  width: 60px;
-  height: 60px;
+  width: var(--sprite-color-box-size, 60px);
+  height: var(--sprite-color-box-size, 60px);
 }
 </style>

--- a/src/features/sprite-viewer/components/PaletteCombinations.vue
+++ b/src/features/sprite-viewer/components/PaletteCombinations.vue
@@ -93,16 +93,22 @@ const getBackgroundPaletteTitle = (index: number) => {
 }
 
 .palettes-container-sprite {
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(var(--sprite-palette-min-width, 300px), 1fr)
+  );
 }
 
 .palettes-container-bg {
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(var(--sprite-palette-min-width, 300px), 1fr)
+  );
 }
 
 .palette-group {
   background: var(--game-surface-bg-inset-gradient);
-  padding: 1.5rem;
+  padding: var(--sprite-palette-group-padding, 1.5rem);
   border-radius: 8px;
   border: 2px solid var(--game-surface-border);
   box-shadow: var(--game-shadow-inset);
@@ -119,7 +125,10 @@ const getBackgroundPaletteTitle = (index: number) => {
 
 .color-combinations {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(var(--sprite-combination-min-width, 200px), 1fr)
+  );
   gap: 1rem;
 }
 
@@ -146,7 +155,7 @@ const getBackgroundPaletteTitle = (index: number) => {
 
 .combination-color-wrapper {
   flex: 1;
-  min-width: 50px;
-  height: 50px;
+  min-width: var(--sprite-combination-wrapper-min-width, 50px);
+  height: var(--sprite-combination-wrapper-height, 50px);
 }
 </style>

--- a/src/features/sprite-viewer/components/SpriteSelector.vue
+++ b/src/features/sprite-viewer/components/SpriteSelector.vue
@@ -33,7 +33,6 @@ const selectOptions = computed(() => {
       @update:model-value="store.setSelectedIndex(Number($event))"
       :options="selectOptions"
       :placeholder="t('spriteViewer.controls.placeholder')"
-      style="width: 300px"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Fixes #365

## Changes
- Add CSS custom properties on IdeSpriteViewerPanel to set compact values for 520px panel context
- Replace hardcoded 60px color boxes with `var(--sprite-color-box-size, 60px)` in ColorPaletteDisplay
- Replace hardcoded 300px min-width with `var(--sprite-palette-min-width, 300px)` in PaletteCombinations
- Remove fixed `style="width: 300px"` from SpriteSelector, letting it use default 100% width
- Scale font sizes in ColorBox via `var(--sprite-color-box-font-size, 0.875rem)`
- All custom properties have fallbacks that preserve full-page CharacterSpriteViewerPage behavior

## Test plan
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes
- [ ] Visual verification: side panel controls are readable and usable
- [ ] Visual verification: full-page sprite viewer unchanged