### PR TITLE
fix: resolve #456 - preserve bgGridData across execution starts

### DIFF
--- a/src/core/devices/DeviceScreenManager.ts
+++ b/src/core/devices/DeviceScreenManager.ts
@@ -52,7 +52,6 @@ export class DeviceScreenManager {
     this.screenStateManager.setCurrentExecutionId(executionId)
     if (executionId) {
       this.screenStateManager.resetState()
-      this.bgGridData = null
       this.syncScreenStateToShared()
       this.postScreenChanged()
       this.cancelPendingScreenUpdate()

--- a/test/core/devices/DeviceScreenManager.test.ts
+++ b/test/core/devices/DeviceScreenManager.test.ts
@@ -8,6 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DeviceScreenManager } from '@/core/devices/DeviceScreenManager'
+import type { BgGridData } from '@/features/bg-editor/types'
 import { BACKGROUND_PALETTES, SPRITE_PALETTES } from '@/shared/data/palette'
 
 // Mock logger to suppress warnings in test output
@@ -141,6 +142,83 @@ describe('DeviceScreenManager', () => {
       manager.setCurrentExecutionId('exec-2')
       const secondBatch = getPaletteCombinationMessages()
       expect(secondBatch.length).toBe(20)
+    })
+  })
+
+  describe('setCurrentExecutionId — BG data persistence (issue #456)', () => {
+    /** Minimal BG grid: 28 cols x 21 rows with a distinctive charCode. */
+    function makeTestBgGrid(): BgGridData {
+      const grid: BgGridData = []
+      for (let row = 0; row < 21; row++) {
+        const rowCells: { charCode: number; colorPattern: 0 | 1 | 2 | 3 }[] = []
+        for (let col = 0; col < 28; col++) {
+          rowCells.push({ charCode: 65 + (row * 28 + col) % 26, colorPattern: 0 })
+        }
+        grid.push(rowCells)
+      }
+      return grid
+    }
+
+    it('should preserve bgGridData when setCurrentExecutionId is called', () => {
+      // Set BG data first (simulates SET_BG_DATA message from main thread)
+      const bgData = makeTestBgGrid()
+      manager.setBgGridData(bgData)
+
+      // Start a new execution (simulates EXECUTE message)
+      // Before the fix, this would reset bgGridData to null
+      manager.setCurrentExecutionId('exec-1')
+
+      // Verify that copyBgGraphicToBackground still renders (does not early-return)
+      // We check by looking at the screen buffer — it should have BG data written to it
+      const screenBefore = manager.getScreenBuffer()
+      // Screen is initialized with spaces (charCode 32), so row 0 col 0 should be space initially
+      expect(screenBefore[0]![0]!.character).toBe(' ')
+
+      manager.copyBgGraphicToBackground()
+
+      // After copyBgGraphicToBackground, row 0 col 0 should have the BG data (charCode 65 = 'A')
+      const screenAfter = manager.getScreenBuffer()
+      expect(screenAfter[0]![0]!.character).toBe('A')
+    })
+
+    it('should render BG data set before execution starts (SET_BG_DATA then EXECUTE ordering)', () => {
+      // This test reproduces the exact race condition from issue #456:
+      // 1. Main thread sends SET_BG_DATA
+      // 2. Main thread sends EXECUTE
+      // 3. VIEW command should still render the BG data
+
+      const bgData = makeTestBgGrid()
+      manager.setBgGridData(bgData)
+
+      // Simulate the EXECUTE flow
+      manager.setCurrentExecutionId('exec-with-bg')
+
+      // Verify screen buffer was updated by copyBgGraphicToBackground
+      manager.copyBgGraphicToBackground()
+      const screen = manager.getScreenBuffer()
+
+      // Check a few cells to confirm BG data was rendered
+      expect(screen[0]![0]!.character).toBe('A') // charCode 65
+      expect(screen[0]![1]!.character).toBe('B') // charCode 66
+      // (20*28+27)=587, 587%26=15, 65+15=80='P'
+      expect(screen[20]![27]!.character).toBe('P')
+    })
+
+    it('should preserve bgGridData across multiple execution starts', () => {
+      const bgData = makeTestBgGrid()
+      manager.setBgGridData(bgData)
+
+      // First execution
+      manager.setCurrentExecutionId('exec-1')
+      manager.copyBgGraphicToBackground()
+      let screen = manager.getScreenBuffer()
+      expect(screen[0]![0]!.character).toBe('A')
+
+      // Second execution — BG data should still be available
+      manager.setCurrentExecutionId('exec-2')
+      manager.copyBgGraphicToBackground()
+      screen = manager.getScreenBuffer()
+      expect(screen[0]![0]!.character).toBe('A')
     })
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #456 — BG VIEW TEST no longer shows BG on screen

## Root Cause
Race condition: `setCurrentExecutionId()` reset `this.bgGridData = null`, wiping BG data that was set before the EXECUTE message arrived. When `VIEW` then executed, `copyBgGraphicToBackground()` saw null and early-returned.

## Changes
- Removed `this.bgGridData = null` from `DeviceScreenManager.setCurrentExecutionId()`. BG data is explicitly managed by `SET_BG_DATA` messages and should persist across execution boundaries.
- Added 3 regression tests covering the race condition, SET_BG_DATA→EXECUTE ordering, and persistence across multiple execution starts.

## Test plan
- [x] All 3318 tests pass (including 3 new regression tests)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes