### PR TITLE
refactor: resolve #432 - split TestDeviceAdapter.ts exceeding 500-line limit

### DIFF
--- a/src/core/devices/TestDeviceAdapter.ts
+++ b/src/core/devices/TestDeviceAdapter.ts
@@ -16,7 +16,6 @@ import {
   DEFAULT_BACKGROUND_PALETTES,
   DEFAULT_SPRITE_PALETTES,
 } from './TestDeviceAdapterHelpers'
-import type { ScheduledInputDelivery, ScheduledInputEvent } from './TestDeviceInputScheduler'
 import { TestDeviceInputScheduler } from './TestDeviceInputScheduler'
 
 export class TestDeviceAdapter implements BasicDeviceAdapter {
@@ -64,8 +63,8 @@ export class TestDeviceAdapter implements BasicDeviceAdapter {
   public inputResponseQueue: string[][] = []
 
   // === INPUT TIMELINE SCHEDULING ===
-  /** Scheduler delegates frame tracking and event delivery. */
-  private readonly inputScheduler: TestDeviceInputScheduler = new TestDeviceInputScheduler({
+  /** Scheduler delegates frame tracking and event delivery. Public for direct access. */
+  public readonly inputScheduler = new TestDeviceInputScheduler({
     setStickState: (player, direction) => this.setStickState(player, direction),
     pushStrigState: (player, button) => this.pushStrigState(player, button),
     setInkeyState: (keyChar) => this.setInkeyStateForTest(keyChar),
@@ -172,49 +171,6 @@ export class TestDeviceAdapter implements BasicDeviceAdapter {
     }
     // Otherwise return current state
     return this.inkeyState
-  }
-
-  // === INPUT TIMELINE SCHEDULING ===
-  // Delegates to TestDeviceInputScheduler. See that class for full API docs.
-
-  getCurrentFrame(): number {
-    return this.inputScheduler.getCurrentFrame()
-  }
-
-  scheduleInput(event: ScheduledInputEvent): void {
-    this.inputScheduler.scheduleInput(event)
-  }
-
-  scheduleInputs(events: ScheduledInputEvent[]): void {
-    this.inputScheduler.scheduleInputs(events)
-  }
-
-  advanceFrame(): ScheduledInputDelivery {
-    return this.inputScheduler.advanceFrame()
-  }
-
-  setCurrentFrame(frame: number): void {
-    this.inputScheduler.setCurrentFrame(frame)
-  }
-
-  deliverScheduledEvents(): ScheduledInputDelivery {
-    return this.inputScheduler.deliverScheduledEvents()
-  }
-
-  clearScheduledInputs(): void {
-    this.inputScheduler.clearScheduledInputs()
-  }
-
-  getScheduledInputCount(): number {
-    return this.inputScheduler.getScheduledInputCount()
-  }
-
-  getScheduledInputs(): ScheduledInputEvent[] {
-    return this.inputScheduler.getScheduledInputs()
-  }
-
-  get deliveryLog(): ScheduledInputDelivery[] {
-    return this.inputScheduler.getDeliveryLog()
   }
 
   // === SPRITE POSITION QUERY ===

--- a/test/core/devices/TestDeviceInputScheduler.test.ts
+++ b/test/core/devices/TestDeviceInputScheduler.test.ts
@@ -350,7 +350,7 @@ describe('TestDeviceInputScheduler', () => {
 })
 
 // ============================================================================
-// Integration: scheduling through TestDeviceAdapter
+// Integration: scheduling through TestDeviceAdapter.inputScheduler
 // ============================================================================
 
 describe('TestDeviceAdapter scheduling integration', () => {
@@ -360,38 +360,38 @@ describe('TestDeviceAdapter scheduling integration', () => {
 
   it('should start at frame 0', () => {
     const adapter = createAdapter()
-    expect(adapter.getCurrentFrame()).toBe(0)
+    expect(adapter.inputScheduler.getCurrentFrame()).toBe(0)
   })
 
-  it('should deliver stick event through adapter delegation', () => {
+  it('should deliver stick event through adapter.inputScheduler', () => {
     const adapter = createAdapter()
-    adapter.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
-    adapter.advanceFrame()
+    adapter.inputScheduler.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
+    adapter.inputScheduler.advanceFrame()
     expect(adapter.getStickState(0)).toBe(8)
   })
 
-  it('should deliver strig event through adapter delegation', () => {
+  it('should deliver strig event through adapter.inputScheduler', () => {
     const adapter = createAdapter()
-    adapter.scheduleInput({ atFrame: 1, strig: { player: 0, button: 1 } })
-    adapter.advanceFrame()
+    adapter.inputScheduler.scheduleInput({ atFrame: 1, strig: { player: 0, button: 1 } })
+    adapter.inputScheduler.advanceFrame()
     expect(adapter.consumeStrigState(0)).toBe(1)
   })
 
-  it('should deliver key event through adapter delegation', () => {
+  it('should deliver key event through adapter.inputScheduler', () => {
     const adapter = createAdapter()
-    adapter.scheduleInput({ atFrame: 1, key: 'A' })
-    adapter.advanceFrame()
+    adapter.inputScheduler.scheduleInput({ atFrame: 1, key: 'A' })
+    adapter.inputScheduler.advanceFrame()
     expect(adapter.getInkeyState()).toBe('A')
   })
 
   it('should reset scheduling state on adapter reset()', () => {
     const adapter = createAdapter()
-    adapter.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
-    adapter.advanceFrame()
+    adapter.inputScheduler.scheduleInput({ atFrame: 1, stick: { player: 0, direction: 8 } })
+    adapter.inputScheduler.advanceFrame()
 
     adapter.reset()
-    expect(adapter.getCurrentFrame()).toBe(0)
-    expect(adapter.getScheduledInputCount()).toBe(0)
-    expect(adapter.deliveryLog).toEqual([])
+    expect(adapter.inputScheduler.getCurrentFrame()).toBe(0)
+    expect(adapter.inputScheduler.getScheduledInputCount()).toBe(0)
+    expect(adapter.inputScheduler.getDeliveryLog()).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #432

## Changes
- Removed 10 pass-through delegation methods (getCurrentFrame, scheduleInput, scheduleInputs, advanceFrame, setCurrentFrame, deliverScheduledEvents, clearScheduledInputs, getScheduledInputCount, getScheduledInputs, deliveryLog) from TestDeviceAdapter
- Exposed `inputScheduler` as public readonly property
- Updated test assertions to use `adapter.inputScheduler` directly
- TestDeviceAdapter.ts reduced from 512 to 468 lines

## Test plan
- [x] Targeted tests pass (3291 tests)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes