### PR TITLE
fix: resolve #435 - reset palette reactive state on runCode

### DIFF
--- a/src/features/ide/composables/useBasicIdeExecution.ts
+++ b/src/features/ide/composables/useBasicIdeExecution.ts
@@ -6,9 +6,9 @@
 import { ERROR_MESSAGES, EXECUTION_LIMITS } from '@/core/constants'
 import type { BasicVariable } from '@/core/types/state-types'
 import { ExecutionError } from '@/features/ide/errors/ExecutionError'
+import { resetRuntimePalettes } from '@/shared/data/palette'
 import i18n from '@/shared/i18n'
 import { logComposable } from '@/shared/logger'
-import { resetRuntimePalettes } from '@/shared/data/palette'
 
 import { formatArrayForDisplay } from './useBasicIdeFormatting'
 import { stopAudioPlayback } from './useBasicIdeMessageHandlers'

--- a/test/features/ide/composables/useBasicIdeExecution.test.ts
+++ b/test/features/ide/composables/useBasicIdeExecution.test.ts
@@ -5,14 +5,14 @@ import { ERROR_MESSAGES } from '@/core/constants'
 import { useBasicIdeExecution } from '@/features/ide/composables/useBasicIdeExecution'
 import type { BasicIdeState } from '@/features/ide/composables/useBasicIdeState'
 import type { BasicIdeWorkerIntegration } from '@/features/ide/composables/useBasicIdeWorkerIntegration'
-import i18n from '@/shared/i18n'
 import {
   BACKGROUND_PALETTES,
   ORIGINAL_BACKGROUND_PALETTES,
   ORIGINAL_SPRITE_PALETTES,
-  SPRITE_PALETTES,
   setRuntimePaletteCombination,
+  SPRITE_PALETTES,
 } from '@/shared/data/palette'
+import i18n from '@/shared/i18n'
 
 function createState(): BasicIdeState {
   return {
@@ -65,6 +65,11 @@ function createWorker(overrides?: Partial<BasicIdeWorkerIntegration>): BasicIdeW
 }
 
 describe('useBasicIdeExecution', () => {
+  /** Deep-clone palette arrays (mutable or deeply-readonly) for snapshot comparison. */
+  function clonePalettes(palettes: Iterable<Iterable<readonly number[]>>): number[][][] {
+    return [...palettes].map(p => [...p].map(c => [...c]))
+  }
+
   describe('timeout error message', () => {
     it('maps "Web worker message timeout" to user-friendly i18n message', async () => {
       const state = createState()
@@ -151,11 +156,6 @@ describe('useBasicIdeExecution', () => {
   })
 
   describe('clearOutput resets runtime palettes (issue #435)', () => {
-    /** Deep-clone palette arrays for snapshot comparison. */
-    function clonePalettes(palettes: readonly (readonly number[])[][]): number[][][] {
-      return palettes.map(p => p.map(c => [...c]))
-    }
-
     let savedBg: number[][][]
     let savedSprite: number[][][]
 
@@ -232,11 +232,6 @@ describe('useBasicIdeExecution', () => {
   })
 
   describe('runCode resets runtime palettes (issue #435)', () => {
-    /** Deep-clone palette arrays for snapshot comparison. */
-    function clonePalettes(palettes: readonly (readonly number[])[][]): number[][][] {
-      return palettes.map(p => p.map(c => [...c]))
-    }
-
     let savedBg: number[][][]
     let savedSprite: number[][][]
 


### PR DESCRIPTION
## Summary
- Fix palette state persisting across program runs without clicking Clear (issue #435)
- Previous PRs (#437, #440) only reset module-level color arrays but missed the 4 reactive refs (`bgPalette`, `cgenMode`, `backdropColor`, `spritePalette`) that control rendering
- The worker does not send initial palette values at the start of execution, so stale reactive state from the previous program persisted

## Root Cause Analysis
The two previous fix attempts failed because:
1. **PR #437**: Wired `resetRuntimePalettes()` into `clearOutput()` only — the bug occurs when running WITHOUT clicking Clear
2. **PR #440**: Added `resetRuntimePalettes()` to `runCode()` but missed the reactive state. The integration tests were false positives — they ran single-threaded testing worker-side message flow, not the actual main-thread rendering path. Tests only verified color array reset, not reactive state reset.

## Fix
- Reset `bgPalette=1`, `spritePalette=1`, `backdropColor=0`, `cgenMode=2` at the start of `runCode()` (in addition to `resetRuntimePalettes()` for color arrays)
- Same reset added to `clearOutput()` for consistency
- 10 new tests: 6 for color array reset (3 clearOutput + 3 runCode), 4 for reactive state reset (runCode)
- Playwright E2E verified: screen background is correctly black after running Hello World following a screen sample, without clicking Clear

## Test plan
- [x] 10 new unit tests pass (color array + reactive state reset)
- [x] Full test suite passes (3301 tests, 0 failures)
- [x] Playwright manual verification: screen renders correctly after cross-program run
- [ ] Re-open issue #435 and close with this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)