### PR TITLE
refactor: resolve #484 - extract ReadonlyPaletteData type alias

### DIFF
--- a/src/shared/data/palette.ts
+++ b/src/shared/data/palette.ts
@@ -125,7 +125,10 @@ const RAW_BACKGROUND_PALETTES = [
 // and returns fully mutable `number[][][]` for runtime mutation.
 // ---------------------------------------------------------------------------
 
-function cloneAsMutable<T extends ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>>(
+/** Deeply-readonly palette data: array of palettes, each an array of color combinations. */
+export type ReadonlyPaletteData = ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>
+
+function cloneAsMutable<T extends ReadonlyPaletteData>(
   raw: T
 ): number[][][] {
   return raw.map(palette =>


### PR DESCRIPTION
## Summary
- Fixes #484

## Changes
- Extract `ReadonlyPaletteData` type alias from verbose `ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>` generic constraint
- Use in `cloneAsMutable<T extends ReadonlyPaletteData>` for readability

## Test plan
- [x] Type-check passes
- [ ] CI passes