### PR TITLE
refactor: resolve #466 - add sprite position assertion to sprite-interactive headless test

### DIFF
--- a/test/integration/TestProgram.ts
+++ b/test/integration/TestProgram.ts
@@ -246,6 +246,7 @@ export class TestProgram {
       sharedDisplayBuffer: this.sharedBuffer,
       sharedAnimationBuffer: this.sharedBuffer,
     })
+    this._interpreter = interpreter
 
     const executionResult = await interpreter.execute(this.code)
 
@@ -325,6 +326,24 @@ export class TestProgram {
   }
 
   /**
+   * Get sprite state for a given sprite number after execution.
+   *
+   * Returns the sprite's { x, y, visible } state from SpriteStateManager.
+   * Useful for verifying that SPRITE commands moved sprites to expected positions.
+   *
+   * @param spriteNumber - Sprite slot 0-7
+   * @throws Error if run() has not been called
+   */
+  getSpriteState(spriteNumber: number): { x: number; y: number; visible: boolean } | null {
+    if (!this._interpreter) {
+      throw new Error('No interpreter available. Call run() first.')
+    }
+    const states = this._interpreter.getSpriteStates()
+    const state = states.find((s) => s.spriteNumber === spriteNumber)
+    return state ? { x: state.x, y: state.y, visible: state.visible } : null
+  }
+
+  /**
    * Get the shared display buffer accessor for low-level buffer inspection.
    */
   getAccessor(): SharedDisplayBufferAccessor {
@@ -339,4 +358,5 @@ export class TestProgram {
   }
 
   private _lastResult: TestProgramResult | null = null
+  private _interpreter: BasicInterpreter | null = null
 }

--- a/test/program/interactive/sprite-interactive.test.ts
+++ b/test/program/interactive/sprite-interactive.test.ts
@@ -25,5 +25,13 @@ describe('sprite-interactive program', () => {
 
     // CLS was called at program start (line 10)
     expect(tp.getAdapter().getClearScreenCallCount()).toBeGreaterThanOrEqual(1)
+
+    // Sprite 0 started at PX=150 and increments by 2 each movement cycle
+    // (STICK direction=1 → right). With 500 iterations, the sprite must have
+    // advanced well beyond the initial X position.
+    const spriteState = tp.getSpriteState(0)
+    expect(spriteState).not.toBeNull()
+    expect(spriteState!.visible).toBe(true)
+    expect(spriteState!.x).toBeGreaterThan(150)
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #466
- Adds `getSpriteState()` method to `TestProgram` for reading sprite position/visibility
- Adds 3 assertions to sprite-interactive test verifying sprite X position advances

## Changes
- `test/integration/TestProgram.ts` (+20) — Added `_interpreter` field and `getSpriteState(spriteNumber)` method returning `{ x, y, visible }`
- `test/program/interactive/sprite-interactive.test.ts` (+8) — Asserts sprite 0 is visible and X position > 150 after movement

## Test plan
- [x] sprite-interactive.test.ts passes
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)