### PR TITLE
refactor: resolve #487 - remove keypress interaction from PAUSE command demo

### DIFF
--- a/src/core/samples/programs/control/pause.bas
+++ b/src/core/samples/programs/control/pause.bas
@@ -19,13 +19,7 @@
 190 NEXT
 200 PRINT ""
 210 PAUSE 50
-220 REM === Wait for Keypress ===
-230 PRINT "=== WAIT FOR KEYPRESS ==="
-240 PRINT "PAUSE 0 waits for a key..."
-250 PAUSE 0
-260 PRINT "You pressed a key!"
-270 PAUSE 50
-280 REM === Long Pause Demo ===
+220 REM === Long Pause Demo ===
 290 PRINT "=== LONG PAUSE ==="
 300 PRINT "Waiting 3 seconds..."
 310 PAUSE 250

--- a/test/demo/PauseDemo.test.ts
+++ b/test/demo/PauseDemo.test.ts
@@ -100,8 +100,8 @@ describe('Pause Demo Program', () => {
       // Verify all statements are parsed
       const statements = result.cst?.children.statement
       expect(Array.isArray(statements)).toBe(true)
-      // Current pause.bas has 33 lines (10-330)
-      expect(statements?.length).toBe(33)
+      // Current pause.bas has 27 lines (keypress section removed)
+      expect(statements?.length).toBe(27)
     })
 
     it('should parse PAUSE statements correctly', async () => {
@@ -125,16 +125,15 @@ describe('Pause Demo Program', () => {
     it('should execute the complete pause demo program', async () => {
       const { durations } = await executeWithCapturedTimeouts(pauseDemoCode)
 
-      // Current pause.bas has:
-      // 5x PAUSE 80 + 1x PAUSE 50 + 5x PAUSE 30 + 1x PAUSE 50 + 1x PAUSE 50 + 1x PAUSE 250 = 14 pauses
-      // PAUSE 0 has durationMs = 0 so it is filtered out (> 1 check)
-      expect(durations).toHaveLength(14)
+      // Current pause.bas has (keypress section removed):
+      // 5x PAUSE 80 + 1x PAUSE 50 + 5x PAUSE 30 + 1x PAUSE 50 + 1x PAUSE 250 = 13 pauses
+      expect(durations).toHaveLength(13)
 
       // PAUSE 80: (80 * 33.33) / 2.75 = 969.45ms each (5 of these)
       expect(durations.filter((d) => Math.abs(d - 969.45) < 1)).toHaveLength(5)
 
-      // PAUSE 50: (50 * 33.33) / 2.75 = 606.06ms each (3 of these)
-      expect(durations.filter((d) => Math.abs(d - 606.06) < 1)).toHaveLength(3)
+      // PAUSE 50: (50 * 33.33) / 2.75 = 606.06ms each (2 of these)
+      expect(durations.filter((d) => Math.abs(d - 606.06) < 1)).toHaveLength(2)
 
       // PAUSE 30: (30 * 33.33) / 2.75 = 363.63ms each (5 of these)
       expect(durations.filter((d) => Math.abs(d - 363.63) < 1)).toHaveLength(5)
@@ -166,15 +165,10 @@ describe('Pause Demo Program', () => {
       expect(calls[12]).toBe('.')
       expect(calls[13]).toBe('.')
 
-      // Wait for keypress section
-      expect(calls[14]).toBe('=== WAIT FOR KEYPRESS ===')
-      expect(calls[15]).toBe('PAUSE 0 waits for a key...')
-      expect(calls[16]).toBe('You pressed a key!')
-
       // Long pause section
-      expect(calls[17]).toBe('=== LONG PAUSE ===')
-      expect(calls[18]).toBe('Waiting 3 seconds...')
-      expect(calls[19]).toBe('Done!')
+      expect(calls[14]).toBe('=== LONG PAUSE ===')
+      expect(calls[15]).toBe('Waiting 3 seconds...')
+      expect(calls[16]).toBe('Done!')
 
       // OK prompt after successful execution
       expect(calls[calls.length - 1]).toBe('OK')

--- a/test/program/control/pause.test.ts
+++ b/test/program/control/pause.test.ts
@@ -7,9 +7,6 @@ describe('pause program', () => {
   it('runs successfully and produces expected output', async () => {
     const tp = TestProgram.fromSample('pause')
 
-    // PAUSE 0 blocks waiting for keypress — queue one to unblock
-    tp.queueInkey('A')
-
     await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS } })
 
     tp.expectSuccess()
@@ -27,13 +24,9 @@ describe('pause program', () => {
     tp.expectRowText(8, '=== SHORT PAUSE ===')
     tp.expectRowText(9, 'QUICK DOTS...')
     tp.expectRowText(10, '.....')
-    // Wait for keypress section: PAUSE 0 unblocked by queueInkey
-    tp.expectRowText(11, '=== WAIT FOR KEYPRESS ===')
-    tp.expectRowText(12, 'PAUSE 0 WAITS FOR A KEY...')
-    tp.expectRowText(13, 'YOU PRESSED A KEY!')
     // Long pause section: PAUSE 250 (~3s)
-    tp.expectRowText(14, '=== LONG PAUSE ===')
-    tp.expectRowText(15, 'WAITING 3 SECONDS...')
-    tp.expectRowText(16, 'DONE!')
+    tp.expectRowText(11, '=== LONG PAUSE ===')
+    tp.expectRowText(12, 'WAITING 3 SECONDS...')
+    tp.expectRowText(13, 'DONE!')
   }, 20_000)
 })


### PR DESCRIPTION
## Summary
- Fixes #487

## Changes
- Removed "Wait for Keypress" section (PAUSE 0) from pause.bas — demo now focuses purely on time-based delays
- Updated pause.test.ts: removed queueInkey call and keypress assertions, adjusted row numbers
- Updated PauseDemo.test.ts: adjusted statement/pause counts and output indices
- 3 files, +14/-33 lines

## Test plan
- [x] All 3344 tests pass (pause.test.ts + PauseDemo.test.ts)
- [ ] CI passes