### PR TITLE
feat: resolve #412 - add data-testid to IdeControls.vue toolbar buttons

### DIFF
--- a/src/features/ide/components/IdeControls.vue
+++ b/src/features/ide/components/IdeControls.vue
@@ -145,6 +145,7 @@ const handleInputModeChange = (value: InputMode) => {
       icon="mdi:delete"
       size="small"
       :title="t('ide.controls.clear')"
+      data-testid="ide-clear-button"
       @click="handleClear"
     />
 
@@ -155,6 +156,7 @@ const handleInputModeChange = (value: InputMode) => {
       size="small"
       :selected="debugMode"
       :title="t('ide.controls.debug')"
+      data-testid="ide-debug-toggle-button"
       @click="handleDebugToggle"
     />
   </div>

--- a/src/features/ide/components/InputModeToggle.vue
+++ b/src/features/ide/components/InputModeToggle.vue
@@ -51,6 +51,7 @@ function selectKeyboard() {
         size="small"
         :title="t('ide.inputModeToggle.joystickTitle')"
         :selected="props.modelValue === 'joystick'"
+        data-testid="ide-joystick-button"
         @click="selectJoystick"
       />
       <GameIconButton
@@ -60,6 +61,7 @@ function selectKeyboard() {
         size="small"
         :title="t('ide.inputModeToggle.keyboardTitle')"
         :selected="props.modelValue === 'keyboard'"
+        data-testid="ide-keyboard-button"
         @click="selectKeyboard"
       />
     </template>
@@ -70,6 +72,7 @@ function selectKeyboard() {
         icon="mdi:gamepad-variant"
         size="small"
         :selected="props.modelValue === 'joystick'"
+        data-testid="ide-joystick-button"
         @click="selectJoystick"
       >
         {{ t('ide.inputModeToggle.joystick') }}
@@ -80,6 +83,7 @@ function selectKeyboard() {
         icon="mdi:keyboard"
         size="small"
         :selected="props.modelValue === 'keyboard'"
+        data-testid="ide-keyboard-button"
         @click="selectKeyboard"
       >
         {{ t('ide.inputModeToggle.keyboard') }}

--- a/src/features/ide/components/ProgramToolbar.vue
+++ b/src/features/ide/components/ProgramToolbar.vue
@@ -194,6 +194,7 @@ onUnmounted(() => {
           size="small"
           :disabled="isFileOperationPending"
           :title="`${t('ide.toolbar.new')} (Ctrl+N)`"
+          data-testid="ide-new-button"
           @click="handleNew"
         />
         <GameIconButton
@@ -202,6 +203,7 @@ onUnmounted(() => {
           size="small"
           :loading="isFileOperationPending"
           :title="`${t('ide.toolbar.import')} (Ctrl+O)`"
+          data-testid="ide-open-button"
           @click="handleOpen"
         />
         <GameIconButton
@@ -210,6 +212,7 @@ onUnmounted(() => {
           size="small"
           :loading="isFileOperationPending"
           :title="`${t('ide.toolbar.export')} (Ctrl+S)`"
+          data-testid="ide-save-button"
           @click="handleSave"
         />
       </template>
@@ -219,6 +222,7 @@ onUnmounted(() => {
           icon="mdi:file-plus"
           size="small"
           :disabled="isFileOperationPending"
+          data-testid="ide-new-button"
           @click="handleNew"
         >
           {{ t('ide.toolbar.new') }}
@@ -228,6 +232,7 @@ onUnmounted(() => {
           icon="mdi:import"
           size="small"
           :loading="isFileOperationPending"
+          data-testid="ide-open-button"
           @click="handleOpen"
         >
           {{ t('ide.toolbar.import') }}
@@ -237,6 +242,7 @@ onUnmounted(() => {
           icon="mdi:export"
           size="small"
           :loading="isFileOperationPending"
+          data-testid="ide-save-button"
           @click="handleSave"
         >
           {{ t('ide.toolbar.export') }}

--- a/src/shared/components/ui/GameButton.types.ts
+++ b/src/shared/components/ui/GameButton.types.ts
@@ -19,6 +19,8 @@ export interface GameButtonProps {
   iconPosition?: 'left' | 'right'
   /** Whether the button is selected (for toggle variant) */
   selected?: boolean
+  /** Optional test selector forwarded to the native button element */
+  dataTestid?: string
 }
 
 export interface GameButtonEmits {

--- a/src/shared/components/ui/GameButton.vue
+++ b/src/shared/components/ui/GameButton.vue
@@ -65,6 +65,7 @@ const getIconSize = computed(() => {
   <button
     :class="['bg-game-surface', 'border-game-surface', 'text-game-secondary', buttonClasses]"
     :disabled="disabled || loading"
+    :data-testid="props.dataTestid"
     @click="handleClick"
     type="button"
   >

--- a/test/ide/IdeControls.test.ts
+++ b/test/ide/IdeControls.test.ts
@@ -150,8 +150,8 @@ describe('IdeControls', () => {
       },
     })
 
-    const buttons = wrapper.findAll('button')
-    await buttons[2]!.trigger('click') // clear button (3rd button)
+    const clearButton = wrapper.find('[data-testid="ide-clear-button"]')
+    await clearButton.trigger('click')
 
     expect(wrapper.emitted('clear')).toHaveLength(1)
     wrapper.unmount()
@@ -168,8 +168,8 @@ describe('IdeControls', () => {
       },
     })
 
-    const buttons = wrapper.findAll('button')
-    await buttons[3]!.trigger('click') // debug toggle button
+    const debugButton = wrapper.find('[data-testid="ide-debug-toggle-button"]')
+    await debugButton.trigger('click')
 
     expect(wrapper.emitted('toggleDebug')).toHaveLength(1)
     wrapper.unmount()
@@ -186,8 +186,7 @@ describe('IdeControls', () => {
       },
     })
 
-    const buttons = wrapper.findAll('button')
-    const debugButton = buttons[3]!
+    const debugButton = wrapper.find('[data-testid="ide-debug-toggle-button"]')
     expect(debugButton.attributes('data-selected')).toEqual('true')
     wrapper.unmount()
   })

--- a/test/ide/InputModeToggle.test.ts
+++ b/test/ide/InputModeToggle.test.ts
@@ -12,12 +12,12 @@ vi.mock('vue-i18n', () => ({
 
 const gameButtonStub = defineComponent({
   props: ['variant', 'type', 'icon', 'size', 'selected'],
-  template: '<button :data-icon="icon" :data-selected="selected" :data-variant="variant"><slot /></button>',
+  template: '<button :data-icon="icon" :data-selected="selected" :data-variant="variant" :data-testid="$attrs[\'data-testid\']"><slot /></button>',
 })
 
 const gameIconButtonStub = defineComponent({
   props: ['variant', 'type', 'icon', 'size', 'title', 'selected'],
-  template: '<button :data-icon="icon" :data-selected="selected" :title="title" :data-variant="variant" />',
+  template: '<button :data-icon="icon" :data-selected="selected" :title="title" :data-variant="variant" :data-testid="$attrs[\'data-testid\']" />',
 })
 
 describe('InputModeToggle', () => {
@@ -126,6 +126,32 @@ describe('InputModeToggle', () => {
 
     const buttons = wrapper.findAll('button')
     expect(buttons.length).toEqual(2)
+    wrapper.unmount()
+  })
+
+  it('adds data-testid to buttons in compact mode', () => {
+    const wrapper = mount(InputModeToggle, {
+      props: { modelValue: 'joystick', isCompact: true },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="ide-joystick-button"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="ide-keyboard-button"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('adds data-testid to buttons in non-compact mode', () => {
+    const wrapper = mount(InputModeToggle, {
+      props: { modelValue: 'joystick', isCompact: false },
+      global: {
+        stubs: { GameButton: gameButtonStub, GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="ide-joystick-button"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="ide-keyboard-button"]').exists()).toBe(true)
     wrapper.unmount()
   })
 })

--- a/test/ide/ProgramToolbar.test.ts
+++ b/test/ide/ProgramToolbar.test.ts
@@ -59,9 +59,9 @@ describe('ProgramToolbar', () => {
     expect(wrapper.find('.confirm-dialog-overlay').exists()).toBe(false)
 
     // Click the New button
-    const buttons = wrapper.findAll('button')
-    expect(buttons.length).toBeGreaterThanOrEqual(1)
-    await buttons[0]!.trigger('click')
+    const newButton = wrapper.find('[data-testid="ide-new-button"]')
+    expect(newButton.exists()).toBe(true)
+    await newButton.trigger('click')
 
     // Confirm dialog should now be visible
     expect(wrapper.find('.confirm-dialog-overlay').exists()).toBe(true)
@@ -78,9 +78,9 @@ describe('ProgramToolbar', () => {
     })
 
     // Click the New button
-    const buttons = wrapper.findAll('button')
-    expect(buttons.length).toBeGreaterThanOrEqual(1)
-    await buttons[0]!.trigger('click')
+    const newButton = wrapper.find('[data-testid="ide-new-button"]')
+    expect(newButton.exists()).toBe(true)
+    await newButton.trigger('click')
 
     // No confirm dialog should appear
     expect(wrapper.find('.confirm-dialog-overlay').exists()).toBe(false)
@@ -97,8 +97,8 @@ describe('ProgramToolbar', () => {
     })
 
     // Click the New button to show dialog
-    const buttons = wrapper.findAll('button')
-    await buttons[0]!.trigger('click')
+    const newButton = wrapper.find('[data-testid="ide-new-button"]')
+    await newButton.trigger('click')
 
     // Click confirm button in dialog
     const confirmBtn = wrapper.find('.confirm-dialog-btn-confirm')
@@ -119,8 +119,8 @@ describe('ProgramToolbar', () => {
     })
 
     // Click the New button to show dialog
-    const buttons = wrapper.findAll('button')
-    await buttons[0]!.trigger('click')
+    const newButton = wrapper.find('[data-testid="ide-new-button"]')
+    await newButton.trigger('click')
 
     // Click cancel button in dialog
     const cancelBtn = wrapper.find('.confirm-dialog-btn-cancel')
@@ -141,8 +141,8 @@ describe('ProgramToolbar', () => {
     })
 
     // Trigger the dialog
-    const buttons = wrapper.findAll('button')
-    await buttons[0]!.trigger('click')
+    const newButton = wrapper.find('[data-testid="ide-new-button"]')
+    await newButton.trigger('click')
 
     const overlay = wrapper.find('.confirm-dialog-overlay')
     expect(overlay.attributes('role')).toEqual('dialog')
@@ -167,12 +167,13 @@ describe('ProgramToolbar', () => {
       })
 
       // Click Import (Open) button
-      const buttons = wrapper.findAll('button')
-      await buttons[1]!.trigger('click')
+      const openButton = wrapper.find('[data-testid="ide-open-button"]')
+      await openButton.trigger('click')
       await wrapper.vm.$nextTick()
 
       // New button should be disabled during file operation
-      expect(buttons[0]!.attributes('disabled')).toBeDefined()
+      const newButton = wrapper.find('[data-testid="ide-new-button"]')
+      expect(newButton.attributes('disabled')).toBeDefined()
 
       // Resolve the pending operation
       resolveOpen()
@@ -194,12 +195,13 @@ describe('ProgramToolbar', () => {
       })
 
       // Click Export (Save) button
-      const buttons = wrapper.findAll('button')
-      await buttons[2]!.trigger('click')
+      const saveButton = wrapper.find('[data-testid="ide-save-button"]')
+      await saveButton.trigger('click')
       await wrapper.vm.$nextTick()
 
       // New button should be disabled during file operation
-      expect(buttons[0]!.attributes('disabled')).toBeDefined()
+      const newButton = wrapper.find('[data-testid="ide-new-button"]')
+      expect(newButton.attributes('disabled')).toBeDefined()
 
       // Resolve the pending operation
       resolveSave()
@@ -219,8 +221,8 @@ describe('ProgramToolbar', () => {
       })
 
       // Click Import button
-      const buttons = wrapper.findAll('button')
-      await buttons[1]!.trigger('click')
+      const openButton = wrapper.find('[data-testid="ide-open-button"]')
+      await openButton.trigger('click')
       await wrapper.vm.$nextTick()
 
       // Error message should be displayed
@@ -239,8 +241,8 @@ describe('ProgramToolbar', () => {
       })
 
       // Click Import button
-      const buttons = wrapper.findAll('button')
-      await buttons[1]!.trigger('click')
+      const openButton = wrapper.find('[data-testid="ide-open-button"]')
+      await openButton.trigger('click')
       await wrapper.vm.$nextTick()
 
       // Error message should be displayed
@@ -258,8 +260,8 @@ describe('ProgramToolbar', () => {
       })
 
       // Click Export (Save) button
-      const buttons = wrapper.findAll('button')
-      await buttons[2]!.trigger('click')
+      const saveButton = wrapper.find('[data-testid="ide-save-button"]')
+      await saveButton.trigger('click')
       await wrapper.vm.$nextTick()
 
       // Error message should be displayed
@@ -278,8 +280,8 @@ describe('ProgramToolbar', () => {
       })
 
       // Click Import button to trigger error
-      const buttons = wrapper.findAll('button')
-      await buttons[1]!.trigger('click')
+      const openButton = wrapper.find('[data-testid="ide-open-button"]')
+      await openButton.trigger('click')
       await wrapper.vm.$nextTick()
 
       // Error message should be visible
@@ -304,8 +306,8 @@ describe('ProgramToolbar', () => {
       })
 
       // Click Import button
-      const buttons = wrapper.findAll('button')
-      await buttons[1]!.trigger('click')
+      const openButton = wrapper.find('[data-testid="ide-open-button"]')
+      await openButton.trigger('click')
       await wrapper.vm.$nextTick()
 
       // No error message should be displayed


### PR DESCRIPTION
## Summary
- Fixes #412 (Step 3 of 4 for #396)

## Changes
- Added `data-testid` to IdeControls.vue: `ide-clear-button`, `ide-debug-toggle-button`
- Added `data-testid` to InputModeToggle.vue: `ide-joystick-button`, `ide-keyboard-button` (both compact/non-compact)
- Added `data-testid` to ProgramToolbar.vue: `ide-new-button`, `ide-open-button`, `ide-save-button` (both compact/non-compact)
- Added `dataTestid` prop to GameButton (matching existing GameIconButton pattern)
- Updated existing tests to use testid selectors instead of index-based access

## Test plan
- [ ] 3172 unit tests pass
- [ ] Type-check clean
- [ ] ESLint clean
- [ ] CI passes