### PR TITLE
fix: resolve #371 - clear BG data when launching a program

### DIFF
--- a/src/core/devices/DeviceScreenManager.ts
+++ b/src/core/devices/DeviceScreenManager.ts
@@ -51,7 +51,8 @@ export class DeviceScreenManager {
   setCurrentExecutionId(executionId: string | null): void {
     this.screenStateManager.setCurrentExecutionId(executionId)
     if (executionId) {
-      this.screenStateManager.initializeScreen()
+      this.screenStateManager.resetState()
+      this.bgGridData = null
       this.syncScreenStateToShared()
       this.postScreenChanged()
       this.cancelPendingScreenUpdate()

--- a/src/core/devices/ScreenStateManager.ts
+++ b/src/core/devices/ScreenStateManager.ts
@@ -34,6 +34,30 @@ export class ScreenStateManager {
   }
 
   /**
+   * Reset all screen state to defaults for a new execution.
+   * Called when a new RUN starts to clear BG data, palettes, and other
+   * state that would otherwise persist from a previous run.
+   */
+  resetState(): void {
+    this.initializeScreen()
+    this.bgPalette = 1
+    this.spritePalette = 1
+    this.backdropColor = 0
+    this.cgenMode = 2
+    // Reset palettes to original data (undo PALET modifications)
+    for (let i = 0; i < this.backgroundPalettes.length; i++) {
+      for (let j = 0; j < this.backgroundPalettes[i]!.length; j++) {
+        this.backgroundPalettes[i]![j] = [...BACKGROUND_PALETTES[i]![j]!] as [number, number, number, number]
+      }
+    }
+    for (let i = 0; i < this.spritePalettes.length; i++) {
+      for (let j = 0; j < this.spritePalettes[i]!.length; j++) {
+        this.spritePalettes[i]![j] = [...SPRITE_PALETTES[i]![j]!] as [number, number, number, number]
+      }
+    }
+  }
+
+  /**
    * Initialize the screen buffer
    */
   initializeScreen(): void {


### PR DESCRIPTION
## Summary
- Fixes #371

## Changes
- Add `resetState()` to `ScreenStateManager` that resets all BG-related state to defaults:
  - Screen buffer (via existing `initializeScreen()`)
  - BG/sprite palette selections back to 1
  - Backdrop color to 0
  - CGEN mode to 2
  - Background and sprite palette arrays re-initialized from source data (undoes PALET modifications)
- Change `DeviceScreenManager.setCurrentExecutionId()` to call `resetState()` instead of just `initializeScreen()`
- Clear `bgGridData` on new execution start (removes BG editor VIEW artifacts)

## Test plan
- [x] Type-check passes
- [x] ESLint passes
- [x] 3167 unit tests pass
- [ ] CI passes
- [ ] Visual verification: run a BG program, then re-run — no stale artifacts