### PR TITLE
fix: resolve #483 - normalize tab header casing to PALETTE in State Inspector

### DIFF
--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -386,7 +386,7 @@
   },
   "stateInspector": {
     "title": "State Inspector",
-    "tabPalettes": "Palettes",
+    "tabPalettes": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
     "tabBg": "BG",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -386,7 +386,7 @@
   },
   "stateInspector": {
     "title": "状態インスペクタ",
-    "tabPalettes": "パレット",
+    "tabPalettes": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
     "tabBg": "BG",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -386,7 +386,7 @@
   },
   "stateInspector": {
     "title": "状态检查",
-    "tabPalettes": "调色板",
+    "tabPalettes": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
     "tabBg": "BG",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -386,7 +386,7 @@
   },
   "stateInspector": {
     "title": "狀態檢查",
-    "tabPalettes": "調色盤",
+    "tabPalettes": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
     "tabBg": "BG",

--- a/test/ide/StateInspector.test.ts
+++ b/test/ide/StateInspector.test.ts
@@ -4,6 +4,7 @@ import { defineComponent } from 'vue'
 
 import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import StateInspector from '@/features/ide/components/StateInspector.vue'
+import enIde from '@/shared/i18n/locales/en/ide.json'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -83,5 +84,20 @@ describe('StateInspector MOVE tab data', () => {
     expect(emptySlot.attributes('data-has-data')).toBe('false')
 
     wrapper.unmount()
+  })
+})
+
+describe('StateInspector tab header casing consistency', () => {
+  it('all inspector tab labels are uppercase in English locale', () => {
+    const { tabPalettes, tabSprite, tabMove } = enIde.stateInspector
+
+    expect(tabPalettes).toBe('PALETTE')
+    expect(tabSprite).toBe('SPRITE')
+    expect(tabMove).toBe('MOVE')
+
+    // Regression: all three tab labels must be fully uppercase (F-BASIC keyword style)
+    for (const label of [tabPalettes, tabSprite, tabMove]) {
+      expect(label).toBe(label.toUpperCase())
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #483

## Changes
- Changed `tabPalettes` from "Palettes"/"パレット"/"调色板"/"調色盤" to "PALETTE" across all 4 locales (en, ja, zh-CN, zh-TW)
- All State Inspector tab headers now consistently use uppercase F-BASIC keyword style: PALETTE, SPRITE, MOVE, BG

## Test plan
- [x] Regression test: verifies all tab labels are uppercase in English locale
- [x] All 3343 tests pass
- [x] Type-check passes
- [x] ESLint passes