### PR TITLE
refactor: resolve #441 - eliminate palette data duplication between ORIGINAL_* and runtime PALETTES

### DIFF
--- a/src/core/devices/TestDeviceAdapterHelpers.ts
+++ b/src/core/devices/TestDeviceAdapterHelpers.ts
@@ -88,43 +88,13 @@ export function applyPaletteCombination(
 }
 
 // ============================================================================
-// Default Palette Data
+// Default Palette Data — re-exported from the single source of truth.
+// The raw palette values are defined once in palette.ts (RAW_* constants)
+// and exposed as immutable ORIGINAL_* arrays. Re-exporting them here avoids
+// a third copy of the same data.
 // ============================================================================
 
-/** Default background palettes used by TestDeviceAdapter. */
-export const DEFAULT_BACKGROUND_PALETTES: ColorTuple[][] = [
-  [
-    [0x00, 0x2c, 0x15, 0x07],
-    [0x00, 0x27, 0x21, 0x12],
-    [0x00, 0x29, 0x36, 0x17],
-    [0x00, 0x30, 0x26, 0x07],
-  ],
-  [
-    [0x00, 0x30, 0x21, 0x02],
-    [0x00, 0x30, 0x27, 0x18],
-    [0x00, 0x30, 0x27, 0x16],
-    [0x00, 0x29, 0x36, 0x17],
-  ],
-]
-
-/** Default sprite palettes used by TestDeviceAdapter. */
-export const DEFAULT_SPRITE_PALETTES: ColorTuple[][] = [
-  [
-    [0x00, 0x36, 0x16, 0x02],
-    [0x00, 0x27, 0x30, 0x19],
-    [0x00, 0x35, 0x25, 0x17],
-    [0x00, 0x30, 0x27, 0x16],
-  ],
-  [
-    [0x00, 0x30, 0x16, 0x01],
-    [0x00, 0x10, 0x00, 0x01],
-    [0x00, 0x30, 0x29, 0x09],
-    [0x00, 0x30, 0x16, 0x07],
-  ],
-  [
-    [0x00, 0x30, 0x26, 0x12],
-    [0x00, 0x30, 0x15, 0x12],
-    [0x00, 0x30, 0x12, 0x16],
-    [0x00, 0x30, 0x26, 0x19],
-  ],
-]
+export {
+  ORIGINAL_BACKGROUND_PALETTES as DEFAULT_BACKGROUND_PALETTES,
+  ORIGINAL_SPRITE_PALETTES as DEFAULT_SPRITE_PALETTES,
+} from '@/shared/data/palette'

