### PR TITLE
feat: resolve #410 - expose window.__fbasicIDE DEV-only global API

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -13,6 +13,13 @@ declare global {
       getWorkerUrl?: (workerId: string, label: string) => string
       getWorker?: (workerId: string, label: string) => Worker
     }
+    /** DEV-only API for headless test code injection. Undefined in production builds. */
+    __fbasicIDE?: {
+      loadCode: (code: string) => void
+      run: () => Promise<void>
+      stop: () => void
+      respondToInput: (value: string) => void
+    }
   }
 }
 

--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -25,6 +25,7 @@ import {
 } from './composables/commandPalette'
 import { useBasicIde as useBasicIdeEnhanced } from './composables/useBasicIdeEnhanced'
 import type { InputMode } from './composables/useBasicIdeState'
+import { useDevApi } from './composables/useDevApi'
 import { provideScreenContext } from './composables/useScreenContext'
 
 /**
@@ -128,6 +129,15 @@ const registerScheduleRender = basicIde?.registerScheduleRender ?? (() => {})
 const pendingInputRequest = basicIde?.pendingInputRequest ?? ref<RequestInputMessage['data'] | null>(null)
 const respondToInputRequest =
   basicIde?.respondToInputRequest ?? ((_requestId: string, _values: string[], _cancelled: boolean) => {})
+
+// Expose DEV-only global API for headless test code injection
+useDevApi({
+  code,
+  runCode,
+  stopCode,
+  pendingInputRequest,
+  respondToInputRequest,
+})
 
 // UI state
 const sampleSelectorOpen = shallowRef(false)

--- a/src/features/ide/composables/useDevApi.ts
+++ b/src/features/ide/composables/useDevApi.ts
@@ -1,0 +1,51 @@
+import { onMounted, onUnmounted,type Ref } from 'vue'
+
+import type { RequestInputMessage } from '@/core/types/worker-messages'
+
+/**
+ * DEV-only global API exposed on `window.__fbasicIDE` for headless test
+ * code injection. This avoids clipboard hacks when automating the IDE
+ * in browser-based E2E tests.
+ *
+ * In production builds `import.meta.env.DEV` is `false`, so the
+ * composable body is completely eliminated by Vite tree-shaking.
+ */
+export function useDevApi(options: {
+  code: Ref<string>
+  runCode: () => Promise<void>
+  stopCode: () => void
+  pendingInputRequest: Ref<RequestInputMessage['data'] | null>
+  respondToInputRequest: (requestId: string, values: string[], cancelled: boolean) => void
+}): void {
+  if (!import.meta.env.DEV) {
+    return
+  }
+
+  function loadCode(code: string): void {
+    options.code.value = code
+  }
+
+  function respondToInput(value: string): void {
+    const request = options.pendingInputRequest.value
+    if (!request) {
+      console.warn('[__fbasicIDE] respondToInput called but no pending input request')
+      return
+    }
+    options.respondToInputRequest(request.requestId, [value], false)
+  }
+
+  const api = {
+    loadCode,
+    run: options.runCode,
+    stop: options.stopCode,
+    respondToInput,
+  }
+
+  onMounted(() => {
+    window.__fbasicIDE = api
+  })
+
+  onUnmounted(() => {
+    window.__fbasicIDE = undefined
+  })
+}

