### PR TITLE
feat: resolve #406 - add input timeline scheduling to TestDeviceAdapter

### DIFF
--- a/src/core/devices/TestDeviceAdapter.ts
+++ b/src/core/devices/TestDeviceAdapter.ts
@@ -16,6 +16,8 @@ import {
   DEFAULT_BACKGROUND_PALETTES,
   DEFAULT_SPRITE_PALETTES,
 } from './TestDeviceAdapterHelpers'
+import type { ScheduledInputDelivery, ScheduledInputEvent } from './TestDeviceInputScheduler'
+import { TestDeviceInputScheduler } from './TestDeviceInputScheduler'
 
 export class TestDeviceAdapter implements BasicDeviceAdapter {
   // === JOYSTICK STATE ===
@@ -60,6 +62,14 @@ export class TestDeviceAdapter implements BasicDeviceAdapter {
   // === INPUT (for INPUT/LINPUT executor tests) ===
   /** Queue of responses for requestInput; each call pops the next. Default: ['0'] if empty. */
   public inputResponseQueue: string[][] = []
+
+  // === INPUT TIMELINE SCHEDULING ===
+  /** Scheduler delegates frame tracking and event delivery. */
+  private readonly inputScheduler: TestDeviceInputScheduler = new TestDeviceInputScheduler({
+    setStickState: (player, direction) => this.setStickState(player, direction),
+    pushStrigState: (player, button) => this.pushStrigState(player, button),
+    setInkeyState: (keyChar) => this.setInkeyStateForTest(keyChar),
+  })
 
   constructor() {
     logDevice.debug('TestDeviceAdapter created')
@@ -162,6 +172,49 @@ export class TestDeviceAdapter implements BasicDeviceAdapter {
     }
     // Otherwise return current state
     return this.inkeyState
+  }
+
+  // === INPUT TIMELINE SCHEDULING ===
+  // Delegates to TestDeviceInputScheduler. See that class for full API docs.
+
+  getCurrentFrame(): number {
+    return this.inputScheduler.getCurrentFrame()
+  }
+
+  scheduleInput(event: ScheduledInputEvent): void {
+    this.inputScheduler.scheduleInput(event)
+  }
+
+  scheduleInputs(events: ScheduledInputEvent[]): void {
+    this.inputScheduler.scheduleInputs(events)
+  }
+
+  advanceFrame(): ScheduledInputDelivery {
+    return this.inputScheduler.advanceFrame()
+  }
+
+  setCurrentFrame(frame: number): void {
+    this.inputScheduler.setCurrentFrame(frame)
+  }
+
+  deliverScheduledEvents(): ScheduledInputDelivery {
+    return this.inputScheduler.deliverScheduledEvents()
+  }
+
+  clearScheduledInputs(): void {
+    this.inputScheduler.clearScheduledInputs()
+  }
+
+  getScheduledInputCount(): number {
+    return this.inputScheduler.getScheduledInputCount()
+  }
+
+  getScheduledInputs(): ScheduledInputEvent[] {
+    return this.inputScheduler.getScheduledInputs()
+  }
+
+  get deliveryLog(): ScheduledInputDelivery[] {
+    return this.inputScheduler.getDeliveryLog()
   }
 
   // === SPRITE POSITION QUERY ===
@@ -407,6 +460,7 @@ export class TestDeviceAdapter implements BasicDeviceAdapter {
     this.clearJoystickState()
     this.spritePositions.clear()
     this.seededBgData = null
+    this.inputScheduler.reset()
   }
 
   /**

--- a/src/core/devices/TestDeviceAdapterHelpers.ts
+++ b/src/core/devices/TestDeviceAdapterHelpers.ts
@@ -4,7 +4,8 @@
  * Standalone functions that operate on TestDeviceAdapter state.
  * Extracted from TestDeviceAdapter.ts for modularity and testability.
  *
- * Handles: Output aggregation, output querying, and state reset.
+ * Handles: Output aggregation, output querying, palette combination,
+ * and default palette data.
  */
 
 // ============================================================================

--- a/src/core/devices/TestDeviceInputScheduler.ts
+++ b/src/core/devices/TestDeviceInputScheduler.ts
@@ -1,0 +1,247 @@
+/**
+ * Test Device Input Scheduler
+ *
+ * Manages scheduling and delivery of input events at specific frame boundaries.
+ * Used by TestDeviceAdapter to provide timeline-based input simulation.
+ *
+ * Events are one-shot: once delivered at the target frame, they are removed.
+ * Multiple events can be scheduled at the same frame.
+ *
+ * This module owns the scheduling data model and delivery orchestration.
+ * The actual I/O mutations (setStickState, pushStrigState, setInkeyState)
+ * are provided via callbacks, keeping this module decoupled from the adapter.
+ */
+
+import { logDevice } from '@/shared/logger'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * A single scheduled input event.
+ *
+ * Events are one-shot: once delivered at the target frame, they are removed.
+ * Schedule multiple events at the same frame to combine stick, strig, and key.
+ */
+export interface ScheduledInputEvent {
+  /** The frame number at which this input should be delivered. */
+  atFrame: number
+  /** STICK direction to set (e.g. 1=right, 2=left, 4=down, 8=up). */
+  stick?: { player: number; direction: number }
+  /** STRIG button to push (e.g. 1, 2, 4, 8 for A/B/Select/Start). */
+  strig?: { player: number; button: number }
+  /** Key character to set for INKEY$. */
+  key?: string
+}
+
+/**
+ * Result of delivering scheduled events at a frame boundary.
+ * Used by tests to verify which events were delivered.
+ */
+export interface ScheduledInputDelivery {
+  frame: number
+  delivered: ScheduledInputEvent[]
+}
+
+// ============================================================================
+// Pure Functions
+// ============================================================================
+
+/**
+ * Extract and remove all scheduled events targeting the given frame.
+ *
+ * This is a pure function operating on the event list. It returns the
+ * events that match the target frame and the remaining events (minus
+ * those delivered).
+ *
+ * @param events - The current list of scheduled events
+ * @param targetFrame - The frame number to deliver events for
+ * @returns An object with the delivered events and the remaining events
+ */
+export function extractScheduledEvents(
+  events: ScheduledInputEvent[],
+  targetFrame: number
+): { delivered: ScheduledInputEvent[]; remaining: ScheduledInputEvent[] } {
+  const delivered: ScheduledInputEvent[] = []
+  const remaining: ScheduledInputEvent[] = []
+
+  for (const event of events) {
+    if (event.atFrame === targetFrame) {
+      delivered.push(event)
+    } else {
+      remaining.push(event)
+    }
+  }
+
+  return { delivered, remaining }
+}
+
+// ============================================================================
+// Callbacks Interface
+// ============================================================================
+
+/**
+ * Callbacks for applying delivered input events to the device adapter.
+ * Decouples the scheduler from the adapter's specific implementation.
+ */
+export interface InputDeliveryCallbacks {
+  setStickState: (player: number, direction: number) => void
+  pushStrigState: (player: number, button: number) => void
+  setInkeyState: (keyChar: string) => void
+}
+
+// ============================================================================
+// Scheduler Class
+// ============================================================================
+
+/**
+ * Manages input event scheduling and frame-based delivery.
+ *
+ * Tracks a frame counter and a list of scheduled events. When the frame
+ * is advanced, events matching the new frame are delivered via callbacks.
+ */
+export class TestDeviceInputScheduler {
+  private currentFrame = 0
+  private scheduledInputs: ScheduledInputEvent[] = []
+  private readonly deliveryLog: ScheduledInputDelivery[] = []
+  private readonly callbacks: InputDeliveryCallbacks
+
+  constructor(callbacks: InputDeliveryCallbacks) {
+    this.callbacks = callbacks
+  }
+
+  /**
+   * Get the current frame counter value.
+   */
+  getCurrentFrame(): number {
+    return this.currentFrame
+  }
+
+  /**
+   * Set the frame counter to a specific value.
+   * Does NOT deliver events for the target frame.
+   */
+  setCurrentFrame(frame: number): void {
+    this.currentFrame = frame
+    logDevice.debug('Frame counter set to:', frame)
+  }
+
+  /**
+   * Schedule an input event to be delivered at a specific frame.
+   */
+  scheduleInput(event: ScheduledInputEvent): void {
+    this.scheduledInputs.push(event)
+    logDevice.debug('Input scheduled:', {
+      atFrame: event.atFrame,
+      stick: event.stick,
+      strig: event.strig,
+      key: event.key,
+    })
+  }
+
+  /**
+   * Schedule multiple input events at once.
+   */
+  scheduleInputs(events: ScheduledInputEvent[]): void {
+    for (const event of events) {
+      this.scheduleInput(event)
+    }
+  }
+
+  /**
+   * Advance the frame counter by 1 and deliver any scheduled input events
+   * for the new frame.
+   *
+   * This is the primary hook for the test harness to drive frame-based
+   * input delivery. Call this at each PAUSE boundary or frame tick.
+   */
+  advanceFrame(): ScheduledInputDelivery {
+    this.currentFrame++
+    return this.deliverScheduledEvents()
+  }
+
+  /**
+   * Deliver any scheduled input events for the current frame.
+   *
+   * For each delivered event:
+   * - stick: calls setStickState(player, direction)
+   * - strig: calls pushStrigState(player, button)
+   * - key: calls setInkeyState(key)
+   *
+   * Delivered events are removed from the schedule (one-shot).
+   * The delivery is recorded in the delivery log for test assertions.
+   */
+  deliverScheduledEvents(): ScheduledInputDelivery {
+    const { delivered, remaining } = extractScheduledEvents(
+      this.scheduledInputs,
+      this.currentFrame
+    )
+    this.scheduledInputs = remaining
+
+    for (const event of delivered) {
+      if (event.stick) {
+        this.callbacks.setStickState(event.stick.player, event.stick.direction)
+      }
+      if (event.strig) {
+        this.callbacks.pushStrigState(event.strig.player, event.strig.button)
+      }
+      if (event.key) {
+        this.callbacks.setInkeyState(event.key)
+      }
+    }
+
+    const delivery: ScheduledInputDelivery = {
+      frame: this.currentFrame,
+      delivered,
+    }
+    this.deliveryLog.push(delivery)
+
+    if (delivered.length > 0) {
+      logDevice.debug(
+        'Scheduled inputs delivered at frame', this.currentFrame,
+        ':', delivered.length, 'events'
+      )
+    }
+
+    return delivery
+  }
+
+  /**
+   * Clear all scheduled input events without delivering them.
+   */
+  clearScheduledInputs(): void {
+    this.scheduledInputs = []
+    logDevice.debug('All scheduled inputs cleared')
+  }
+
+  /**
+   * Get the number of pending scheduled input events.
+   */
+  getScheduledInputCount(): number {
+    return this.scheduledInputs.length
+  }
+
+  /**
+   * Get a copy of all pending scheduled input events.
+   */
+  getScheduledInputs(): ScheduledInputEvent[] {
+    return [...this.scheduledInputs]
+  }
+
+  /**
+   * Get the delivery log (all past deliveries).
+   */
+  getDeliveryLog(): ScheduledInputDelivery[] {
+    return [...this.deliveryLog]
+  }
+
+  /**
+   * Reset all scheduler state: frame counter, scheduled events, and delivery log.
+   */
+  reset(): void {
+    this.currentFrame = 0
+    this.scheduledInputs = []
+    this.deliveryLog.length = 0
+  }
+}

--- a/test/core/devices/TestDeviceInputScheduler.test.ts
+++ b/test/core/devices/TestDeviceInputScheduler.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Unit tests for TestDeviceInputScheduler
+ *
+ * Tests the input timeline scheduling system: frame tracking, event scheduling,
+ * one-shot delivery, and the pure extractScheduledEvents function.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { TestDeviceAdapter } from '@/core/devices/TestDeviceAdapter'
+import type { ScheduledInputEvent } from '@/core/devices/TestDeviceInputScheduler'
+import {
+  extractScheduledEvents,
+  TestDeviceInputScheduler,
+} from '@/core/devices/TestDeviceInputScheduler'
+
+// Mock logger
+vi.mock('@/shared/logger', () => ({
+  logDevice: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+// ============================================================================
+// extractScheduledEvents (pure function)
+// ============================================================================
+
+describe('extractScheduledEvents', () => {
+  it('should return empty arrays when no events scheduled', () => {
+    const result = extractScheduledEvents([], 5)
+    expect(result.delivered).toEqual([])
+    expect(result.remaining).toEqual([])
+  })
+
+  it('should deliver events matching the target frame', () => {
+    const events: ScheduledInputEvent[] = [
+      { atFrame: 3, stick: { player: 0, direction: 8 } },
+      { atFrame: 5, stick: { player: 0, direction: 4 } },
+      { atFrame: 3, strig: { player: 0, button: 1 } },
+    ]
+
+    const result = extractScheduledEvents(events, 3)
+
+    expect(result.delivered).toEqual([
+      { atFrame: 3, stick: { player: 0, direction: 8 } },
+      { atFrame: 3, strig: { player: 0, button: 1 } },
+    ])
+    expect(result.remaining).toEqual([
+      { atFrame: 5, stick: { player: 0, direction: 4 } },
+    ])
+  })
+
+  it('should return all events as remaining when no match', () => {
+    const events: ScheduledInputEvent[] = [
+      { atFrame: 1, key: 'A' },
+      { atFrame: 2, key: 'B' },
+    ]
+
+    const result = extractScheduledEvents(events, 99)
+
+    expect(result.delivered).toEqual([])
+    expect(result.remaining).toEqual([
+      { atFrame: 1, key: 'A' },
+      { atFrame: 2, key: 'B' },
+    ])
+  })
+
+  it('should deliver all events when all match target frame', () => {
+    const events: ScheduledInputEvent[] = [
+      { atFrame: 0, stick: { player: 0, direction: 8 } },
+      { atFrame: 0, key: 'X' },
+    ]
+
+    const result = extractScheduledEvents(events, 0)
+
+    expect(result.delivered).toEqual([
+      { atFrame: 0, stick: { player: 0, direction: 8 } },
+      { atFrame: 0, key: 'X' },
+    ])
+    expect(result.remaining).toEqual([])
+  })
+
+  it('should preserve order of remaining events', () => {
+    const events: ScheduledInputEvent[] = [
+      { atFrame: 1, key: 'A' },
+      { atFrame: 2, key: 'B' },
+      { atFrame: 3, key: 'C' },
+      { atFrame: 4, key: 'D' },
+    ]
+
+    const result = extractScheduledEvents(events, 2)
+
+    expect(result.remaining).toEqual([
+      { atFrame: 1, key: 'A' },
+      { atFrame: 3, key: 'C' },
+      { atFrame: 4, key: 'D' },
+    ])
+  })
+
+  it('should not mutate the original events array', () => {
+    const events: ScheduledInputEvent[] = [
+      { atFrame: 1, stick: { player: 0, direction: 8 } },
+      { atFrame: 2, stick: { player: 0, direction: 4 } },
+    ]
+
+    extractScheduledEvents(events, 1)
+
+    expect(events).toHaveLength(2)
+    expect(events[0]!.atFrame).toBe(1)
+    expect(events[1]!.atFrame).toBe(2)
+  })
+})
+
+// ============================================================================
+// TestDeviceInputScheduler (standalone, with mock callbacks)
+// ============================================================================
+
+describe('TestDeviceInputScheduler', () => {
+  function createScheduler() {
+    const stickStates: Map<number, number> = new Map()
+    const strigBuffer: Map<number, number[]> = new Map()
+    let inkeyState = ''
+
+    const scheduler = new TestDeviceInputScheduler({
+      setStickState: (player, direction) => stickStates.set(player, direction),
+      pushStrigState: (player, button) => {
+        if (!strigBuffer.has(player)) strigBuffer.set(player, [])
+        strigBuffer.get(player)!.push(button)
+      },
+      setInkeyState: (key) => { inkeyState = key },
+    })
+
+    return {
+      scheduler,
+      getStick: (player: number) => stickStates.get(player) ?? 0,
+      consumeStrig: (player: number) => {
+        const buf = strigBuffer.get(player)
+        return buf && buf.length > 0 ? buf.shift()! : 0
+      },
+      getInkey: () => inkeyState,
+    }
+  }
+
+  it('should start at frame 0', () => {
+    const { scheduler } = createScheduler()
+    expect(scheduler.getCurrentFrame()).toBe(0)
+  })
+
+  it('should advance frame counter by 1', () => {
+    const { scheduler } = createScheduler()
+    const delivery = scheduler.advanceFrame()
+    expect(scheduler.getCurrentFrame()).toBe(1)
+    expect(delivery.frame).toBe(1)
+    expect(delivery.delivered).toEqual([])
+  })
+
+  it('should deliver stick event at scheduled frame', () => {
+    const { scheduler, getStick } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 3, stick: { player: 0, direction: 8 } })
+
+    scheduler.advanceFrame()
+    scheduler.advanceFrame()
+    expect(getStick(0)).toBe(0)
+
+    const delivery = scheduler.advanceFrame()
+    expect(getStick(0)).toBe(8)
+    expect(delivery.delivered).toHaveLength(1)
+    expect(delivery.delivered[0]!.stick).toEqual({ player: 0, direction: 8 })
+  })
+
+  it('should deliver strig event at scheduled frame', () => {
+    const { scheduler, consumeStrig } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 2, strig: { player: 0, button: 1 } })
+
+    scheduler.advanceFrame()
+    expect(consumeStrig(0)).toBe(0)
+
+    scheduler.advanceFrame()
+    expect(consumeStrig(0)).toBe(1)
+  })
+
+  it('should deliver key event at scheduled frame', () => {
+    const { scheduler, getInkey } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 1, key: 'A' })
+
+    scheduler.advanceFrame()
+    expect(getInkey()).toBe('A')
+  })
+
+  it('should deliver multiple events at the same frame', () => {
+    const { scheduler, getStick, consumeStrig, getInkey } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 1 } })
+    scheduler.scheduleInput({ atFrame: 1, strig: { player: 0, button: 4 } })
+    scheduler.scheduleInput({ atFrame: 1, key: 'X' })
+
+    const delivery = scheduler.advanceFrame()
+    expect(getStick(0)).toBe(1)
+    expect(consumeStrig(0)).toBe(4)
+    expect(getInkey()).toBe('X')
+    expect(delivery.delivered).toHaveLength(3)
+  })
+
+  it('should not redeliver one-shot events', () => {
+    const { scheduler, getStick } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
+
+    scheduler.advanceFrame()
+    expect(getStick(0)).toBe(8)
+
+    scheduler.advanceFrame()
+    expect(getStick(0)).toBe(8) // Value persists (setStickState was called once)
+  })
+
+  it('should deliver events at frame 0 via deliverScheduledEvents', () => {
+    const { scheduler, getStick } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 0, stick: { player: 0, direction: 8 } })
+
+    const delivery = scheduler.deliverScheduledEvents()
+    expect(getStick(0)).toBe(8)
+    expect(delivery.frame).toBe(0)
+    expect(delivery.delivered).toHaveLength(1)
+  })
+
+  it('should not deliver frame 0 events on advanceFrame', () => {
+    const { scheduler, getStick } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 0, stick: { player: 0, direction: 8 } })
+
+    scheduler.advanceFrame()
+    expect(scheduler.getCurrentFrame()).toBe(1)
+    expect(getStick(0)).toBe(0)
+  })
+
+  it('should clear scheduled inputs without delivering', () => {
+    const { scheduler, getStick, consumeStrig } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
+    scheduler.scheduleInput({ atFrame: 2, strig: { player: 0, button: 1 } })
+
+    expect(scheduler.getScheduledInputCount()).toBe(2)
+    scheduler.clearScheduledInputs()
+    expect(scheduler.getScheduledInputCount()).toBe(0)
+
+    scheduler.advanceFrame()
+    scheduler.advanceFrame()
+    expect(getStick(0)).toBe(0)
+    expect(consumeStrig(0)).toBe(0)
+  })
+
+  it('should return copy of scheduled inputs', () => {
+    const { scheduler } = createScheduler()
+    const event = { atFrame: 1, stick: { player: 0, direction: 8 } }
+    scheduler.scheduleInput(event)
+
+    const inputs = scheduler.getScheduledInputs()
+    expect(inputs).toEqual([event])
+
+    inputs.push({ atFrame: 99, stick: { player: 0, direction: 0 } })
+    expect(scheduler.getScheduledInputCount()).toBe(1)
+  })
+
+  it('should schedule multiple inputs at once via scheduleInputs', () => {
+    const { scheduler, getStick, consumeStrig, getInkey } = createScheduler()
+    scheduler.scheduleInputs([
+      { atFrame: 1, stick: { player: 0, direction: 1 } },
+      { atFrame: 2, strig: { player: 0, button: 1 } },
+      { atFrame: 3, key: 'Z' },
+    ])
+
+    expect(scheduler.getScheduledInputCount()).toBe(3)
+
+    scheduler.advanceFrame()
+    expect(getStick(0)).toBe(1)
+
+    scheduler.advanceFrame()
+    expect(consumeStrig(0)).toBe(1)
+
+    scheduler.advanceFrame()
+    expect(getInkey()).toBe('Z')
+  })
+
+  it('should set frame counter via setCurrentFrame', () => {
+    const { scheduler } = createScheduler()
+    scheduler.setCurrentFrame(10)
+    expect(scheduler.getCurrentFrame()).toBe(10)
+  })
+
+  it('should deliver events for frame set via setCurrentFrame', () => {
+    const { scheduler, getStick } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 5, stick: { player: 0, direction: 8 } })
+
+    scheduler.setCurrentFrame(5)
+    const delivery = scheduler.deliverScheduledEvents()
+    expect(getStick(0)).toBe(8)
+    expect(delivery.delivered).toHaveLength(1)
+  })
+
+  it('should record deliveries in delivery log', () => {
+    const { scheduler } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
+
+    scheduler.advanceFrame()
+    scheduler.advanceFrame()
+
+    const log = scheduler.getDeliveryLog()
+    expect(log).toHaveLength(2)
+    expect(log[0]!.frame).toBe(1)
+    expect(log[0]!.delivered).toHaveLength(1)
+    expect(log[1]!.frame).toBe(2)
+    expect(log[1]!.delivered).toHaveLength(0)
+  })
+
+  it('should reset all state', () => {
+    const { scheduler } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
+    scheduler.advanceFrame()
+
+    scheduler.reset()
+    expect(scheduler.getCurrentFrame()).toBe(0)
+    expect(scheduler.getScheduledInputCount()).toBe(0)
+    expect(scheduler.getDeliveryLog()).toEqual([])
+  })
+
+  it('should handle events for different players', () => {
+    const { scheduler, getStick } = createScheduler()
+    scheduler.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
+    scheduler.scheduleInput({ atFrame: 1, stick: { player: 1, direction: 4 } })
+
+    scheduler.advanceFrame()
+    expect(getStick(0)).toBe(8)
+    expect(getStick(1)).toBe(4)
+  })
+
+  it('should deliver combined stick, strig, and key in single event', () => {
+    const { scheduler, getStick, consumeStrig, getInkey } = createScheduler()
+    scheduler.scheduleInput({
+      atFrame: 1,
+      stick: { player: 0, direction: 1 },
+      strig: { player: 0, button: 2 },
+      key: 'A',
+    })
+
+    const delivery = scheduler.advanceFrame()
+    expect(getStick(0)).toBe(1)
+    expect(consumeStrig(0)).toBe(2)
+    expect(getInkey()).toBe('A')
+    expect(delivery.delivered).toHaveLength(1)
+  })
+})
+
+// ============================================================================
+// Integration: scheduling through TestDeviceAdapter
+// ============================================================================
+
+describe('TestDeviceAdapter scheduling integration', () => {
+  function createAdapter(): TestDeviceAdapter {
+    return new TestDeviceAdapter()
+  }
+
+  it('should start at frame 0', () => {
+    const adapter = createAdapter()
+    expect(adapter.getCurrentFrame()).toBe(0)
+  })
+
+  it('should deliver stick event through adapter delegation', () => {
+    const adapter = createAdapter()
+    adapter.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
+    adapter.advanceFrame()
+    expect(adapter.getStickState(0)).toBe(8)
+  })
+
+  it('should deliver strig event through adapter delegation', () => {
+    const adapter = createAdapter()
+    adapter.scheduleInput({ atFrame: 1, strig: { player: 0, button: 1 } })
+    adapter.advanceFrame()
+    expect(adapter.consumeStrigState(0)).toBe(1)
+  })
+
+  it('should deliver key event through adapter delegation', () => {
+    const adapter = createAdapter()
+    adapter.scheduleInput({ atFrame: 1, key: 'A' })
+    adapter.advanceFrame()
+    expect(adapter.getInkeyState()).toBe('A')
+  })
+
+  it('should reset scheduling state on adapter reset()', () => {
+    const adapter = createAdapter()
+    adapter.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
+    adapter.advanceFrame()
+
+    adapter.reset()
+    expect(adapter.getCurrentFrame()).toBe(0)
+    expect(adapter.getScheduledInputCount()).toBe(0)
+    expect(adapter.deliveryLog).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #406 (Step 2 of 5 for #403)

## Changes
- New `TestDeviceInputScheduler` class (247 lines) with callback-based design for scheduling STICK/STRIG/KEY events at frame boundaries
- TestDeviceAdapter exposes delegation methods: `scheduleInput()`, `advanceFrame()`, `deliverScheduledEvents()`, etc.
- One-shot delivery with frame counter managed by scheduler
- Delivery log for test assertions
- 29 new tests in `TestDeviceInputScheduler.test.ts`

## Test plan
- [ ] 3186 unit tests pass (29 new)
- [ ] Type-check clean
- [ ] ESLint clean
- [ ] CI passes