### PR TITLE
refactor: resolve #492 - rename tabPalettes i18n key to tabPalette

### DIFF
--- a/src/features/ide/components/StateInspector.vue
+++ b/src/features/ide/components/StateInspector.vue
@@ -112,7 +112,7 @@ defineExpose({
   <GameBlock :title="t('ide.stateInspector.title')" title-icon="mdi:eye" :hide-header="true" class="state-inspector">
     <div class="inspector-content">
       <GameTabs v-model="activeTab" type="border-card" class="inspector-tabs">
-        <GameTabPane name="palettes" :label="t('ide.stateInspector.tabPalettes')">
+        <GameTabPane name="palettes" :label="t('ide.stateInspector.tabPalette')">
           <div class="tab-pane horizontal palettes-tab">
             <div class="palettes-row">
               <ActivePaletteDisplay :bg-palette="bgPalette" :sprite-palette="spritePalette" />

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -386,7 +386,7 @@
   },
   "stateInspector": {
     "title": "State Inspector",
-    "tabPalettes": "PALETTE",
+    "tabPalette": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
     "tabBg": "BG",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -386,7 +386,7 @@
   },
   "stateInspector": {
     "title": "状態インスペクタ",
-    "tabPalettes": "PALETTE",
+    "tabPalette": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
     "tabBg": "BG",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -386,7 +386,7 @@
   },
   "stateInspector": {
     "title": "状态检查",
-    "tabPalettes": "PALETTE",
+    "tabPalette": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
     "tabBg": "BG",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -386,7 +386,7 @@
   },
   "stateInspector": {
     "title": "狀態檢查",
-    "tabPalettes": "PALETTE",
+    "tabPalette": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
     "tabBg": "BG",

--- a/test/ide/StateInspector.test.ts
+++ b/test/ide/StateInspector.test.ts
@@ -89,14 +89,14 @@ describe('StateInspector MOVE tab data', () => {
 
 describe('StateInspector tab header casing consistency', () => {
   it('all inspector tab labels are uppercase in English locale', () => {
-    const { tabPalettes, tabSprite, tabMove } = enIde.stateInspector
+    const { tabPalette, tabSprite, tabMove } = enIde.stateInspector
 
-    expect(tabPalettes).toBe('PALETTE')
+    expect(tabPalette).toBe('PALETTE')
     expect(tabSprite).toBe('SPRITE')
     expect(tabMove).toBe('MOVE')
 
     // Regression: all three tab labels must be fully uppercase (F-BASIC keyword style)
-    for (const label of [tabPalettes, tabSprite, tabMove]) {
+    for (const label of [tabPalette, tabSprite, tabMove]) {
       expect(label).toBe(label.toUpperCase())
     }
   })


### PR DESCRIPTION
## Summary
- Fixes #492

## Changes
- Renamed i18n key `tabPalettes` to `tabPalette` across 4 locale files (en, ja, zh-CN, zh-TW)
- Updated StateInspector.vue template reference
- Updated StateInspector.test.ts variable names
- 6 files, +8/-8 lines

## Test plan
- [x] All 3344 tests pass
- [ ] CI passes