### PR TITLE
test: resolve #449 - add song playback path to player headless test

### DIFF
--- a/test/program/music/player.test.ts
+++ b/test/program/music/player.test.ts
@@ -19,4 +19,48 @@ describe('player program', () => {
     tp.expectRowText(7, '4. EXIT')
     tp.expectRowText(9, 'GOODBYE!')
   })
+
+  it('plays Twinkle Twinkle (option 1) then exits', async () => {
+    const tp = TestProgram.fromSample('musicPlayer')
+    tp.seedInput(['1'])
+    tp.seedInput(['4'])
+
+    await tp.run()
+
+    tp.expectSuccess()
+    // After song plays, program loops back to menu via GOTO 10 (which CLS)
+    // Final screen: menu re-drawn + Goodbye! from selecting exit
+    tp.expectRowText(0, '====================')
+    tp.expectRowText(1, '   F-BASIC JUKEBOX')
+    tp.expectRowText(2, '====================')
+    tp.expectRowText(9, 'GOODBYE!')
+  })
+
+  it('plays C Major Scale (option 2) then exits', async () => {
+    const tp = TestProgram.fromSample('musicPlayer')
+    tp.seedInput(['2'])
+    tp.seedInput(['4'])
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, '====================')
+    tp.expectRowText(1, '   F-BASIC JUKEBOX')
+    tp.expectRowText(2, '====================')
+    tp.expectRowText(9, 'GOODBYE!')
+  })
+
+  it('plays Chord Progression (option 3) then exits', async () => {
+    const tp = TestProgram.fromSample('musicPlayer')
+    tp.seedInput(['3'])
+    tp.seedInput(['4'])
+
+    await tp.run()
+
+    tp.expectSuccess()
+    tp.expectRowText(0, '====================')
+    tp.expectRowText(1, '   F-BASIC JUKEBOX')
+    tp.expectRowText(2, '====================')
+    tp.expectRowText(9, 'GOODBYE!')
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes #449

## Changes
- Add 3 song playback tests to player.test.ts covering options 1-3 (Twinkle Twinkle, C Major Scale, Chord Progression)
- Each test seeds two inputs: song selection then exit, verifying the full play-and-return cycle

## Test plan
- [x] Targeted tests pass (`test/program/music/player.test.ts`)
- [ ] CI passes