### PR TITLE
refactor: resolve #473 - use PALETTE_DEFAULTS constants in PALETTE_REFS test data

### DIFF
--- a/test/features/ide/composables/useBasicIdeExecution.test.ts
+++ b/test/features/ide/composables/useBasicIdeExecution.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
-import { ERROR_MESSAGES } from '@/core/constants'
+import { ERROR_MESSAGES, PALETTE_DEFAULTS } from '@/core/constants'
 import { useBasicIdeExecution } from '@/features/ide/composables/useBasicIdeExecution'
 import type { BasicIdeState } from '@/features/ide/composables/useBasicIdeState'
 import type { BasicIdeWorkerIntegration } from '@/features/ide/composables/useBasicIdeWorkerIntegration'
@@ -292,10 +292,10 @@ describe('useBasicIdeExecution', () => {
 
   /** Palette reactive refs that should be reset by clearOutput/runCode. */
   const PALETTE_REFS = [
-    { key: 'bgPalette', nonDefault: 0, expected: 1, label: 'bgPalette' },
-    { key: 'cgenMode', nonDefault: 0, expected: 2, label: 'cgenMode' },
-    { key: 'backdropColor', nonDefault: 1, expected: 0, label: 'backdropColor' },
-    { key: 'spritePalette', nonDefault: 2, expected: 1, label: 'spritePalette' },
+    { key: 'bgPalette', nonDefault: 0, expected: PALETTE_DEFAULTS.BG_PALETTE, label: 'bgPalette' },
+    { key: 'cgenMode', nonDefault: 0, expected: PALETTE_DEFAULTS.CGEN_MODE, label: 'cgenMode' },
+    { key: 'backdropColor', nonDefault: 1, expected: PALETTE_DEFAULTS.BACKDROP_COLOR, label: 'backdropColor' },
+    { key: 'spritePalette', nonDefault: 2, expected: PALETTE_DEFAULTS.SPRITE_PALETTE, label: 'spritePalette' },
   ] as const
 
   describe('clearOutput resets palette reactive state (issue #444)', () => {


### PR DESCRIPTION
## Summary
- Fixes #473

## Changes
- Replace hardcoded palette default values (1, 2, 0, 1) in PALETTE_REFS with PALETTE_DEFAULTS constants from `src/core/constants.ts`
- Prevents test/data drift if defaults change

## Test plan
- [x] 3344 tests pass including 8 palette reset tests
- [ ] CI passes