### PR TITLE
fix: resolve #444 - add regression tests for clearOutput palette reactive ref resets

### DIFF
--- a/test/features/ide/composables/useBasicIdeExecution.test.ts
+++ b/test/features/ide/composables/useBasicIdeExecution.test.ts
@@ -322,6 +322,60 @@ describe('useBasicIdeExecution', () => {
     })
   })
 
+  describe('clearOutput resets palette reactive state (issue #444)', () => {
+    it('should reset bgPalette to default when clearOutput is called', () => {
+      const state = createState()
+      // Simulate a screen sample that changed bgPalette via CGEN command
+      state.bgPalette.value = 0
+      const worker = createWorker()
+      const parseCode = vi.fn().mockResolvedValue({})
+      const { clearOutput } = useBasicIdeExecution(state, worker, parseCode)
+
+      clearOutput()
+
+      expect(state.bgPalette.value).toEqual(1)
+    })
+
+    it('should reset cgenMode to default when clearOutput is called', () => {
+      const state = createState()
+      // Simulate a screen sample that changed cgenMode via CGEN command
+      state.cgenMode.value = 0
+      const worker = createWorker()
+      const parseCode = vi.fn().mockResolvedValue({})
+      const { clearOutput } = useBasicIdeExecution(state, worker, parseCode)
+
+      clearOutput()
+
+      expect(state.cgenMode.value).toEqual(2)
+    })
+
+    it('should reset backdropColor to default when clearOutput is called', () => {
+      const state = createState()
+      // Simulate a screen sample that set a non-zero backdrop color
+      state.backdropColor.value = 1
+      const worker = createWorker()
+      const parseCode = vi.fn().mockResolvedValue({})
+      const { clearOutput } = useBasicIdeExecution(state, worker, parseCode)
+
+      clearOutput()
+
+      expect(state.backdropColor.value).toEqual(0)
+    })
+
+    it('should reset spritePalette to default when clearOutput is called', () => {
+      const state = createState()
+      // Simulate a screen sample that changed sprite palette index
+      state.spritePalette.value = 2
+      const worker = createWorker()
+      const parseCode = vi.fn().mockResolvedValue({})
+      const { clearOutput } = useBasicIdeExecution(state, worker, parseCode)
+
+      clearOutput()
+
+      expect(state.spritePalette.value).toEqual(1)
+    })
+  })
+
   describe('runCode resets palette reactive state (issue #435)', () => {
     it('should reset bgPalette to default when runCode is called', async () => {
       const state = createState()


### PR DESCRIPTION
## Summary
- Fixes #444 — adds regression test coverage for `clearOutput()` palette reactive ref resets

## Changes
- Added 4 targeted regression tests in `useBasicIdeExecution.test.ts` verifying that `clearOutput()` resets `bgPalette`, `spritePalette`, `backdropColor`, and `cgenMode` to defaults
- The bug was already fixed on master (clearOutput had the ref resets), but had zero test coverage for this behavior
- Tests mirror the existing `runCode` palette reset tests from #435

## Test plan
- [x] All 3305 tests pass (including 4 new regression tests)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes