### PR TITLE
feat: resolve #425 - add headless program tests for control samples

### DIFF
--- a/test/program/control/conditionals.test.ts
+++ b/test/program/control/conditionals.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('conditionals program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('conditionals')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // Header
+    tp.expectRowText(0, '=== COMPARISONS ===')
+    // I=1: matches =, <, <>, <=
+    tp.expectRowText(1, 'ONE')
+    tp.expectRowText(2, ' 1 < 3')
+    tp.expectRowText(3, ' 1 <> 3')
+    tp.expectRowText(4, ' 1 <= 2')
+    // I=2: matches <, <>, <=
+    tp.expectRowText(5, ' 2 < 3')
+    tp.expectRowText(6, ' 2 <> 3')
+    tp.expectRowText(7, ' 2 <= 2')
+    // I=3: no comparisons match
+    // I=4: matches >, <>, >=
+    tp.expectRowText(8, ' 4 > 3')
+    tp.expectRowText(9, ' 4 <> 3')
+    tp.expectRowText(10, ' 4 >= 4')
+    // I=5: matches >, <>, >=
+    tp.expectRowText(11, ' 5 > 3')
+    tp.expectRowText(12, ' 5 <> 3')
+    tp.expectRowText(13, ' 5 >= 4')
+    // Logic section
+    tp.expectRowText(14, '=== LOGIC ===')
+    tp.expectRowText(15, 'X IN RANGE')
+    tp.expectRowText(16, 'X >= 5')
+    tp.expectRowText(17, '=== DONE ===')
+  })
+})

--- a/test/program/control/loops.test.ts
+++ b/test/program/control/loops.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('loops program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('loops')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // CLS at line 20 clears screen — all content starts from row 0
+    // Count up section
+    tp.expectRowText(0, '=== COUNT UP ===')
+    tp.expectRowText(1, ' 1 2 3 4 5')
+    // STEP 2 section
+    tp.expectRowText(2, '=== STEP 2 ===')
+    tp.expectRowText(3, ' 0 2 4 6 8 10')
+    // Countdown section: PRINT I; " "; adds sign-space + explicit space
+    tp.expectRowText(4, '=== COUNTDOWN ===')
+    tp.expectRowText(5, ' 3  2  1 GO!')
+    // Multiplication table: PRINT I; "x"; J; "="; P; " " → num X num = num space
+    tp.expectRowText(6, '=== MULTIPLICATION ===')
+    tp.expectRowText(7, ' 1X 1= 1  1X 2= 2  1X 3= 3')
+    tp.expectRowText(8, ' 2X 1= 2  2X 2= 4  2X 3= 6')
+    tp.expectRowText(9, ' 3X 1= 3  3X 2= 6  3X 3= 9')
+    tp.expectRowText(10, '=== DONE ===')
+  })
+})

--- a/test/program/control/pause.test.ts
+++ b/test/program/control/pause.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('pause program', () => {
+  // PAUSE uses real setTimeout — total ~11s of delays, needs extended timeout
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('pause')
+
+    // PAUSE 0 blocks waiting for keypress — queue one to unblock
+    tp.queueInkey('A')
+
+    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+
+    tp.expectSuccess()
+    // CLS at line 30 clears screen
+    // Countdown section: 5-1 with PAUSE 80 each
+    tp.expectRowText(0, '=== COUNTDOWN ===')
+    tp.expectRowText(1, 'COUNTDOWN:  5')
+    tp.expectRowText(2, 'COUNTDOWN:  4')
+    tp.expectRowText(3, 'COUNTDOWN:  3')
+    tp.expectRowText(4, 'COUNTDOWN:  2')
+    tp.expectRowText(5, 'COUNTDOWN:  1')
+    tp.expectRowText(6, 'BLAST OFF!')
+    // Row 7 is blank (PRINT "")
+    // Short pause section: dots with PAUSE 30
+    tp.expectRowText(8, '=== SHORT PAUSE ===')
+    tp.expectRowText(9, 'QUICK DOTS...')
+    tp.expectRowText(10, '.....')
+    // Wait for keypress section: PAUSE 0 unblocked by queueInkey
+    tp.expectRowText(11, '=== WAIT FOR KEYPRESS ===')
+    tp.expectRowText(12, 'PAUSE 0 WAITS FOR A KEY...')
+    tp.expectRowText(13, 'YOU PRESSED A KEY!')
+    // Long pause section: PAUSE 250 (~3s)
+    tp.expectRowText(14, '=== LONG PAUSE ===')
+    tp.expectRowText(15, 'WAITING 3 SECONDS...')
+    tp.expectRowText(16, 'DONE!')
+  }, 20_000)
+})

--- a/test/program/control/subroutines.test.ts
+++ b/test/program/control/subroutines.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('subroutines program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('subroutines')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // CLS at line 30 clears screen
+    tp.expectRowText(0, '=== SQUARE CALCULATOR ===')
+    // Row 1 is blank (PRINT "")
+    tp.expectRowText(2, ' 1 SQUARED =  1')
+    tp.expectRowText(3, ' 2 SQUARED =  4')
+    tp.expectRowText(4, ' 3 SQUARED =  9')
+    tp.expectRowText(5, ' 4 SQUARED =  16')
+    tp.expectRowText(6, ' 5 SQUARED =  25')
+    // Row 7 is blank (PRINT "")
+    tp.expectRowText(8, '=== DIVIDERS ===')
+    tp.expectRowText(9, 'DIVIDERS OF 12:')
+    // Divisors of 12: 1,2,3,4,6,12 — PRINT D; " "; gives sign-space + explicit space
+    tp.expectRowText(10, ' 1  2  3  4  6  12')
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #425 (Step 2 of 8 for #423)
- Adds headless Vitest integration tests for 4 control category sample programs

## Changes
- `test/program/control/conditionals.test.ts` — tests IF/THEN with =, <, >, <>, <=, >=, AND/OR logic
- `test/program/control/loops.test.ts` — tests FOR/NEXT count up, STEP 2, countdown STEP -1, nested multiplication table
- `test/program/control/pause.test.ts` — tests PAUSE with timed delays and PAUSE 0 (keypress via queueInkey)
- `test/program/control/subroutines.test.ts` — tests GOSUB/RETURN square calculator and divisor checker

All expectations use correct F-BASIC output format (uppercase rendering, positive number padding).

## Test plan
- [x] `pnpm test:run -- test/program/control/` — 4/4 pass
- [x] `pnpm type-check` — no errors
- [x] `pnpm exec eslint test/program/control/*.test.ts` — no errors
- [ ] CI passes