--- a/test/ide/useDevApi.test.ts
+++ b/test/ide/useDevApi.test.ts
@@ -1,0 +1,138 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h,ref } from 'vue'
+
+import { useDevApi } from '@/features/ide/composables/useDevApi'
+
+/**
+ * Helper: mount a minimal component that calls useDevApi so that
+ * onMounted / onUnmounted lifecycle hooks fire correctly.
+ */
+function mountWithDevApi(options: Parameters<typeof useDevApi>[0]) {
+  const testHost = defineComponent({
+    setup() {
+      useDevApi(options)
+      return () => h('div')
+    },
+  })
+  return mount(testHost)
+}
+
+describe('useDevApi', () => {
+  beforeEach(() => {
+    window.__fbasicIDE = undefined
+  })
+
+  afterEach(() => {
+    window.__fbasicIDE = undefined
+  })
+
+  it('exposes __fbasicIDE on window after mount', () => {
+    const code = ref('')
+    const runCode = vi.fn().mockResolvedValue(undefined)
+    const stopCode = vi.fn()
+    const pendingInputRequest = ref(null)
+    const respondToInputRequest = vi.fn()
+
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+
+    expect(window.__fbasicIDE).toBeDefined()
+  })
+
+  it('removes __fbasicIDE on unmount', () => {
+    const code = ref('')
+    const runCode = vi.fn().mockResolvedValue(undefined)
+    const stopCode = vi.fn()
+    const pendingInputRequest = ref(null)
+    const respondToInputRequest = vi.fn()
+
+    const wrapper = mountWithDevApi({
+      code,
+      runCode,
+      stopCode,
+      pendingInputRequest,
+      respondToInputRequest,
+    })
+    expect(window.__fbasicIDE).toBeDefined()
+
+    wrapper.unmount()
+    expect(window.__fbasicIDE).toBeUndefined()
+  })
+
+  it('loadCode sets the code ref value', () => {
+    const code = ref('')
+    const runCode = vi.fn().mockResolvedValue(undefined)
+    const stopCode = vi.fn()
+    const pendingInputRequest = ref(null)
+    const respondToInputRequest = vi.fn()
+
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+
+    window.__fbasicIDE!.loadCode('10 PRINT "HELLO"')
+    expect(code.value).toEqual('10 PRINT "HELLO"')
+  })
+
+  it('run delegates to runCode', () => {
+    const code = ref('')
+    const runCode = vi.fn().mockResolvedValue(undefined)
+    const stopCode = vi.fn()
+    const pendingInputRequest = ref(null)
+    const respondToInputRequest = vi.fn()
+
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+
+    void window.__fbasicIDE!.run()
+    expect(runCode).toHaveBeenCalledOnce()
+  })
+
+  it('stop delegates to stopCode', () => {
+    const code = ref('')
+    const runCode = vi.fn().mockResolvedValue(undefined)
+    const stopCode = vi.fn()
+    const pendingInputRequest = ref(null)
+    const respondToInputRequest = vi.fn()
+
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+
+    window.__fbasicIDE!.stop()
+    expect(stopCode).toHaveBeenCalledOnce()
+  })
+
+  it('respondToInput sends value via respondToInputRequest when request is pending', () => {
+    const code = ref('')
+    const runCode = vi.fn().mockResolvedValue(undefined)
+    const stopCode = vi.fn()
+    const pendingInputRequest = ref({
+      requestId: 'req-42',
+      executionId: 'exec-1',
+      prompt: '?',
+      variableCount: 1,
+      isLinput: false,
+    })
+    const respondToInputRequest = vi.fn()
+
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+
+    window.__fbasicIDE!.respondToInput('hello')
+    expect(respondToInputRequest).toHaveBeenCalledWith('req-42', ['hello'], false)
+  })
+
+  it('respondToInput warns and does nothing when no pending request', () => {
+    const code = ref('')
+    const runCode = vi.fn().mockResolvedValue(undefined)
+    const stopCode = vi.fn()
+    const pendingInputRequest = ref(null)
+    const respondToInputRequest = vi.fn()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+
+    window.__fbasicIDE!.respondToInput('hello')
+    expect(respondToInputRequest).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[__fbasicIDE] respondToInput called but no pending input request',
+    )
+
+    warnSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #410 (Step 1 of 4 for #396)

## Changes
- Added `useDevApi` composable that exposes `window.__fbasicIDE` in DEV mode with `loadCode()`, `run()`, `stop()`, `respondToInput()` methods
- Added `__fbasicIDE` type declaration to `env.d.ts`
- Vite tree-shakes the entire composable in production builds
- 7 unit tests covering all methods + lifecycle

## Test plan
- [ ] 7/7 unit tests pass in `test/ide/useDevApi.test.ts`
- [ ] CI passes