### PR TITLE
refactor: resolve #476 - eliminate duplicate module path in DisplaySnapshotV1 import/export

### DIFF
--- a/test/screen-assertions.ts
+++ b/test/screen-assertions.ts
@@ -21,8 +21,8 @@ import type { DecodedScreenState } from '@/core/animation/sharedDisplayBufferAcc
 import type { BgCell, BgGridData } from '@/features/bg-editor/types'
 
 // Re-export snapshot type so consumers can use a single import
-export type { DisplaySnapshotV1 } from './integration/displaySnapshotTestUtils'
 import type { DisplaySnapshotV1 } from './integration/displaySnapshotTestUtils'
+export type { DisplaySnapshotV1 }
 
 // ============================================================================
 // Unified screen source types


### PR DESCRIPTION
## Summary
- Fixes #476

## Changes
- Restructured `export type { DisplaySnapshotV1 } from '...'` + `import type { DisplaySnapshotV1 } from '...'` to `import type` first, then `export type` re-export
- Eliminates duplicate module path reference while preserving both the local type usage and the re-export for consumers

## Note
The original issue claimed the `import type` was redundant, but `export type { X } from '...'` is a pure re-export that doesn't introduce the name into local scope. The `import type` was needed for local type annotations (lines 37, 52, 105, 199, 223). The fix restructures the order to avoid the duplicate module path.

## Test plan
- [x] All 3342 tests pass
- [x] Type-check passes