### PR TITLE
feat: resolve #427 - add headless program tests for screen samples

### DIFF
--- a/test/program/screen/bg-items.test.ts
+++ b/test/program/screen/bg-items.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('bg-items program', () => {
+  it('runs successfully and prints character ranges', async () => {
+    const tp = TestProgram.fromSample('bgItems')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // Row 0: CHR$(0-27) — control/special characters
+    // Row 1: CHR$(28-31) — remaining chars from first range
+    // Row 3: CHR$(33-47) — punctuation/symbols: !"#$%&'()*+,-./
+    tp.expectRowText(3, '!')
+    tp.expectRowText(3, '/')
+    // Row 5: CHR$(48-57) — digits: 0123456789
+    tp.expectRowText(5, '0123456789')
+    // Row 7: CHR$(65-90) — uppercase letters: ABCDEFGHIJKLMNOPQRSTUVWXYZ
+    tp.expectRowText(7, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+    // Row 9: CHR$(91-95) — brackets: [\]^_
+    tp.expectRowText(9, '[')
+    // Row 11+: CHR$(96-175) — lowercase and extended characters
+    tp.expectRowText(11, '`')
+  })
+})

--- a/test/program/screen/cursor-position.test.ts
+++ b/test/program/screen/cursor-position.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('cursor-position program', () => {
+  // PAUSE 50 per loop iteration × 16 iterations ≈ 16s total, needs extended timeout
+  it('runs successfully and shows cursor position output', async () => {
+    const tp = TestProgram.fromSample('cursorPosition')
+
+    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+
+    tp.expectSuccess()
+    // LOCATE I,I for I=0..15 → diagonal POS/LINE output
+    // Row 0: POS= 0 LINE= 0 (positive numbers have space padding)
+    tp.expectRowText(0, 'POS=')
+    tp.expectRowText(0, 'LINE=')
+    // Row 12: POS= 12 LINE= 12 (last row before wrapping)
+    tp.expectRowText(12, 'POS= 12 LINE= 12')
+    // Row 16: "Done!"
+    tp.expectRowText(16, 'DONE!')
+  }, 20_000)
+})

--- a/test/program/screen/screen-fill.test.ts
+++ b/test/program/screen/screen-fill.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('screen-fill program', () => {
+  it('runs successfully and fills screen with line numbers', async () => {
+    const tp = TestProgram.fromSample('screenFill')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // Test adapter does not scroll, so rows 0-22 keep LINE 1-23
+    // Row 0: "LINE  1" (positive numbers have space padding for sign)
+    tp.expectRowText(0, 'LINE  1')
+    // Row 1: "LINE  2"
+    tp.expectRowText(1, 'LINE  2')
+    // Row 22: "LINE  23"
+    tp.expectRowText(22, 'LINE  23')
+    // Row 23: last written line — "DONE" from PRINT "Done", but " 50" remains
+    // from the last FOR iteration's "LINE  50" which is longer than "DONE"
+    tp.expectRowText(23, 'DONE')
+  })
+})

--- a/test/program/screen/screen-read.test.ts
+++ b/test/program/screen/screen-read.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('screen-read program', () => {
+  it('runs successfully and reads screen characters', async () => {
+    const tp = TestProgram.fromSample('screenRead')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // Row 5: "FAMILY BASIC" (printed at LOCATE 0,5)
+    tp.expectRowText(5, 'FAMILY BASIC')
+    // Row 6: "============"
+    tp.expectRowText(6, '============')
+    // Row 10: "Reading chars..." (LOCATE 0,10)
+    tp.expectRowText(10, 'READING CHARS...')
+    // Row 14: "Reading color..." (LOCATE 0,14)
+    tp.expectRowText(14, 'READING COLOR...')
+    // Row 15: "CHAR: " — SCR$() reads character from screen position
+    tp.expectRowText(15, 'CHAR:')
+    // Row 16: "COLOR: " — SCR$() with color flag
+    tp.expectRowText(16, 'COLOR:')
+    // Row 18: "Done!"
+    tp.expectRowText(18, 'DONE!')
+  })
+})

--- a/test/program/screen/screen.test.ts
+++ b/test/program/screen/screen.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('screen program', () => {
+  it('runs successfully and shows screen control output', async () => {
+    const tp = TestProgram.fromSample('screen')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // Row 0: "SCREEN DEMO" (CLS then PRINT)
+    tp.expectRowText(0, 'SCREEN DEMO')
+    // Row 5: "ROW 5, COL 10" (LOCATE 10,5)
+    tp.expectRowText(5, 'ROW 5, COL 10')
+    // Row 7: "ROW 7, COL 10" (LOCATE 10,7)
+    tp.expectRowText(7, 'ROW 7, COL 10')
+    // Diagonal asterisks at LOCATE 5+I, 10+I for I=0..9
+    tp.expectRowText(10, '*')
+    // Row 22: "Done!" (LOCATE 0,22)
+    tp.expectRowText(22, 'DONE!')
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #427 (Step 4 of 8 for #423)
- Adds headless Vitest integration tests for 5 screen category sample programs

## Changes
- `test/program/screen/bg-items.test.ts` — tests CHR$() character range output
- `test/program/screen/cursor-position.test.ts` — tests LOCATE, POS, CSRLIN with PAUSE
- `test/program/screen/screen-fill.test.ts` — tests 50-line print loop
- `test/program/screen/screen-read.test.ts` — tests SCR$() screen read function
- `test/program/screen/screen.test.ts` — tests LOCATE, CGSET, PALETB, diagonal line

Skipped 4 programs (bg-platform, bg-title, bg-view, printable-area) that require BG editor data via VIEW command.

## Test plan
- [x] `pnpm test:run -- test/program/screen/` — 5/5 pass
- [x] `pnpm type-check` — no errors
- [x] `pnpm exec eslint` — no errors
- [ ] CI passes