### PR TITLE
style: resolve #460 - normalize vitest import spacing in headless program test files

### DIFF
--- a/test/program/comprehensive/knight.test.ts
+++ b/test/program/comprehensive/knight.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect,it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { TestProgram } from '../../integration/TestProgram'
 

--- a/test/program/comprehensive/scr-sample.test.ts
+++ b/test/program/comprehensive/scr-sample.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect,it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { TestProgram } from '../../integration/TestProgram'
 

--- a/test/program/comprehensive/ufo.test.ts
+++ b/test/program/comprehensive/ufo.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect,it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { TestProgram } from '../../integration/TestProgram'
 


### PR DESCRIPTION
## Summary
- Fixes #460

## Changes
- Fixed missing space after comma in vitest imports across 3 comprehensive test files
- `import { describe, expect,it }` → `import { describe, expect, it }`
- Files: knight.test.ts, scr-sample.test.ts, ufo.test.ts

## Test plan
- [x] All 3342 tests pass
- [x] Type-check passes
- [x] ESLint passes