### PR TITLE
refactor: resolve #469 - parameterize player.test.ts song playback tests with it.each

### DIFF
--- a/test/program/music/player.test.ts
+++ b/test/program/music/player.test.ts
@@ -20,9 +20,13 @@ describe('player program', () => {
     tp.expectRowText(9, 'GOODBYE!')
   })
 
-  it('plays Twinkle Twinkle (option 1) then exits', async () => {
+  it.each([
+    ['1', 'Twinkle Twinkle'],
+    ['2', 'C Major Scale'],
+    ['3', 'Chord Progression'],
+  ] as const)('plays option %s (%s) then exits', async (option, _name) => {
     const tp = TestProgram.fromSample('musicPlayer')
-    tp.seedInput(['1'])
+    tp.seedInput([option])
     tp.seedInput(['4'])
 
     await tp.run()
@@ -30,34 +34,6 @@ describe('player program', () => {
     tp.expectSuccess()
     // After song plays, program loops back to menu via GOTO 10 (which CLS)
     // Final screen: menu re-drawn + Goodbye! from selecting exit
-    tp.expectRowText(0, '====================')
-    tp.expectRowText(1, '   F-BASIC JUKEBOX')
-    tp.expectRowText(2, '====================')
-    tp.expectRowText(9, 'GOODBYE!')
-  })
-
-  it('plays C Major Scale (option 2) then exits', async () => {
-    const tp = TestProgram.fromSample('musicPlayer')
-    tp.seedInput(['2'])
-    tp.seedInput(['4'])
-
-    await tp.run()
-
-    tp.expectSuccess()
-    tp.expectRowText(0, '====================')
-    tp.expectRowText(1, '   F-BASIC JUKEBOX')
-    tp.expectRowText(2, '====================')
-    tp.expectRowText(9, 'GOODBYE!')
-  })
-
-  it('plays Chord Progression (option 3) then exits', async () => {
-    const tp = TestProgram.fromSample('musicPlayer')
-    tp.seedInput(['3'])
-    tp.seedInput(['4'])
-
-    await tp.run()
-
-    tp.expectSuccess()
     tp.expectRowText(0, '====================')
     tp.expectRowText(1, '   F-BASIC JUKEBOX')
     tp.expectRowText(2, '====================')


### PR DESCRIPTION
## Summary
- Fixes #469

## Changes
- Consolidated 3 structurally identical song playback tests (options 1, 2, 3) into a single `it.each([['1', 'Twinkle Twinkle'], ['2', 'C Major Scale'], ['3', 'Chord Progression']] as const)` parameterized test
- Net -24 lines (67 → 43 lines)

## Test plan
- [x] All 4 player tests pass (1 exit + 3 parameterized song tests)
- [ ] CI passes