### PR TITLE
feat: resolve #428 - add headless program tests for music samples

### DIFF
--- a/test/program/music/arpeggio.test.ts
+++ b/test/program/music/arpeggio.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('arpeggio program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicArpeggio')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'C MAJOR ARPEGGIO')
+    tp.expectRowText(1, '================')
+    tp.expectRowText(2, 'ASCENDING...')
+    tp.expectRowText(3, 'DESCENDING...')
+    tp.expectRowText(5, 'COMPLETE!')
+  })
+})

--- a/test/program/music/bgplay-demo.test.ts
+++ b/test/program/music/bgplay-demo.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('bgplay-demo program', () => {
+  // BGPLAY + PAUSE 30 in part 1, then CLS and interactive game loop with STRIG exit.
+  // Part 2 clears Part 1 output, so screen shows game loop + "Goodbye!"
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicBgplayDemo')
+    // Queue START button press (bit 0) to exit the Part 2 game loop
+    tp.pushStrigState(0, 1)
+
+    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+
+    tp.expectSuccess()
+    // After Part 2 CLS, screen shows game loop header
+    tp.expectRowText(0, '=== GAME LOOP + BGPLAY ===')
+    // Text truncated to 28-char screen width
+    tp.expectRowText(1, 'SPRITE MOVES WHILE MUSIC PLA')
+    tp.expectRowText(2, 'PRESS A = SOUND EFFECT')
+    tp.expectRowText(3, 'PRESS START = EXIT')
+    tp.expectRowText(8, 'GOODBYE!')
+  }, 20_000)
+})

--- a/test/program/music/happy-birthday.test.ts
+++ b/test/program/music/happy-birthday.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('happy-birthday program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicHappyBirthday')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'HAPPY BIRTHDAY TO YOU!')
+    tp.expectRowText(1, '=======================')
+    tp.expectRowText(3, 'MAKE A WISH!')
+  })
+})

--- a/test/program/music/jingle-bells.test.ts
+++ b/test/program/music/jingle-bells.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('jingle-bells program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicJingleBells')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'JINGLE BELLS')
+    tp.expectRowText(1, '============')
+    tp.expectRowText(3, 'MERRY CHRISTMAS!')
+  })
+})

--- a/test/program/music/loop-demo.test.ts
+++ b/test/program/music/loop-demo.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('loop-demo program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicLoopDemo')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'MUSIC LOOP DEMO')
+    tp.expectRowText(1, '===============')
+    tp.expectRowText(2, 'ASCENDING SCALE 3X:')
+    tp.expectRowText(3, 'DESCENDING SCALE 3X:')
+    tp.expectRowText(4, 'PATTERN REPEAT 4X:')
+    tp.expectRowText(6, 'COMPLETE!')
+  })
+})

--- a/test/program/music/mary-lamb.test.ts
+++ b/test/program/music/mary-lamb.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('mary-lamb program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicMaryHadALittleLamb')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // LOCATE 6,12 positions text on row 12
+    tp.expectRowText(12, 'MARY HAD A LITTLE LAMB')
+    tp.expectRowText(14, 'SONG COMPLETE!')
+  })
+})

--- a/test/program/music/ode-to-joy.test.ts
+++ b/test/program/music/ode-to-joy.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('ode-to-joy program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicOdeToJoy')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'ODE TO JOY - BEETHOVEN')
+    tp.expectRowText(1, 'SYMPHONY NO.9 - FULL THEME')
+    tp.expectRowText(2, '==========================')
+    tp.expectRowText(4, 'FIN!')
+  })
+})

--- a/test/program/music/play-demo.test.ts
+++ b/test/program/music/play-demo.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('play-demo program', () => {
+  // PLAY + PAUSE 30 sections — total ~3s of PAUSE delays
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicPlayDemo')
+
+    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+
+    tp.expectSuccess()
+    tp.expectRowText(0, '=== PLAY DEMO ===')
+    tp.expectRowText(2, 'QUARTER NOTES:')
+    tp.expectRowText(3, 'EIGHTH NOTES:')
+    tp.expectRowText(4, 'HALF NOTES:')
+    tp.expectRowText(5, 'CHORD:')
+    tp.expectRowText(7, 'DONE!')
+  }, 20_000)
+})

--- a/test/program/music/player.test.ts
+++ b/test/program/music/player.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('player program', () => {
+  it('exits immediately when selecting option 4', async () => {
+    const tp = TestProgram.fromSample('musicPlayer')
+    tp.seedInput(['4'])
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, '====================')
+    tp.expectRowText(1, '   F-BASIC JUKEBOX')
+    tp.expectRowText(2, '====================')
+    tp.expectRowText(4, '1. TWINKLE TWINKLE')
+    tp.expectRowText(5, '2. SCALE DEMO')
+    tp.expectRowText(6, '3. CHORD DEMO')
+    tp.expectRowText(7, '4. EXIT')
+    tp.expectRowText(9, 'GOODBYE!')
+  })
+})

--- a/test/program/music/rockn-rouge.test.ts
+++ b/test/program/music/rockn-rouge.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('rockn-rouge program', () => {
+  // Long program (~450 lines) with many PLAY commands and loop structures
+  it('runs successfully without errors', async () => {
+    const tp = TestProgram.fromSample('musicRocknRouge')
+
+    await tp.run({
+      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+    })
+
+    tp.expectSuccess()
+  }, 30_000)
+})

--- a/test/program/music/scale.test.ts
+++ b/test/program/music/scale.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('scale program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicScale')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'C MAJOR SCALE')
+    tp.expectRowText(1, '=============')
+    tp.expectRowText(2, 'ASCENDING...')
+    tp.expectRowText(3, 'DESCENDING...')
+    tp.expectRowText(5, 'COMPLETE!')
+  })
+})

--- a/test/program/music/three-channel.test.ts
+++ b/test/program/music/three-channel.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('three-channel program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicThreeChannel')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'THREE-CHANNEL HARMONY DEMO')
+    tp.expectRowText(1, '==========================')
+    tp.expectRowText(2, 'PLAYING C MAJOR CHORD...')
+    tp.expectRowText(3, 'PLAYING F MAJOR CHORD...')
+    tp.expectRowText(4, 'PLAYING G MAJOR CHORD...')
+    tp.expectRowText(5, 'PLAYING C MAJOR CHORD...')
+    tp.expectRowText(7, 'COMPLETE!')
+  })
+})

--- a/test/program/music/twinkle.test.ts
+++ b/test/program/music/twinkle.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('twinkle program', () => {
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('musicTwinkle')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'TWINKLE TWINKLE LITTLE STAR')
+    tp.expectRowText(1, '===========================')
+    // PRINT "Verse ";V produces "VERSE " + V with space padding
+    tp.expectRowText(3, /VERSE\s+2/)
+    tp.expectRowText(5, 'SONG COMPLETE!')
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #428 — Step 5 of 8 for #423

## Changes
- Adds 13 headless Vitest test files for music category samples (arpeggio, bgplay-demo, happy-birthday, jingle-bells, loop-demo, mary-lamb, ode-to-joy, play-demo, player, rockn-rouge, scale, three-channel, twinkle)
- Uses TestProgram fluent API with expectSuccess and expectRowText assertions
- Handles interactive programs: bgplay-demo (pushStrigState to exit), player (seedInput for jukebox exit)
- Extended timeouts for slow programs: rockn-rouge (30s), bgplay-demo and play-demo (20s)

## Test plan
- [x] All 12 music tests pass locally
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes