### PR TITLE
fix: resolve #489 - force full screen redraw on PALETB palette combination changes

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -127,6 +127,7 @@ const sharedDisplayViews: SharedDisplayViews = basicIde?.sharedDisplayViews ?? {
 const sharedJoystickBuffer = basicIde?.sharedJoystickBuffer ?? ({} as SharedArrayBuffer)
 const setDecodedScreenState = basicIde?.setDecodedScreenState ?? (() => {})
 const registerScheduleRender = basicIde?.registerScheduleRender ?? (() => {})
+const registerInvalidateBackgroundBuffer = basicIde?.registerInvalidateBackgroundBuffer ?? (() => {})
 const pendingInputRequest = basicIde?.pendingInputRequest ?? ref<RequestInputMessage['data'] | null>(null)
 const respondToInputRequest =
   basicIde?.respondToInputRequest ?? ((_requestId: string, _values: string[], _cancelled: boolean) => {})
@@ -175,6 +176,7 @@ if (!isE2ELite && sharedDisplayViews && sharedDisplayBufferAccessor && sharedAni
     sharedJoystickBuffer: ref(sharedJoystickBuffer),
     setDecodedScreenState,
     registerScheduleRender,
+    registerInvalidateBackgroundBuffer,
     // Callback for animation loop to update inspector MOVE tab data
     updateInspectorMoveSlots: () => bottomAreaRef.value?.updateMoveSlotsData(),
   })

--- a/src/features/ide/components/Screen.vue
+++ b/src/features/ide/components/Screen.vue
@@ -338,6 +338,17 @@ watch(
   { immediate: true }
 )
 
+// Register buffer invalidation callback for palette changes (PALETB etc.)
+// Nullifying lastBackgroundBufferRef forces the dirty renderer to do a full redraw
+// since renderBackgroundToCanvasDirty falls back to full render when lastBuffer is null.
+watch(
+  () => ctx.registerInvalidateBackgroundBuffer,
+  fn => {
+    if (fn) fn(() => { lastBackgroundBufferRef.value = null })
+  },
+  { immediate: true }
+)
+
 // Watch screenBuffer and render when it changes (PRINT). Use full when movements > nodes.
 // When using shared buffer, SCREEN_CHANGED triggers scheduleRender; this watch still runs for ref updates.
 watch(

--- a/src/features/ide/composables/messageHandlerContext.ts
+++ b/src/features/ide/composables/messageHandlerContext.ts
@@ -49,6 +49,8 @@ export interface MessageHandlerContext {
   scheduleRender?: () => void
   /** Coalesced version: at most one schedule per frame. Prefer this for SCREEN_CHANGED to avoid main-thread flood. */
   scheduleRenderForScreenChanged?: () => void
+  /** Invalidate last-rendered background buffer so next render does a full redraw (e.g. after palette change). */
+  invalidateBackgroundBuffer?: () => void
   /** Called by Screen.vue after decoding shared buffer to update refs (screenBuffer, cursorX, etc.). */
   setDecodedScreenState?: (decoded: DecodedScreenState) => void
   /** Pending INPUT/LINPUT request from worker; set when REQUEST_INPUT is received, cleared on submit/cancel. */

--- a/src/features/ide/composables/screenHandlers.ts
+++ b/src/features/ide/composables/screenHandlers.ts
@@ -234,6 +234,10 @@ function handlePaletteCombinationUpdate(context: MessageHandlerContext, update: 
     )
     clearBackgroundTileCache()
     clearSpriteImageCache()
+    // Invalidate last-rendered buffer so dirty renderer does a full redraw.
+    // PALETB changes palette data without modifying the screen buffer,
+    // so without this the dirty renderer would skip all cells (no buffer change detected).
+    context.invalidateBackgroundBuffer?.()
     context.scheduleRender?.()
     logComposable.debug('Updated runtime palette combination:', {
       target: update.paletteTarget,

--- a/src/features/ide/composables/useBasicIdeEnhanced.ts
+++ b/src/features/ide/composables/useBasicIdeEnhanced.ts
@@ -149,5 +149,6 @@ export function useBasicIde() {
     sharedJoystickBuffer: screen.sharedJoystickBuffer,
     setDecodedScreenState: screen.setDecodedScreenState,
     registerScheduleRender: screen.registerScheduleRender,
+    registerInvalidateBackgroundBuffer: screen.registerInvalidateBackgroundBuffer,
   }
 }

--- a/src/features/ide/composables/useBasicIdeScreenIntegration.ts
+++ b/src/features/ide/composables/useBasicIdeScreenIntegration.ts
@@ -32,7 +32,11 @@ export interface BasicIdeScreenIntegration {
   sharedKeyboardBuffer: SharedArrayBuffer
   sharedKeyboardBufferView: KeyboardBufferView
   registerScheduleRender: (fn: () => void) => void
+  /** Register callback from Screen.vue to invalidate last-rendered background buffer. */
+  registerInvalidateBackgroundBuffer: (fn: () => void) => void
   setDecodedScreenState: (decoded: DecodedScreenState) => void
+  /** Invalidate last-rendered background buffer so next render does a full redraw. */
+  invalidateBackgroundBuffer: () => void
   /** Called by message handlers when SCREEN_CHANGED is received. */
   scheduleRender: () => void
   /** Coalesced: at most one scheduleRender per frame. Use for SCREEN_CHANGED to avoid main-thread flood. */
@@ -62,6 +66,12 @@ export function useBasicIdeScreenIntegration(state: BasicIdeState): BasicIdeScre
   const registerScheduleRender = (fn: () => void) => {
     scheduleScreenRenderRef.value = fn
   }
+
+  const invalidateBackgroundBufferRef = ref<(() => void) | null>(null)
+  const registerInvalidateBackgroundBuffer = (fn: () => void) => {
+    invalidateBackgroundBufferRef.value = fn
+  }
+  const invalidateBackgroundBuffer = () => invalidateBackgroundBufferRef.value?.()
 
   const setDecodedScreenState = (decoded: DecodedScreenState) => {
     state.screenBuffer.value = decoded.buffer
@@ -155,7 +165,9 @@ export function useBasicIdeScreenIntegration(state: BasicIdeState): BasicIdeScre
     sharedKeyboardBuffer,
     sharedKeyboardBufferView,
     registerScheduleRender,
+    registerInvalidateBackgroundBuffer,
     setDecodedScreenState,
+    invalidateBackgroundBuffer,
     scheduleRender,
     scheduleRenderForScreenChanged,
     clearDisplayToSharedBuffer,

--- a/src/features/ide/composables/useBasicIdeWorkerIntegration.ts
+++ b/src/features/ide/composables/useBasicIdeWorkerIntegration.ts
@@ -67,6 +67,7 @@ export function useBasicIdeWorkerIntegration(
     sharedDisplayViews: screen.sharedDisplayViews,
     scheduleRender: screen.scheduleRender,
     scheduleRenderForScreenChanged: screen.scheduleRenderForScreenChanged,
+    invalidateBackgroundBuffer: screen.invalidateBackgroundBuffer,
     setDecodedScreenState: screen.setDecodedScreenState,
     pendingInputRequest: state.pendingInputRequest,
     respondToInputRequest: respondToInputRequestImpl,

--- a/src/features/ide/composables/useScreenContext.ts
+++ b/src/features/ide/composables/useScreenContext.ts
@@ -41,6 +41,8 @@ export interface ScreenContextValue {
   sharedJoystickBuffer: Ref<SharedArrayBuffer | undefined>
   setDecodedScreenState: (decoded: DecodedScreenState) => void
   registerScheduleRender: (fn: () => void) => void
+  /** Register callback to invalidate last-rendered background buffer for full redraw. */
+  registerInvalidateBackgroundBuffer?: (fn: () => void) => void
   /** Callback to update inspector MOVE tab data (called by animation loop every frame). */
   updateInspectorMoveSlots?: () => void
 }

--- a/test/ide/useBasicIdeMessageHandlers.test.ts
+++ b/test/ide/useBasicIdeMessageHandlers.test.ts
@@ -22,7 +22,7 @@ function restorePalettes(target: RuntimePalettes, snapshot: PaletteSnapshot): vo
   })
 }
 
-function createContext(scheduleRender: () => void): MessageHandlerContext {
+function createContext(scheduleRender: () => void, invalidateBackgroundBuffer?: () => void): MessageHandlerContext {
   return {
     output: ref([]),
     errors: ref([]),
@@ -35,6 +35,7 @@ function createContext(scheduleRender: () => void): MessageHandlerContext {
       pendingMessages: new Map(),
     } as MessageHandlerContext['webWorkerManager'],
     scheduleRender,
+    invalidateBackgroundBuffer,
   }
 }
 
@@ -101,6 +102,33 @@ describe('useBasicIdeMessageHandlers palette combination updates', () => {
     )
 
     expect(SPRITE_PALETTES[2][3]).toEqual([1, 2, 3, 4])
+    expect(scheduleRender).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidates background buffer on palette-combination update (regression #489)', () => {
+    const scheduleRender = vi.fn()
+    const invalidateBackgroundBuffer = vi.fn()
+    const context = createContext(scheduleRender, invalidateBackgroundBuffer)
+
+    handleScreenUpdateMessage(
+      {
+        type: 'SCREEN_UPDATE',
+        id: 'test-invalidate-bg',
+        timestamp: Date.now(),
+        data: {
+          executionId: 'exec-3',
+          updateType: 'palette-combination',
+          paletteTarget: 'B',
+          paletteIndex: 0,
+          paletteCombination: 1,
+          paletteColors: [10, 20, 30, 40],
+          timestamp: Date.now(),
+        },
+      } as never,
+      context
+    )
+
+    expect(invalidateBackgroundBuffer).toHaveBeenCalledTimes(1)
     expect(scheduleRender).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #489

## Changes
- Added `invalidateBackgroundBuffer` callback to `MessageHandlerContext` interface
- `handlePaletteCombinationUpdate` now calls `context.invalidateBackgroundBuffer()` before `scheduleRender()` to null out `lastBackgroundBufferRef`
- When the dirty renderer sees null buffer, it performs a full redraw — fixing the bug where PALETB changes were invisible
- Wired through composable chain: `useBasicIdeScreenIntegration` → `useBasicIdeWorkerIntegration` → `useBasicIdeEnhanced` → `Screen.vue`
- Regression test: verifies `invalidateBackgroundBuffer` is called on palette-combination update

## Root Cause
PALETB updates palette data (BACKGROUND_PALETTES arrays) without modifying the screen buffer. The dirty renderer compared old vs new buffer cells, found zero changes, and skipped repainting entirely.

## Test plan
- [x] Regression test passes (invalidates background buffer on palette-combination update)
- [x] All 3343 tests pass
- [x] Type-check passes
- [x] ESLint passes