### PR TITLE
feat: resolve #400 - add data-testid to InputModal for E2E testing

### DIFF
--- a/src/features/ide/components/InputModal.vue
+++ b/src/features/ide/components/InputModal.vue
@@ -52,6 +52,7 @@ watch(
   <div
     v-if="pendingRequest"
     class="input-modal-overlay"
+    data-testid="input-modal"
     role="dialog"
     aria-modal="true"
     aria-labelledby="input-modal-prompt"
@@ -64,6 +65,7 @@ watch(
         <GameInput
           v-model="inputValue"
           type="text"
+          data-testid="input-modal-field"
           :placeholder="
             pendingRequest.isLinput
               ? t('ide.inputModal.linputPlaceholder')
@@ -72,7 +74,7 @@ watch(
           class="input-modal-field"
         />
         <div class="input-modal-actions">
-          <GameButton type="primary" size="medium" @click="submit">
+          <GameButton type="primary" size="medium" data-testid="input-modal-submit" @click="submit">
             {{ t('ide.input.submit') }}
           </GameButton>
           <GameButton type="default" size="medium" @click="cancel">

--- a/src/shared/components/ui/GameInput.types.ts
+++ b/src/shared/components/ui/GameInput.types.ts
@@ -15,6 +15,8 @@ export interface GameInputProps {
   size?: 'small' | 'medium' | 'large'
   /** Whether the input has a clear button */
   clearable?: boolean
+  /** Optional test selector forwarded to the native input element */
+  dataTestid?: string
 }
 
 export interface GameInputEmits {

--- a/src/shared/components/ui/GameInput.vue
+++ b/src/shared/components/ui/GameInput.vue
@@ -20,6 +20,7 @@ import type { GameInputEmits, GameInputProps } from './GameInput.types'
  */
 defineOptions({
   name: 'GameInput',
+  inheritAttrs: false,
 })
 
 const props = withDefaults(defineProps<GameInputProps>(), {
@@ -78,6 +79,7 @@ const inputClasses = computed(() => {
       :value="modelValue"
       :placeholder="placeholder"
       :disabled="disabled"
+      :data-testid="props.dataTestid"
       @input="handleInput"
       @focus="handleFocus"
       @blur="handleBlur"

--- a/test/ide/InputModal.test.ts
+++ b/test/ide/InputModal.test.ts
@@ -11,14 +11,14 @@ vi.mock('vue-i18n', () => ({
 }))
 
 const gameInputStub = defineComponent({
-  props: ['modelValue', 'type', 'placeholder'],
+  props: ['modelValue', 'type', 'placeholder', 'dataTestid'],
   emits: ['update:modelValue'],
-  template: '<input :value="modelValue" :type="type" :placeholder="placeholder" @input="$emit(\'update:modelValue\', $event.target.value)" data-testid="game-input" />',
+  template: '<input :value="modelValue" :type="type" :placeholder="placeholder" :data-testid="dataTestid" @input="$emit(\'update:modelValue\', $event.target.value)" />',
 })
 
 const gameButtonStub = defineComponent({
-  props: ['type', 'size'],
-  template: '<button :data-type="type" :data-size="size"><slot /></button>',
+  props: ['type', 'size', 'dataTestid'],
+  template: '<button :data-type="type" :data-size="size" :data-testid="dataTestid"><slot /></button>',
 })
 
 function createPendingRequest(overrides: Partial<{
@@ -55,7 +55,7 @@ describe('InputModal', () => {
 
     expect(wrapper.find('.input-modal-overlay').exists()).toBe(true)
     expect(wrapper.find('.input-modal-prompt').text()).toEqual('?')
-    expect(wrapper.find('[data-testid="game-input"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="input-modal-field"]').exists()).toBe(true)
     wrapper.unmount()
   })
 
@@ -65,7 +65,7 @@ describe('InputModal', () => {
       global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
     })
 
-    const input = wrapper.find('[data-testid="game-input"]')
+    const input = wrapper.find('[data-testid="input-modal-field"]')
     expect(input.attributes('placeholder')).toEqual('ide.inputModal.inputPlaceholder')
     wrapper.unmount()
   })
@@ -76,7 +76,7 @@ describe('InputModal', () => {
       global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
     })
 
-    const input = wrapper.find('[data-testid="game-input"]')
+    const input = wrapper.find('[data-testid="input-modal-field"]')
     expect(input.attributes('placeholder')).toEqual('ide.inputModal.linputPlaceholder')
     wrapper.unmount()
   })
@@ -88,7 +88,7 @@ describe('InputModal', () => {
       global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
     })
 
-    await wrapper.find('[data-testid="game-input"]').setValue('hello, world')
+    await wrapper.find('[data-testid="input-modal-field"]').setValue('hello, world')
     const buttons = wrapper.findAll('button')
     await buttons[0]!.trigger('click') // Submit button
 
@@ -108,7 +108,7 @@ describe('InputModal', () => {
       global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
     })
 
-    await wrapper.find('[data-testid="game-input"]').setValue('hello, world')
+    await wrapper.find('[data-testid="input-modal-field"]').setValue('hello, world')
     const buttons = wrapper.findAll('button')
     await buttons[0]!.trigger('click') // Submit button
 
@@ -157,13 +157,13 @@ describe('InputModal', () => {
       global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
     })
 
-    await wrapper.find('[data-testid="game-input"]').setValue('typed value')
-    expect((wrapper.find('[data-testid="game-input"]').element as HTMLInputElement).value).toEqual('typed value')
+    await wrapper.find('[data-testid="input-modal-field"]').setValue('typed value')
+    expect((wrapper.find('[data-testid="input-modal-field"]').element as HTMLInputElement).value).toEqual('typed value')
 
     await wrapper.setProps({ pendingRequest: createPendingRequest({ requestId: 'req-2' }) })
     await nextTick()
 
-    expect((wrapper.find('[data-testid="game-input"]').element as HTMLInputElement).value).toEqual('')
+    expect((wrapper.find('[data-testid="input-modal-field"]').element as HTMLInputElement).value).toEqual('')
     wrapper.unmount()
   })
 
@@ -177,6 +177,18 @@ describe('InputModal', () => {
     expect(overlay.attributes('role')).toEqual('dialog')
     expect(overlay.attributes('aria-modal')).toEqual('true')
     expect(overlay.attributes('aria-labelledby')).toEqual('input-modal-prompt')
+    wrapper.unmount()
+  })
+
+  it('has data-testid attributes for E2E testing', () => {
+    const wrapper = mount(InputModal, {
+      props: { pendingRequest: createPendingRequest() },
+      global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
+    })
+
+    expect(wrapper.find('[data-testid="input-modal"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="input-modal-field"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="input-modal-submit"]').exists()).toBe(true)
     wrapper.unmount()
   })
 
@@ -199,13 +211,13 @@ describe('InputModal', () => {
       global: { stubs: { GameInput: gameInputStub, GameButton: gameButtonStub } },
     })
 
-    expect(wrapper.find('[data-testid="game-input"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="input-modal-field"]').exists()).toBe(false)
 
     await wrapper.setProps({ pendingRequest: createPendingRequest() })
     await nextTick()
     await nextTick()
 
-    const input = wrapper.find('[data-testid="game-input"]').element as HTMLInputElement
+    const input = wrapper.find('[data-testid="input-modal-field"]').element as HTMLInputElement
     expect(focusSpy).toHaveBeenCalledWith()
     expect(focusSpy.mock.instances).toContain(input)
     focusSpy.mockRestore()
@@ -228,7 +240,7 @@ describe('InputModal', () => {
     await nextTick()
     await nextTick()
 
-    const newInput = wrapper.find('[data-testid="game-input"]').element as HTMLInputElement
+    const newInput = wrapper.find('[data-testid="input-modal-field"]').element as HTMLInputElement
     expect(focusSpy).toHaveBeenCalledWith()
     expect(focusSpy.mock.instances).toContain(newInput)
     focusSpy.mockRestore()


### PR DESCRIPTION
## Summary
- Fixes #400

## Changes
- Added `dataTestid` prop to `GameInput.types.ts` and `GameInput.vue` (matches GameButton pattern)
- Added `data-testid="input-modal"` on InputModal overlay container
- Added `data-testid="input-modal-field"` on the input field (via GameInput dataTestid)
- Added `data-testid="input-modal-submit"` on the submit button (via GameButton dataTestid)
- Updated InputModal tests to use new selectors
- Added new test asserting all three data-testid attributes are present

## Test plan
- [x] `pnpm test:run -- test/ide/InputModal.test.ts` — 3257 tests pass
- [x] `pnpm type-check` — pass
- [x] `pnpm exec eslint` — pass
- [ ] CI passes