### PR TITLE
feat: resolve #431 - add headless program tests for interactive samples

### DIFF
--- a/test/program/interactive/beep-interactive.test.ts
+++ b/test/program/interactive/beep-interactive.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('beep-interactive program', () => {
+  it('triggers BEEP on button A and exits on START', async () => {
+    const tp = TestProgram.fromSample('beepInteractive')
+
+    // STRIG(0) is consumed each loop iteration (line 50).
+    // Bit 8 = button A (trigger BEEP), bit 1 = START (exit).
+    // Push: button A press (8) -> BEEP, then START press (1) -> exit to "Goodbye!"
+    tp.pushStrigState(0, 8) // T=8: (8 AND 8)=8 -> BEEP, (8 AND 1)=0 -> no exit
+    tp.pushStrigState(0, 1) // T=1: (1 AND 8)=0 -> no BEEP, (1 AND 1)=1 -> exit
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'PRESS A TO BEEP')
+    tp.expectRowText(1, 'PRESS START TO EXIT')
+    tp.expectRowText(2, 'GOODBYE!')
+
+    // Verify BEEP was triggered at least once
+    expect(tp.getAdapter().beepCalls).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/test/program/interactive/inkey-blocking.test.ts
+++ b/test/program/interactive/inkey-blocking.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('inkey-blocking program', () => {
+  it('reads blocking INKEY$(0) characters and exits on Q', async () => {
+    const tp = TestProgram.fromSample('inkeyBlockingTest')
+
+    // INKEY$(0) uses waitForInkeyBlocking which pops from queue.
+    // Program loop: read char -> print char+code -> check Q -> loop or end.
+    // Queue: 'H' (first loop), 'Q' (second loop triggers exit)
+    tp.queueInkey('H')
+    tp.queueInkey('Q')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // Row 0: "=== INKEY$(0) BLOCKING TEST ===" truncated at 28 chars
+    tp.expectRowText(0, 'INKEY$(0) BLOCKING')
+    tp.expectRowText(1, 'THIS MODE WAITS')
+    // Row 3: "Enter character: " + 'H' + " (code " + 72 + ")"
+    tp.expectRowText(3, 'ENTER CHARACTER: H')
+    // "Done!" printed after Q exit
+    tp.expectRowText(7, 'DONE!')
+  })
+})

--- a/test/program/interactive/inkey-test.test.ts
+++ b/test/program/interactive/inkey-test.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('inkey-test program', () => {
+  it('reads non-blocking INKEY$ and exits on Q', async () => {
+    const tp = TestProgram.fromSample('inkeyTest')
+
+    // INKEY$ (non-blocking) returns the persistent inkeyState.
+    // Program loops: check INKEY$, if empty loop, if Q exit, else print+loop.
+    // Since inkeyState persists, setting anything other than Q causes infinite loop.
+    // Set 'Q' to trigger the exit path immediately.
+    tp.setInkeyState('Q')
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'INKEY$ TEST')
+    tp.expectRowText(1, 'PRESS ANY KEY TO SEE IT')
+    tp.expectRowText(2, 'PRESS Q TO QUIT')
+    tp.expectRowText(4, 'GOODBYE!')
+  })
+})

--- a/test/program/interactive/joystick.test.ts
+++ b/test/program/interactive/joystick.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('joystick program', () => {
+  it('reads joystick direction and exits on button press', async () => {
+    const tp = TestProgram.fromSample('joystick')
+
+    // STICK(0) reads persistent state; STRIG(0) consumes from buffer.
+    // Set stick direction to 1 (right), then push STRIG values:
+    //  0 = idle (loop continues), 1 = exit button
+    tp.setStickState(0, 1) // direction: right
+    tp.pushStrigState(0, 0) // first iteration: no button press
+    tp.pushStrigState(0, 0) // second iteration: still idle
+    tp.pushStrigState(0, 1) // third iteration: exit
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, 'JOYSTICK TEST')
+    // When direction changes from L1=0 to S=1, line 80 prints " 1"
+    tp.expectRowText(1, ' 1')
+  })
+})

--- a/test/program/interactive/sprite-interactive.test.ts
+++ b/test/program/interactive/sprite-interactive.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { TestProgram } from '../../integration/TestProgram'
+
+describe('sprite-interactive program', () => {
+  it('processes sprite setup and joystick movement', async () => {
+    // sprite-interactive runs an infinite loop (IF T=1 THEN 190 -> GOTO 80).
+    // Use reduced maxIterations so the test finishes quickly.
+    const tp = TestProgram.fromSample('spriteInteractive', {
+      maxIterations: 500,
+    })
+
+    // Set stick to direction 1 (right) so PX increments by 2 each movement cycle.
+    // STRIG is consumed each loop iteration; push enough zeros for idle iterations.
+    tp.setStickState(0, 1) // direction: right
+    for (let i = 0; i < 50; i++) {
+      tp.pushStrigState(0, 0) // idle: no button press
+    }
+
+    const result = await tp.run()
+
+    // Program runs until max iterations — expect the iteration error
+    expect(result.executionResult.success).toBe(false)
+    expect(result.executionResult.errors[0]?.message).toContain('Maximum iterations exceeded')
+
+    // CLS was called at program start (line 10)
+    expect(tp.getAdapter().getClearScreenCallCount()).toBeGreaterThanOrEqual(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #431 — adds headless Vitest tests for interactive category samples (Step 8 of 8 for #423)

## Changes
- `beep-interactive.test.ts` — STRIG button polling with pushStrigState
- `inkey-blocking.test.ts` — blocking INKEY$(0) with queueInkey (H then Q)
- `inkey-test.test.ts` — non-blocking INKEY$ with setInkeyState
- `joystick.test.ts` — STICK direction + STRIG with setStickState
- `sprite-interactive.test.ts` — sprite movement with joystick, capped at 500 iterations (infinite loop program)

This PR **completes the 8-step program test coverage** for #423.

## Test plan
- [x] All 3323 tests pass (including 5 new interactive tests)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes