### PR TITLE
feat: resolve #424 - add headless program tests for basics samples

### DIFF
--- a/test/program/basics/basic.test.ts
+++ b/test/program/basics/basic.test.ts
@@ -1,0 +1,15 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('basic program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('basic')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'BASIC F-BASIC PROGRAM')
+    tp.expectRowText(1, 'A + B =  30')
+  })
+})

--- a/test/program/basics/beep.test.ts
+++ b/test/program/basics/beep.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('beep program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('beep')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'BEEP DEMO')
+    tp.expectRowText(1, 'THREE BEEPS:')
+    tp.expectRowText(3, 'COUNTDOWN BEEPS:')
+    tp.expectRowText(4, 'GO!')
+  })
+})

--- a/test/program/basics/hello.test.ts
+++ b/test/program/basics/hello.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('hello program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('hello')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'FAMILY BASIC V3')
+    tp.expectRowText(1, '==============')
+    tp.expectRowText(2, 'HELLO, WORLD')
+  })
+})

--- a/test/program/basics/input.test.ts
+++ b/test/program/basics/input.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('input program', () => {
+  it('runs successfully and produces expected output with seeded input', async () => {
+    const tp = TestProgram.fromSample('input')
+    tp.seedInput(['WORLD'])
+    tp.seedInput(['5'])
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'HELLO WORLD')
+    tp.expectRowText(1, 'SQUARE= 25')
+  })
+})

--- a/test/program/basics/variables.test.ts
+++ b/test/program/basics/variables.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('variables program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('variables')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'A=')
+    tp.expectRowText(0, ' B=')
+    tp.expectRowText(1, 'A+B= 35')
+    tp.expectRowText(2, 'ABS(-5)= 5')
+    tp.expectRowText(3, 'SGN(3)= 1')
+    tp.expectRowText(4, 'LEN= 5')
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #424 (Step 1 of 8 for #423)
- Adds headless Vitest integration tests for 5 basics category sample programs

## Changes
- `test/program/basics/basic.test.ts` — tests PRINT, LET, expression evaluation
- `test/program/basics/beep.test.ts` — tests BEEP command with loops and PAUSE
- `test/program/basics/hello.test.ts` — tests simple PRINT output
- `test/program/basics/input.test.ts` — tests INPUT with seeded values (string + number)
- `test/program/basics/variables.test.ts` — tests variable assignment, ABS, SGN, LEN functions

All expectations use correct F-BASIC output format (uppercase rendering, positive number padding).

## Test plan
- [x] `pnpm test:run -- test/program/basics/` — 5/5 pass
- [x] `pnpm type-check` — no errors
- [x] `pnpm exec eslint test/program/basics/*.test.ts` — no errors
- [ ] CI passes