### PR TITLE
feat: resolve #429 - add headless program tests for sprite samples

### DIFF
--- a/test/program/sprites/sprite-animation.test.ts
+++ b/test/program/sprites/sprite-animation.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('sprite-animation program', () => {
+  // PAUSE 180 + PAUSE 120 (~4s total) plus sprite movement
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('spriteAnimation')
+
+    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'THREE SPRITES MOVING...')
+    tp.expectRowText(1, 'MOVEMENT STOPPED!')
+  }, 20_000)
+})

--- a/test/program/sprites/sprite-basic.test.ts
+++ b/test/program/sprites/sprite-basic.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('sprite-basic program', () => {
+  // PAUSE 150 + PAUSE 100 (~3s total) plus sprite placement and movement
+  it('runs successfully and produces expected output', async () => {
+    const tp = TestProgram.fromSample('spriteBasic')
+
+    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'SPRITE PLACED AT (120,100)')
+    tp.expectRowText(1, 'NOW MOVING RIGHT...')
+    tp.expectRowText(2, 'STOPPED AT X=')
+    tp.expectRowText(3, 'SPRITE ERASED. DONE!')
+  }, 20_000)
+})

--- a/test/program/sprites/sprite-control.test.ts
+++ b/test/program/sprites/sprite-control.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('sprite-control program', () => {
+  // 8 directions x (PAUSE 150 + PAUSE 120) = ~36s of pauses, very long program.
+  // Screen scrolls — 8 directions x 2 rows each = 16 printed lines fills the
+  // entire 16-row screen, so only the last few direction outputs remain visible.
+  it('runs successfully and tests all 8 directions', async () => {
+    const tp = TestProgram.fromSample('spriteControl')
+
+    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 10000 } })
+
+    tp.expectSuccess()
+    // Early directions scroll off — verify the screen contains direction data
+    // by checking the last visible rows show X/Y position output from direction 8
+    tp.expectRowText(14, 'DIRECTION 8: UP-LEFT')
+    tp.expectRowText(15, 'X=')
+  }, 60_000)
+})

--- a/test/program/sprites/sprite-table-b.test.ts
+++ b/test/program/sprites/sprite-table-b.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('sprite-table-b program', () => {
+  // Interactive program with STICK/STRIG game loop — push START (T=1) to exit
+  it('runs successfully and exits on START button', async () => {
+    const tp = TestProgram.fromSample('spriteTableB')
+    // T=1 triggers line 450: "IF T=1 THEN 450" to exit the game loop
+    tp.pushStrigState(0, 1)
+
+    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+
+    tp.expectSuccess()
+    tp.expectRowText(0, '=== SPRITE TABLE B TEST ===')
+    tp.expectRowText(1, 'CGEN 3: B ON BG, B ON SPRITE')
+    // Screen width is 28 chars — "USING BG CHARACTERS FOR SPRITES" truncates
+    tp.expectRowText(2, 'USING BG CHARACTERS FOR SPRI')
+    tp.expectRowText(4, 'SPRITE 0: FLAG AT (50,100)')
+    tp.expectRowText(5, 'SPRITE 1: APPLE AT (150,100)')
+    tp.expectRowText(7, 'USE D-PAD TO MOVE SPRITE 0')
+    tp.expectRowText(8, 'PRESS A TO HIDE SPRITE 1')
+    tp.expectRowText(9, 'PRESS B TO SHOW SPRITE 1')
+    tp.expectRowText(10, 'PRESS START TO END')
+    tp.expectRowText(11, 'GOODBYE!')
+  }, 20_000)
+})


### PR DESCRIPTION
## Summary
- Fixes #429 — adds headless Vitest tests for sprite category samples (Step 6 of 8 for #423)

## Changes
- `sprite-animation.test.ts` — 3-sprite movement with PAUSE delays, asserts "THREE SPRITES MOVING..." and "MOVEMENT STOPPED!"
- `sprite-basic.test.ts` — sprite placement, movement, and erasure with expectRowText assertions
- `sprite-control.test.ts` — all 8 movement directions, 60s timeout for ~36s of PAUSE delays
- `sprite-table-b.test.ts` — interactive CGEN3/table-B test using pushStrigState to exit game loop

## Test plan
- [x] All 3318 tests pass (including 4 new sprite tests)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes