### PR TITLE
feat: resolve #426 - add headless program tests for data samples

### DIFF
--- a/test/program/data/arrays.test.ts
+++ b/test/program/data/arrays.test.ts
@@ -1,0 +1,15 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('arrays program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('arrays')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // PRINT A(1); A(2); A(3) → sign-space padded values concatenated by semicolons
+    tp.expectRowText(0, ' 10 20 30')
+  })
+})

--- a/test/program/data/data-read.test.ts
+++ b/test/program/data/data-read.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('dataRead program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('dataRead')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // Each PRINT N on a separate line — sign-space padded
+    tp.expectRowText(0, ' 10')
+    tp.expectRowText(1, ' 20')
+    tp.expectRowText(2, ' 30')
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #426 (Step 3 of 8 for #423)
- Adds headless Vitest integration tests for 2 data category sample programs

## Changes
- `test/program/data/arrays.test.ts` — tests DIM, array assignment, semicolon-concatenated PRINT
- `test/program/data/data-read.test.ts` — tests READ/DATA loop with per-line output

## Test plan
- [x] `pnpm test:run -- test/program/data/` — 2/2 pass
- [x] `pnpm type-check` — no errors
- [x] `pnpm exec eslint` — no errors
- [ ] CI passes