### PR TITLE
fix: resolve #394 - suppress false Missing NEXT error on externally stopped programs

### DIFF
--- a/src/core/execution/ExecutionEngine.ts
+++ b/src/core/execution/ExecutionEngine.ts
@@ -124,8 +124,9 @@ export class ExecutionEngine {
       // Execution completed
       this.context.isRunning = false
 
-      // Check for unclosed FOR loops
-      if (this.context.loopStack.length > 0) {
+      // Check for unclosed FOR loops (only when program finished naturally,
+      // not when stopped externally — external stop may interrupt a loop in progress)
+      if (this.context.loopStack.length > 0 && !this.context.externallyStopped) {
         this.context.addError({
           line: 0,
           message: 'Missing NEXT statement for FOR loop',
@@ -169,10 +170,11 @@ export class ExecutionEngine {
   }
 
   /**
-   * Stop execution
+   * Stop execution (called externally, e.g., user presses Stop button)
    */
   stop(): void {
     this.context.shouldStop = true
+    this.context.externallyStopped = true
     this.context.isRunning = false
   }
 

--- a/src/core/state/ExecutionContext.ts
+++ b/src/core/state/ExecutionContext.ts
@@ -30,6 +30,7 @@ export class ExecutionContext {
   public variables: Map<string, BasicVariable> = new Map()
   public isRunning = false
   public shouldStop = false
+  public externallyStopped = false
   public currentStatementIndex = 0
   public statements: ExpandedStatement[] = [] // Expanded statements (flat list)
   public labelMap: Map<number, number[]> = new Map() // Line number -> statement indices
@@ -67,6 +68,7 @@ export class ExecutionContext {
     this.variables.clear()
     this.isRunning = false
     this.shouldStop = false
+    this.externallyStopped = false
     this.currentStatementIndex = 0
     this.statements = []
     this.labelMap.clear()


### PR DESCRIPTION
## Summary
- Fixes #394

## Changes
- Added `externallyStopped` flag to `ExecutionContext`, set by `ExecutionEngine.stop()`
- "Missing NEXT statement for FOR loop" warning now only fires for natural program termination with unclosed loops, not for user-stopped programs
- The cursorPosition sample was correct all along — it was a false positive when programs were killed mid-loop

## Test plan
- [ ] Targeted executor tests pass (511 tests)
- [ ] CI passes