### PR TITLE
refactor: resolve #459 - add typed generic parameter to cloneAsMutable

### DIFF
--- a/src/shared/data/palette.ts
+++ b/src/shared/data/palette.ts
@@ -121,12 +121,14 @@ const RAW_BACKGROUND_PALETTES = [
 
 // ---------------------------------------------------------------------------
 // Deep-clone helper — produces mutable arrays from raw const data.
-// The `as unknown` cast is needed because `as const` produces deeply-nested
-// readonly tuple types that are not assignable to mutable array types.
+// Accepts deeply-readonly tuple/array types (from `as const` assertions)
+// and returns fully mutable `number[][][]` for runtime mutation.
 // ---------------------------------------------------------------------------
 
-function cloneAsMutable(raw: unknown): number[][][] {
-  return (raw as number[][][]).map(palette =>
+function cloneAsMutable<T extends ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>>(
+  raw: T
+): number[][][] {
+  return raw.map(palette =>
     palette.map(combination => [...combination])
   )
 }


### PR DESCRIPTION
## Summary
- Fixes #459

## Changes
- Replaced `cloneAsMutable(raw: unknown): number[][][]` with generic `cloneAsMutable<T extends ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>>`
- Removed unsafe `as number[][][]` cast from function body — `raw.map(...)` now works directly via generic constraint
- Updated JSDoc to describe generic behavior
- Call-site tuple-narrowing casts remain (legitimate narrowing from general to specific tuple types)

## Test plan
- [x] All 3342 tests pass
- [x] Type-check passes
- [x] ESLint passes