### PR TITLE
test: resolve #448 - add screen assertions to rockn-rouge headless test

### DIFF
--- a/test/program/music/rockn-rouge.test.ts
+++ b/test/program/music/rockn-rouge.test.ts
@@ -3,8 +3,9 @@ import { describe, it } from 'vitest'
 import { TestProgram } from '../../integration/TestProgram'
 
 describe('rockn-rouge program', () => {
-  // Long program (~450 lines) with many PLAY commands and loop structures
-  it('runs successfully without errors', async () => {
+  // Long program (~450 lines) with PLAY commands, IF/GOTO loops, and no PRINT.
+  // All screen rows should remain blank since the program produces no text output.
+  it('runs successfully with empty screen (no PRINT output)', async () => {
     const tp = TestProgram.fromSample('musicRocknRouge')
 
     await tp.run({
@@ -12,5 +13,9 @@ describe('rockn-rouge program', () => {
     })
 
     tp.expectSuccess()
+    // Program has no PRINT statements — screen should stay blank
+    tp.expectRowText(0, /^\s*$/)
+    tp.expectRowText(1, /^\s*$/)
+    tp.expectRowText(23, /^\s*$/)
   }, 30_000)
 })


### PR DESCRIPTION
## Summary
- Fixes #448

## Changes
- Add 3 `expectRowText()` assertions to rockn-rouge headless test verifying blank screen rows (program has zero PRINT statements, so all rows should be empty)

## Test plan
- [x] Targeted tests pass (`test/program/music/rockn-rouge.test.ts`)
- [ ] CI passes