### PR TITLE
refactor: resolve #464 - extract shared palette reset helper to reduce duplication

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -207,6 +207,18 @@ export const PALETTE_DEFAULTS = {
   CGEN_MODE: 2,
 } as const
 
+/**
+ * Reset palette-related state fields to their default values.
+ * Accepts a setter callback to support both direct field assignment
+ * (e.g. ScreenStateManager private fields) and reactive ref assignment
+ * (e.g. Vue .value refs in useBasicIdeExecution).
+ */
+export function resetPaletteState(
+  setter: (defaults: typeof PALETTE_DEFAULTS) => void
+): void {
+  setter(PALETTE_DEFAULTS)
+}
+
 // Color patterns and codes
 export const COLOR_PATTERNS = {
   MIN: 0, // Minimum color pattern number

--- a/src/core/devices/ScreenStateManager.ts
+++ b/src/core/devices/ScreenStateManager.ts
@@ -4,7 +4,7 @@
  * Manages screen buffer, cursor position, and screen-related operations.
  */
 
-import { PALETTE_DEFAULTS } from '@/core/constants'
+import { PALETTE_DEFAULTS, resetPaletteState } from '@/core/constants'
 import type { ScreenCell } from '@/core/types/execution-types'
 import type { ScreenUpdateMessage } from '@/core/types/worker-messages'
 import { ORIGINAL_BACKGROUND_PALETTES, ORIGINAL_SPRITE_PALETTES } from '@/shared/data/palette'
@@ -80,10 +80,12 @@ export class ScreenStateManager {
     this.cursorX = 0
     this.cursorY = 0
     // Reset BG/screen state to defaults so stale data does not persist
-    this.bgPalette = PALETTE_DEFAULTS.BG_PALETTE
-    this.spritePalette = PALETTE_DEFAULTS.SPRITE_PALETTE
-    this.backdropColor = PALETTE_DEFAULTS.BACKDROP_COLOR
-    this.cgenMode = PALETTE_DEFAULTS.CGEN_MODE
+    resetPaletteState((d) => {
+      this.bgPalette = d.BG_PALETTE
+      this.spritePalette = d.SPRITE_PALETTE
+      this.backdropColor = d.BACKDROP_COLOR
+      this.cgenMode = d.CGEN_MODE
+    })
     // Reset palette combinations to original data
     this.resetPalettes()
   }

--- a/src/features/ide/composables/useBasicIdeExecution.ts
+++ b/src/features/ide/composables/useBasicIdeExecution.ts
@@ -3,7 +3,7 @@
  * Depends on state, worker integration, and parseCode from editor.
  */
 
-import { ERROR_MESSAGES, EXECUTION_LIMITS, PALETTE_DEFAULTS } from '@/core/constants'
+import { ERROR_MESSAGES, EXECUTION_LIMITS, resetPaletteState } from '@/core/constants'
 import type { BasicVariable } from '@/core/types/state-types'
 import { ExecutionError } from '@/features/ide/errors/ExecutionError'
 import { resetRuntimePalettes } from '@/shared/data/palette'
@@ -59,10 +59,12 @@ export function useBasicIdeExecution(
     resetRuntimePalettes()
     // Reactive state (bgPalette, cgenMode, etc.) — the worker does not send
     // initial palette values at the start of execution, so we must reset here.
-    state.bgPalette.value = PALETTE_DEFAULTS.BG_PALETTE
-    state.spritePalette.value = PALETTE_DEFAULTS.SPRITE_PALETTE
-    state.backdropColor.value = PALETTE_DEFAULTS.BACKDROP_COLOR
-    state.cgenMode.value = PALETTE_DEFAULTS.CGEN_MODE
+    resetPaletteState((d) => {
+      state.bgPalette.value = d.BG_PALETTE
+      state.spritePalette.value = d.SPRITE_PALETTE
+      state.backdropColor.value = d.BACKDROP_COLOR
+      state.cgenMode.value = d.CGEN_MODE
+    })
 
     try {
       await worker.initializeWebWorker()
@@ -196,10 +198,12 @@ export function useBasicIdeExecution(
     state.cursorX.value = 0
     state.cursorY.value = 0
     // Reset BG/screen state to defaults so stale palettes, backdrop, and cgen do not persist
-    state.bgPalette.value = PALETTE_DEFAULTS.BG_PALETTE
-    state.spritePalette.value = PALETTE_DEFAULTS.SPRITE_PALETTE
-    state.backdropColor.value = PALETTE_DEFAULTS.BACKDROP_COLOR
-    state.cgenMode.value = PALETTE_DEFAULTS.CGEN_MODE
+    resetPaletteState((d) => {
+      state.bgPalette.value = d.BG_PALETTE
+      state.spritePalette.value = d.SPRITE_PALETTE
+      state.backdropColor.value = d.BACKDROP_COLOR
+      state.cgenMode.value = d.CGEN_MODE
+    })
     // Clear BG items (above), SPRITEs (DEF SPRITE + display)
     state.spriteStates.value = []
     // Do NOT clear spriteEnabled - SPRITE ON/OFF state should persist (Clear only clears display)


### PR DESCRIPTION
## Summary
- Fixes #464
- Extracts `resetPaletteState()` callback-based helper to `src/core/constants.ts` next to `PALETTE_DEFAULTS`
- Replaces 3 duplicated 4-line palette reset patterns in `ScreenStateManager` and `useBasicIdeExecution`

## Changes
- `src/core/constants.ts` — added `resetPaletteState(resetter)` function with callback pattern for generic field/reactive ref assignment
- `src/core/devices/ScreenStateManager.ts` — `initializeScreen()` now calls `resetPaletteState()` instead of 4 direct field assignments
- `src/features/ide/composables/useBasicIdeExecution.ts` — both `runCode()` and `clearOutput()` now call `resetPaletteState()` instead of 4 `.value` assignments each

## Test plan
- [x] `ScreenStateManager.test.ts` — 63 tests pass
- [x] `useBasicIdeExecution.test.ts` — all tests pass
- [x] Type-check passes
- [x] ESLint passes
- [x] All files under 500 lines
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)