### PR TITLE
refactor: resolve #454 - export DEFAULT_STABLE_OPTIONS for shared test config

### DIFF
--- a/test/integration/TestProgram.ts
+++ b/test/integration/TestProgram.ts
@@ -87,7 +87,11 @@ const DEFAULT_OPTIONS: Required<TestProgramOptions> = {
   suppressOkPrompt: true,
 }
 
-const DEFAULT_STABLE_OPTIONS: WaitForStableOptions = {
+/**
+ * Shared stable-wait defaults for headless program tests.
+ * Spread-override as needed: `{ ...DEFAULT_STABLE_OPTIONS, timeoutMs: 10000 }`
+ */
+export const DEFAULT_STABLE_OPTIONS: WaitForStableOptions = {
   stablePolls: 3,
   intervalMs: 20,
   timeoutMs: 1000,

--- a/test/program/control/pause.test.ts
+++ b/test/program/control/pause.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
 
 describe('pause program', () => {
   // PAUSE uses real setTimeout — total ~11s of delays, needs extended timeout
@@ -10,7 +10,7 @@ describe('pause program', () => {
     // PAUSE 0 blocks waiting for keypress — queue one to unblock
     tp.queueInkey('A')
 
-    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 } })
 
     tp.expectSuccess()
     // CLS at line 30 clears screen

--- a/test/program/music/bgplay-demo.test.ts
+++ b/test/program/music/bgplay-demo.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
 
 describe('bgplay-demo program', () => {
   // BGPLAY + PAUSE 30 in part 1, then CLS and interactive game loop with STRIG exit.
@@ -10,7 +10,7 @@ describe('bgplay-demo program', () => {
     // Queue START button press (bit 0) to exit the Part 2 game loop
     tp.pushStrigState(0, 1)
 
-    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 } })
 
     tp.expectSuccess()
     // After Part 2 CLS, screen shows game loop header

--- a/test/program/music/play-demo.test.ts
+++ b/test/program/music/play-demo.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
 
 describe('play-demo program', () => {
   // PLAY + PAUSE 30 sections — total ~3s of PAUSE delays
   it('runs successfully and produces expected output', async () => {
     const tp = TestProgram.fromSample('musicPlayDemo')
 
-    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 } })
 
     tp.expectSuccess()
     tp.expectRowText(0, '=== PLAY DEMO ===')

--- a/test/program/music/rockn-rouge.test.ts
+++ b/test/program/music/rockn-rouge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
 
 describe('rockn-rouge program', () => {
   // Long program (~450 lines) with many PLAY commands and loop structures
@@ -8,7 +8,7 @@ describe('rockn-rouge program', () => {
     const tp = TestProgram.fromSample('musicRocknRouge')
 
     await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 },
     })
 
     tp.expectSuccess()

--- a/test/program/screen/cursor-position.test.ts
+++ b/test/program/screen/cursor-position.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
 
 describe('cursor-position program', () => {
   // PAUSE 50 per loop iteration × 16 iterations ≈ 16s total, needs extended timeout
   it('runs successfully and shows cursor position output', async () => {
     const tp = TestProgram.fromSample('cursorPosition')
 
-    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 } })
 
     tp.expectSuccess()
     // LOCATE I,I for I=0..15 → diagonal POS/LINE output


### PR DESCRIPTION
## Summary
- Fixes #454

## Changes
- Export `DEFAULT_STABLE_OPTIONS` from TestProgram.ts (was already defined but unexported)
- Replace 5 inline `stableOptions` objects with spread-override pattern: `{ ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 }`

## Test plan
- [x] All 3318 tests pass (including all `test/program/` tests)
- [ ] CI passes