### PR TITLE
style: resolve #450 - document assertion pattern conventions in headless tests

### DIFF
--- a/test/integration/TestProgram.ts
+++ b/test/integration/TestProgram.ts
@@ -282,7 +282,9 @@ export class TestProgram {
    * Assert text content of a specific row in the display snapshot.
    *
    * @param row - Row index (0-based)
-   * @param expected - Expected text (partial match via RegExp or exact match)
+   * @param expected - Expected text. Use string for exact substring match,
+   *   RegExp when output has variable-width spacing (e.g. PRINT "X";N where
+   *   N is a number with sign-char padding).
    */
   expectRowText(row: number, expected: string | RegExp): void {
     if (!this.lastResult?.snapshot) {

--- a/test/program/music/twinkle.test.ts
+++ b/test/program/music/twinkle.test.ts
@@ -11,7 +11,8 @@ describe('twinkle program', () => {
     tp.expectSuccess()
     tp.expectRowText(0, 'TWINKLE TWINKLE LITTLE STAR')
     tp.expectRowText(1, '===========================')
-    // PRINT "Verse ";V produces "VERSE " + V with space padding
+    // RegExp: PRINT "Verse ";V concatenates string + number (with sign-char space),
+    // producing variable-width spacing like "VERSE  2" — use \s+ to be resilient.
     tp.expectRowText(3, /VERSE\s+2/)
     tp.expectRowText(5, 'SONG COMPLETE!')
   })


### PR DESCRIPTION
## Summary
- Fixes #450

## Changes
- Document when to use string vs RegExp in `expectRowText()` JSDoc (TestProgram.ts)
- Clarify the regex comment in twinkle.test.ts explaining why RegExp is needed for variable-width number concatenation output

## Test plan
- [x] Targeted tests pass (`test/program/`)
- [ ] CI passes