--- a/src/shared/data/palette.ts
+++ b/src/shared/data/palette.ts
@@ -74,48 +74,15 @@ type Palette = [ColorCombination, ColorCombination, ColorCombination, ColorCombi
 export type ColorCombination = [number, number, number, number]
 export type PaletteTarget = 'B' | 'S'
 
-// Immutable original palette data — never mutated.
-// Used as source-of-truth for resetRuntimePalettes() and
-// ScreenStateManager.resetPalettes() so that resets always
-// restore the correct default values even after setRuntimePaletteCombination()
-// has mutated the runtime BACKGROUND_PALETTES / SPRITE_PALETTES arrays.
-export const ORIGINAL_SPRITE_PALETTES = [
-  [
-    [0x00, 0x36, 0x16, 0x02] as ColorCombination,
-    [0x00, 0x27, 0x30, 0x19] as ColorCombination,
-    [0x00, 0x35, 0x25, 0x17] as ColorCombination,
-    [0x00, 0x30, 0x27, 0x16] as ColorCombination,
-  ],
-  [
-    [0x00, 0x30, 0x16, 0x01] as ColorCombination,
-    [0x00, 0x10, 0x00, 0x01] as ColorCombination,
-    [0x00, 0x30, 0x29, 0x09] as ColorCombination,
-    [0x00, 0x30, 0x16, 0x07] as ColorCombination,
-  ],
-  [
-    [0x00, 0x30, 0x26, 0x12] as ColorCombination,
-    [0x00, 0x30, 0x15, 0x12] as ColorCombination,
-    [0x00, 0x30, 0x12, 0x16] as ColorCombination,
-    [0x00, 0x30, 0x26, 0x19] as ColorCombination,
-  ],
-] as const
+// ---------------------------------------------------------------------------
+// Single source of truth for palette data.
+// All palette arrays (immutable originals and mutable runtime) are derived
+// from these raw definitions, eliminating the risk of the originals drifting
+// from the runtime defaults when palette values are updated.
+// ---------------------------------------------------------------------------
 
-export const ORIGINAL_BACKGROUND_PALETTES = [
-  [
-    [0x00, 0x2c, 0x15, 0x07] as ColorCombination,
-    [0x00, 0x27, 0x21, 0x12] as ColorCombination,
-    [0x00, 0x29, 0x36, 0x17] as ColorCombination,
-    [0x00, 0x30, 0x26, 0x07] as ColorCombination,
-  ],
-  [
-    [0x00, 0x30, 0x21, 0x02] as ColorCombination,
-    [0x00, 0x30, 0x27, 0x18] as ColorCombination,
-    [0x00, 0x30, 0x27, 0x16] as ColorCombination,
-    [0x00, 0x29, 0x36, 0x17] as ColorCombination,
-  ],
-] as const
-
-export const SPRITE_PALETTES: [Palette, Palette, Palette] = [
+/** Raw sprite palette definitions — single source of truth. */
+const RAW_SPRITE_PALETTES = [
   [
     [0x00, 0x36, 0x16, 0x02],
     [0x00, 0x27, 0x30, 0x19],
@@ -134,9 +101,10 @@ export const SPRITE_PALETTES: [Palette, Palette, Palette] = [
     [0x00, 0x30, 0x12, 0x16],
     [0x00, 0x30, 0x26, 0x19],
   ],
-]
+] as const
 
-export const BACKGROUND_PALETTES: [Palette, Palette] = [
+/** Raw background palette definitions — single source of truth. */
+const RAW_BACKGROUND_PALETTES = [
   [
     [0x00, 0x2c, 0x15, 0x07],
     [0x00, 0x27, 0x21, 0x12],
@@ -149,7 +117,40 @@ export const BACKGROUND_PALETTES: [Palette, Palette] = [
     [0x00, 0x30, 0x27, 0x16],
     [0x00, 0x29, 0x36, 0x17],
   ],
-]
+] as const
+
+// ---------------------------------------------------------------------------
+// Deep-clone helper — produces mutable arrays from raw const data.
+// The `as unknown` cast is needed because `as const` produces deeply-nested
+// readonly tuple types that are not assignable to mutable array types.
+// ---------------------------------------------------------------------------
+
+function cloneAsMutable(raw: unknown): number[][][] {
+  return (raw as number[][][]).map(palette =>
+    palette.map(combination => [...combination])
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Immutable originals — never mutated.
+// Used as source-of-truth for resetRuntimePalettes() and
+// ScreenStateManager.resetPalettes() so that resets always restore the correct
+// default values even after setRuntimePaletteCombination() has mutated the
+// runtime BACKGROUND_PALETTES / SPRITE_PALETTES arrays.
+// ---------------------------------------------------------------------------
+
+export const ORIGINAL_SPRITE_PALETTES = RAW_SPRITE_PALETTES
+export const ORIGINAL_BACKGROUND_PALETTES = RAW_BACKGROUND_PALETTES
+
+// ---------------------------------------------------------------------------
+// Mutable runtime arrays — mutated in place by setRuntimePaletteCombination().
+// ---------------------------------------------------------------------------
+
+export const SPRITE_PALETTES: [Palette, Palette, Palette] =
+  cloneAsMutable(RAW_SPRITE_PALETTES) as [Palette, Palette, Palette]
+
+export const BACKGROUND_PALETTES: [Palette, Palette] =
+  cloneAsMutable(RAW_BACKGROUND_PALETTES) as [Palette, Palette]
 
 export function setRuntimePaletteCombination(
   target: PaletteTarget,

--- a/test/core/devices/TestDeviceAdapterHelpers.test.ts
+++ b/test/core/devices/TestDeviceAdapterHelpers.test.ts
@@ -410,11 +410,11 @@ describe('DEFAULT_BACKGROUND_PALETTES', () => {
   })
 
   it('should have specific known values for first palette first combination', () => {
-    expect(DEFAULT_BACKGROUND_PALETTES[0]![0]).toEqual([0x00, 0x2c, 0x15, 0x07])
+    expect(DEFAULT_BACKGROUND_PALETTES[0][0]).toEqual([0x00, 0x2c, 0x15, 0x07])
   })
 
   it('should have specific known values for second palette last combination', () => {
-    expect(DEFAULT_BACKGROUND_PALETTES[1]![3]).toEqual([0x00, 0x29, 0x36, 0x17])
+    expect(DEFAULT_BACKGROUND_PALETTES[1][3]).toEqual([0x00, 0x29, 0x36, 0x17])
   })
 
   it('should have all color values in valid 0x00-0x36 range', () => {
@@ -453,11 +453,11 @@ describe('DEFAULT_SPRITE_PALETTES', () => {
   })
 
   it('should have specific known values for first palette first combination', () => {
-    expect(DEFAULT_SPRITE_PALETTES[0]![0]).toEqual([0x00, 0x36, 0x16, 0x02])
+    expect(DEFAULT_SPRITE_PALETTES[0][0]).toEqual([0x00, 0x36, 0x16, 0x02])
   })
 
   it('should have specific known values for third palette last combination', () => {
-    expect(DEFAULT_SPRITE_PALETTES[2]![3]).toEqual([0x00, 0x30, 0x26, 0x19])
+    expect(DEFAULT_SPRITE_PALETTES[2][3]).toEqual([0x00, 0x30, 0x26, 0x19])
   })
 
   it('should have all color values in valid 0x00-0x36 range', () => {


### PR DESCRIPTION
## Summary
- Fixes #441 — eliminates palette data duplication by establishing a single source of truth

## Changes
- Define `RAW_SPRITE_PALETTES` and `RAW_BACKGROUND_PALETTES` as `as const` single source of truth in `palette.ts`
- `ORIGINAL_*` constants now alias the raw data directly
- `SPRITE_PALETTES`/`BACKGROUND_PALETTES` derived via deep-clone helper `cloneAsMutable()`
- Remove duplicate `DEFAULT_*` arrays from `TestDeviceAdapterHelpers.ts`, replaced with re-exports from `palette.ts`
- Net: -29 lines, zero behavioral changes

## Test plan
- [x] All 3318 tests pass (including palette reset integration tests)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes