### PR TITLE
fix: resolve #374 - increase sprite-basic demo pauses and movement distance

### DIFF
--- a/src/core/samples/programs/sprites/sprite-basic.bas
+++ b/src/core/samples/programs/sprites/sprite-basic.bas
@@ -13,15 +13,15 @@
 110 SPRITE 0, 120, 100
 120 PRINT "Sprite placed at (120,100)"
 130 PRINT "Now moving right..."
-140 PAUSE 60
+140 PAUSE 150
 150 REM Define movement: sprite 0, direction 2 (right),
-160 REM speed 3, distance 60 dots, priority 0, color 0
-170 DEF MOVE(0)=SPRITE(0,2,3,60,0,0)
+160 REM speed 3, distance 120 dots, priority 0, color 0
+170 DEF MOVE(0)=SPRITE(0,2,3,120,0,0)
 180 MOVE 0
-190 PAUSE 40
+190 PAUSE 100
 200 CUT 0
 210 PRINT "Stopped at X="; XPOS(0)
-220 PAUSE 40
+220 PAUSE 100
 230 ERA 0
 240 PRINT "Sprite erased. Done!"
 250 END

--- a/test/fixtures/display-snapshots/sprite-basic-complete.json
+++ b/test/fixtures/display-snapshots/sprite-basic-complete.json
@@ -1368,7 +1368,7 @@
       "isVisible": false,
       "frameIndex": 0,
       "remainingDistance": 0,
-      "totalDistance": 120,
+      "totalDistance": 240,
       "direction": 2,
       "speed": 3,
       "priority": 0,


### PR DESCRIPTION
## Summary
- Fixes #374

## Changes
- `PAUSE 60` → `PAUSE 150` (~2.5s to see the static sprite)
- Movement distance `60` → `120` (more visible travel at speed 3)
- `PAUSE 40` → `PAUSE 100` (~1.7s of movement before CUT)
- `PAUSE 40` → `PAUSE 100` (~1.7s to see stopped sprite before ERA)
- Regenerated display snapshot fixture to match updated program

## Test plan
- [x] All 3167 tests pass
- [x] Type-check clean
- [ ] CI passes