### PR TITLE
fix: resolve #435 - reset palette combinations on program start

### DIFF
--- a/src/core/devices/DeviceScreenManager.ts
+++ b/src/core/devices/DeviceScreenManager.ts
@@ -56,6 +56,9 @@ export class DeviceScreenManager {
       this.syncScreenStateToShared()
       this.postScreenChanged()
       this.cancelPendingScreenUpdate()
+      // Send palette-combination reset messages so the main thread's
+      // BACKGROUND_PALETTES and SPRITE_PALETTES are also restored to defaults.
+      this.postPaletteCombinationResetMessages()
     } else {
       this.screenUpdateBatcher.flush()
     }
@@ -211,6 +214,46 @@ export class DeviceScreenManager {
       type: 'SCREEN_CHANGED',
       id: `screen-changed-${Date.now()}`,
       timestamp: Date.now(),
+    })
+  }
+
+  /**
+   * Send palette-combination SCREEN_UPDATE messages to reset the main thread's
+   * BACKGROUND_PALETTES and SPRITE_PALETTES to their original values.
+   * Called after resetState() to keep the worker as the single source of truth.
+   */
+  private postPaletteCombinationResetMessages(): void {
+    const executionId = this.screenStateManager.getCurrentExecutionId() ?? 'unknown'
+    const { background, sprite } = this.screenStateManager.getAllPaletteCombinations()
+
+    for (const entry of background) {
+      this.postSinglePaletteCombinationMessage(executionId, 'B', entry.paletteIndex, entry.combination, entry.colors)
+    }
+    for (const entry of sprite) {
+      this.postSinglePaletteCombinationMessage(executionId, 'S', entry.paletteIndex, entry.combination, entry.colors)
+    }
+  }
+
+  private postSinglePaletteCombinationMessage(
+    executionId: string,
+    target: 'B' | 'S',
+    paletteIndex: number,
+    combination: number,
+    colors: [number, number, number, number],
+  ): void {
+    self.postMessage({
+      type: 'SCREEN_UPDATE',
+      id: `screen-palette-combination-reset-${Date.now()}-${target}${paletteIndex}-${combination}`,
+      timestamp: Date.now(),
+      data: {
+        executionId,
+        updateType: 'palette-combination',
+        paletteTarget: target,
+        paletteIndex,
+        paletteCombination: combination,
+        paletteColors: colors,
+        timestamp: Date.now(),
+      },
     })
   }
 }

--- a/src/core/devices/ScreenStateManager.ts
+++ b/src/core/devices/ScreenStateManager.ts
@@ -19,6 +19,17 @@ import {
   createPaletteUpdateMessage,
 } from './ScreenUpdateMessageFactory'
 
