### PR TITLE
feat: resolve #411 - add data-sample-key to SampleSelector.vue cards

### DIFF
--- a/src/features/ide/components/SampleSelector.vue
+++ b/src/features/ide/components/SampleSelector.vue
@@ -108,6 +108,7 @@ const categoryColors: Record<string, string> = {
           v-for="sample in samplesInCategory"
           :key="sample.key"
           class="sample-card"
+          :data-sample-key="sample.key"
           @click="emit('select', sample.key)"
         >
           <div class="sample-card-header">

--- a/test/ide/SampleSelector.test.ts
+++ b/test/ide/SampleSelector.test.ts
@@ -115,6 +115,14 @@ describe('SampleSelector', () => {
     wrapper.unmount()
   })
 
+  it('renders data-sample-key attribute on sample cards', () => {
+    const wrapper = mountComponent()
+
+    const card = wrapper.find('.sample-card')
+    expect(card.attributes('data-sample-key')).toEqual('basic')
+    wrapper.unmount()
+  })
+
   it('emits select event when sample card is clicked', async () => {
     const wrapper = mountComponent()
 


### PR DESCRIPTION
## Summary
- Fixes #411 (Step 2 of 4 for #396)

## Changes
- Added `:data-sample-key="sample.key"` attribute to sample card `<div>` in SampleSelector.vue
- Enables E2E tests to select samples by key via `[data-sample-key="hello-world"]` instead of matching localized text
- Added unit test verifying the attribute renders correctly

## Test plan
- [ ] Unit tests pass
- [ ] CI passes