### PR TITLE
refactor: resolve #474 - extract extended stable timeout constant

### DIFF
--- a/test/integration/TestProgram.ts
+++ b/test/integration/TestProgram.ts
@@ -88,8 +88,14 @@ const DEFAULT_OPTIONS: Required<TestProgramOptions> = {
 }
 
 /**
+ * Extended timeout for programs with long PAUSE/play durations (5s vs default 1s).
+ * Use with spread-override: `{ ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS }`
+ */
+export const EXTENDED_STABLE_TIMEOUT_MS = 5000
+
+/**
  * Shared stable-wait defaults for headless program tests.
- * Spread-override as needed: `{ ...DEFAULT_STABLE_OPTIONS, timeoutMs: 10000 }`
+ * Spread-override as needed: `{ ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS }`
  */
 export const DEFAULT_STABLE_OPTIONS: WaitForStableOptions = {
   stablePolls: 3,

--- a/test/program/comprehensive/card.test.ts
+++ b/test/program/comprehensive/card.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('card program', () => {
   // Two-player memory card matching game using STICK/STRIG for cursor and card flipping.
@@ -10,7 +10,7 @@ describe('card program', () => {
     const tp = TestProgram.fromSample('card', { maxIterations: 50000 })
 
     await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     // "LEFT" and "RIGHT" labels at LOCATE 25,9 and LOCATE 25,12

--- a/test/program/comprehensive/knight.test.ts
+++ b/test/program/comprehensive/knight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('knight program', () => {
   // Two-player knight's tour game using STICK/STRIG for piece placement.
@@ -12,7 +12,7 @@ describe('knight program', () => {
     const tp = TestProgram.fromSample('knight', { maxIterations: 50000 })
 
     const result = await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     // Verify no parse errors — the program starts executing correctly

--- a/test/program/comprehensive/route66.test.ts
+++ b/test/program/comprehensive/route66.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('route66 program', () => {
   // Driving game with STICK/STRIG controls and sprite-based cars.
@@ -11,7 +11,7 @@ describe('route66 program', () => {
     const tp = TestProgram.fromSample('route66', { maxIterations: 50000 })
 
     await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     // Verify screen shows HUD elements from GOSUB 500 display routine

--- a/test/program/comprehensive/scr-sample.test.ts
+++ b/test/program/comprehensive/scr-sample.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('scr-sample program', () => {
   // Sprite-based shooting gallery using DEF MOVE, POSITION, MOVE for automated sprites
@@ -13,7 +13,7 @@ describe('scr-sample program', () => {
     const tp = TestProgram.fromSample('scrSample')
 
     const result = await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     // Verify no parse errors — the program starts executing correctly

--- a/test/program/comprehensive/shooting.test.ts
+++ b/test/program/comprehensive/shooting.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('shooting program', () => {
   // Gallery shooter with 8 moving sprites (DEF MOVE), STICK(0) for aiming,
@@ -12,7 +12,7 @@ describe('shooting program', () => {
     const tp = TestProgram.fromSample('shooting')
 
     await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     // Verify screen shows score from line 30

--- a/test/program/comprehensive/super-memory.test.ts
+++ b/test/program/comprehensive/super-memory.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('super-memory program', () => {
   // Simon-like memory game: shows a growing sequence of colors, player repeats via INKEY$.
@@ -11,7 +11,7 @@ describe('super-memory program', () => {
     const tp = TestProgram.fromSample('superMemory')
 
     await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     // Verify the game board was drawn — "YOU" prompt appears at line 230

--- a/test/program/comprehensive/turtle.test.ts
+++ b/test/program/comprehensive/turtle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('turtle program', () => {
   // Turtle race with RND-based movement.
@@ -12,7 +12,7 @@ describe('turtle program', () => {
     tp.seedInput(['N'])
 
     await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     tp.expectSuccess()

--- a/test/program/comprehensive/type-master.test.ts
+++ b/test/program/comprehensive/type-master.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('type-master program', () => {
   // Typing game: PAUSE 100 (~1.2s) countdown, then INKEY$ loop for character matching.
@@ -13,7 +13,7 @@ describe('type-master program', () => {
     tp.queueInkey('N')
 
     await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     // Countdown numbers printed at LOCATE 2,5: FOR I=9 TO 0 STEP -1

--- a/test/program/comprehensive/ufo.test.ts
+++ b/test/program/comprehensive/ufo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('ufo program', () => {
   // Space shooter using STICK(0) for gun movement and STRIG(0) for firing.
@@ -13,7 +13,7 @@ describe('ufo program', () => {
     const tp = TestProgram.fromSample('ufo')
 
     const result = await tp.run({
-      stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     // Verify no parse errors — the program starts executing correctly

--- a/test/program/control/pause.test.ts
+++ b/test/program/control/pause.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('pause program', () => {
   // PAUSE uses real setTimeout — total ~11s of delays, needs extended timeout
@@ -10,7 +10,7 @@ describe('pause program', () => {
     // PAUSE 0 blocks waiting for keypress — queue one to unblock
     tp.queueInkey('A')
 
-    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS } })
 
     tp.expectSuccess()
     // CLS at line 30 clears screen

--- a/test/program/music/bgplay-demo.test.ts
+++ b/test/program/music/bgplay-demo.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('bgplay-demo program', () => {
   // BGPLAY + PAUSE 30 in part 1, then CLS and interactive game loop with STRIG exit.
@@ -10,7 +10,7 @@ describe('bgplay-demo program', () => {
     // Queue START button press (bit 0) to exit the Part 2 game loop
     tp.pushStrigState(0, 1)
 
-    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS } })
 
     tp.expectSuccess()
     // After Part 2 CLS, screen shows game loop header

--- a/test/program/music/play-demo.test.ts
+++ b/test/program/music/play-demo.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'vitest'
 
-import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('play-demo program', () => {
   // PLAY + PAUSE 30 sections — total ~3s of PAUSE delays
   it('runs successfully and produces expected output', async () => {
     const tp = TestProgram.fromSample('musicPlayDemo')
 
-    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS } })
 
     tp.expectSuccess()
     tp.expectRowText(0, '=== PLAY DEMO ===')

--- a/test/program/music/rockn-rouge.test.ts
+++ b/test/program/music/rockn-rouge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('rockn-rouge program', () => {
   // Long program (~450 lines) with PLAY commands, IF/GOTO loops, and no PRINT.
@@ -9,7 +9,7 @@ describe('rockn-rouge program', () => {
     const tp = TestProgram.fromSample('musicRocknRouge')
 
     await tp.run({
-      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 },
+      stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS },
     })
 
     tp.expectSuccess()

--- a/test/program/screen/cursor-position.test.ts
+++ b/test/program/screen/cursor-position.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'vitest'
 
-import { DEFAULT_STABLE_OPTIONS, TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('cursor-position program', () => {
   // PAUSE 50 per loop iteration × 16 iterations ≈ 16s total, needs extended timeout
   it('runs successfully and shows cursor position output', async () => {
     const tp = TestProgram.fromSample('cursorPosition')
 
-    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS } })
 
     tp.expectSuccess()
     // LOCATE I,I for I=0..15 → diagonal POS/LINE output

--- a/test/program/sprites/sprite-animation.test.ts
+++ b/test/program/sprites/sprite-animation.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('sprite-animation program', () => {
   // PAUSE 180 + PAUSE 120 (~4s total) plus sprite movement
   it('runs successfully and produces expected output', async () => {
     const tp = TestProgram.fromSample('spriteAnimation')
 
-    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS } })
 
     tp.expectSuccess()
     tp.expectRowText(0, 'THREE SPRITES MOVING...')

--- a/test/program/sprites/sprite-basic.test.ts
+++ b/test/program/sprites/sprite-basic.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('sprite-basic program', () => {
   // PAUSE 150 + PAUSE 100 (~3s total) plus sprite placement and movement
   it('runs successfully and produces expected output', async () => {
     const tp = TestProgram.fromSample('spriteBasic')
 
-    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS } })
 
     tp.expectSuccess()
     tp.expectRowText(0, 'SPRITE PLACED AT (120,100)')

--- a/test/program/sprites/sprite-table-b.test.ts
+++ b/test/program/sprites/sprite-table-b.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import { DEFAULT_STABLE_OPTIONS, EXTENDED_STABLE_TIMEOUT_MS, TestProgram } from '../../integration/TestProgram'
 
 describe('sprite-table-b program', () => {
   // Interactive program with STICK/STRIG game loop — push START (T=1) to exit
@@ -9,7 +9,7 @@ describe('sprite-table-b program', () => {
     // T=1 triggers line 450: "IF T=1 THEN 450" to exit the game loop
     tp.pushStrigState(0, 1)
 
-    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 5000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS } })
 
     tp.expectSuccess()
     tp.expectRowText(0, '=== SPRITE TABLE B TEST ===')


### PR DESCRIPTION
## Summary
- Fixes #474

## Changes
- Added `EXTENDED_STABLE_TIMEOUT_MS = 5000` export to TestProgram.ts
- Replaced `timeoutMs: 5000` magic number in 5 files that already imported DEFAULT_STABLE_OPTIONS
- Converted 12 files from inline `{ stablePolls: 3, intervalMs: 20, timeoutMs: 5000 }` to `{ ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS }`
- 18 files changed, +41/-35 lines

## Test plan
- [x] All 3344 tests pass
- [ ] CI passes