+type PaletteCombinationEntry = {
+  paletteIndex: number
+  combination: number
+  colors: [number, number, number, number]
+}
+
+export type PaletteCombinationSnapshot = {
+  background: PaletteCombinationEntry[]
+  sprite: PaletteCombinationEntry[]
+}
+
 export class ScreenStateManager {
   private screenBuffer: ScreenCell[][] = []
   private cursorX = 0
@@ -322,6 +333,35 @@ export class ScreenStateManager {
    */
   getPalette(): { bgPalette: number; spritePalette: number } {
     return { bgPalette: this.bgPalette, spritePalette: this.spritePalette }
+  }
+
+  /**
+   * Get all background and sprite palette combination data.
+   * Used by DeviceScreenManager to send palette-combination reset messages
+   * to the main thread when a new execution starts.
+   */
+  getAllPaletteCombinations(): PaletteCombinationSnapshot {
+    type Entry = { paletteIndex: number; combination: number; colors: [number, number, number, number] }
+
+    const background: Entry[] = []
+    for (let i = 0; i < this.backgroundPalettes.length; i++) {
+      const palette = this.backgroundPalettes[i]!
+      for (let j = 0; j < palette.length; j++) {
+        const colors = [...palette[j]!] as [number, number, number, number]
+        background.push({ paletteIndex: i, combination: j, colors })
+      }
+    }
+
+    const sprite: Entry[] = []
+    for (let i = 0; i < this.spritePalettes.length; i++) {
+      const palette = this.spritePalettes[i]!
+      for (let j = 0; j < palette.length; j++) {
+        const colors = [...palette[j]!] as [number, number, number, number]
+        sprite.push({ paletteIndex: i, combination: j, colors })
+      }
+    }
+
+    return { background, sprite }
   }
 
   /**

--- a/test/core/devices/DeviceScreenManager.test.ts
+++ b/test/core/devices/DeviceScreenManager.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for DeviceScreenManager
+ *
+ * Tests screen lifecycle operations, focusing on the palette-combination
+ * reset messages sent when a new execution starts (issue #435).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DeviceScreenManager } from '@/core/devices/DeviceScreenManager'
+import { BACKGROUND_PALETTES, SPRITE_PALETTES } from '@/shared/data/palette'
+
+// Mock logger to suppress warnings in test output
+vi.mock('@/shared/logger', () => ({
+  logWorker: {
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+// ============================================================================
+// postMessage mock — DeviceScreenManager uses self.postMessage (worker API)
+// ============================================================================
+
+let capturedMessages: unknown[] = []
+
+beforeEach(() => {
+  capturedMessages = []
+  const selfTyped = self as typeof self & {
+    postMessage: (msg: unknown, transfer?: Transferable[]) => void
+  }
+  selfTyped.postMessage = (msg: unknown) => {
+    capturedMessages.push(msg)
+  }
+})
+
+afterEach(() => {
+  capturedMessages = []
+})
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface ScreenUpdateMsg {
+  type: string
+  data: {
+    updateType: string
+    paletteTarget?: string
+    paletteIndex?: number
+    paletteCombination?: number
+    paletteColors?: [number, number, number, number]
+    [key: string]: unknown
+  }
+}
+
+function getPaletteCombinationMessages(): ScreenUpdateMsg[] {
+  return capturedMessages.filter(
+    (msg): msg is ScreenUpdateMsg =>
+      typeof msg === 'object' && msg !== null &&
+      (msg as ScreenUpdateMsg).type === 'SCREEN_UPDATE' &&
+      (msg as ScreenUpdateMsg).data?.updateType === 'palette-combination',
+  )
+}
+
+describe('DeviceScreenManager', () => {
+  let manager: DeviceScreenManager
+
+  beforeEach(() => {
+    manager = new DeviceScreenManager()
+  })
+
+  describe('setCurrentExecutionId — palette combination reset', () => {
+    it('should send palette-combination reset messages for all background palettes', () => {
+      manager.setCurrentExecutionId('exec-1')
+
+      const msgs = getPaletteCombinationMessages()
+
+      // BACKGROUND_PALETTES has 2 palettes, each with 4 combinations = 8
+      const bgMsgs = msgs.filter(m => m.data.paletteTarget === 'B')
+      expect(bgMsgs.length).toBe(8) // 2 palettes x 4 combinations
+
+      // Verify each combination has the original palette data
+      for (const msg of bgMsgs) {
+        const { paletteIndex, paletteCombination, paletteColors } = msg.data
+        const expected = BACKGROUND_PALETTES[paletteIndex! as 0 | 1][paletteCombination! as 0 | 1 | 2 | 3]
+        expect(paletteColors).toEqual([...expected] as [number, number, number, number])
+      }
+    })
+
+    it('should send palette-combination reset messages for all sprite palettes', () => {
+      manager.setCurrentExecutionId('exec-1')
+
+      const msgs = getPaletteCombinationMessages()
+
+      // SPRITE_PALETTES has 3 palettes, each with 4 combinations = 12
+      const spriteMsgs = msgs.filter(m => m.data.paletteTarget === 'S')
+      expect(spriteMsgs.length).toBe(12) // 3 palettes x 4 combinations
+
+      // Verify each combination has the original palette data
+      for (const msg of spriteMsgs) {
+        const { paletteIndex, paletteCombination, paletteColors } = msg.data
+        const expected = SPRITE_PALETTES[paletteIndex! as 0 | 1 | 2][paletteCombination! as 0 | 1 | 2 | 3]
+        expect(paletteColors).toEqual([...expected] as [number, number, number, number])
+      }
+    })
+
+    it('should send a total of 20 palette-combination messages (8 bg + 12 sprite)', () => {
+      manager.setCurrentExecutionId('exec-1')
+
+      const msgs = getPaletteCombinationMessages()
+      expect(msgs.length).toBe(20)
+    })
+
+    it('should include the correct executionId in reset messages', () => {
+      manager.setCurrentExecutionId('test-exec-42')
+
+      const msgs = getPaletteCombinationMessages()
+      for (const msg of msgs) {
+        expect(msg.data.executionId).toBe('test-exec-42')
+      }
+    })
+
+    it('should not send palette-combination messages when executionId is null', () => {
+      manager.setCurrentExecutionId(null)
+
+      const msgs = getPaletteCombinationMessages()
+      expect(msgs.length).toBe(0)
+    })
+
+    it('should send reset messages on each new execution start', () => {
+      // First execution
+      manager.setCurrentExecutionId('exec-1')
+      const firstBatch = getPaletteCombinationMessages()
+      expect(firstBatch.length).toBe(20)
+
+      // Second execution — should also reset
+      capturedMessages = []
+      manager.setCurrentExecutionId('exec-2')
+      const secondBatch = getPaletteCombinationMessages()
+      expect(secondBatch.length).toBe(20)
+    })
+  })
+})

--- a/test/core/devices/ScreenStateManager.palettes.test.ts
+++ b/test/core/devices/ScreenStateManager.palettes.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for ScreenStateManager palette combination snapshot
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ScreenStateManager } from '@/core/devices/ScreenStateManager'
+
+// Mock logger to suppress warnings in test output
+vi.mock('@/shared/logger', () => ({
+  logDevice: {
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+describe('ScreenStateManager - palette combinations', () => {
+  let manager: ScreenStateManager
+
+  beforeEach(() => {
+    manager = new ScreenStateManager()
+  })
+
+  describe('getAllPaletteCombinations', () => {
+    it('should return all background palette combinations with correct count', () => {
+      const { background } = manager.getAllPaletteCombinations()
+      // 2 background palettes x 4 combinations each = 8
+      expect(background.length).toBe(8)
+    })
+
+    it('should return all sprite palette combinations with correct count', () => {
+      const { sprite } = manager.getAllPaletteCombinations()
+      // 3 sprite palettes x 4 combinations each = 12
+      expect(sprite.length).toBe(12)
+    })
+
+    it('should return original palette data after resetState', () => {
+      // Mutate a palette combination — default bgPalette is 1, so this mutates backgroundPalettes[1][0]
+      manager.setPaletteCombination('B', 0, [99, 99, 99, 99])
+      // Reset
+      manager.resetState()
+      const { background } = manager.getAllPaletteCombinations()
+      // paletteIndex=1, combination=0 should be restored to BACKGROUND_PALETTES[1][0] = [0x00, 0x30, 0x21, 0x02]
+      const mutatedEntry = background.find(
+        e => e.paletteIndex === 1 && e.combination === 0,
+      )
+      expect(mutatedEntry!.colors).toEqual([0x00, 0x30, 0x21, 0x02])
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #435
- Palette combinations and backdrop color no longer persist across program runs

## Changes
- Added `postPaletteCombinationResetMessages()` to `DeviceScreenManager` — sends `palette-combination` SCREEN_UPDATE messages for all 20 palette entries (8 bg + 12 sprite) when a new execution starts
- Added `getAllPaletteCombinations()` to `ScreenStateManager` — returns snapshot of all palette data for both background and sprite palettes
- Called reset after `resetState()` in `setCurrentExecutionId()` to ensure main-thread palette arrays are restored

## Root Cause
Main-thread `BACKGROUND_PALETTES`/`SPRITE_PALETTES` are mutated in place by PALET but never reset when a new program starts. The worker resets its own copy, but no messages are sent to reset the main thread's arrays.

## Test plan
- [x] New `DeviceScreenManager.test.ts` — 6 regression tests for palette reset
- [x] New `ScreenStateManager.palettes.test.ts` — 3 tests for `getAllPaletteCombinations()`
- [x] All 3270 existing tests pass
- [x] Type-check clean, ESLint clean
- [ ] CI passes