### PR TITLE
refactor: resolve #502 - add bounds validation to TestProgram.getSpriteState

### DIFF
--- a/test/integration/TestProgram.test.ts
+++ b/test/integration/TestProgram.test.ts
@@ -186,6 +186,46 @@ describe('TestProgram', () => {
     })
   })
 
+  describe('getSpriteState bounds validation', () => {
+    it('throws RangeError for negative spriteNumber', async () => {
+      const tp = TestProgram.fromCode('10 END')
+      await tp.run()
+      expect(() => tp.getSpriteState(-1)).toThrow(RangeError)
+      expect(() => tp.getSpriteState(-1)).toThrow(
+        'spriteNumber must be 0-7, got -1'
+      )
+    })
+
+    it('throws RangeError for spriteNumber >= SPRITE_COUNT', async () => {
+      const tp = TestProgram.fromCode('10 END')
+      await tp.run()
+      expect(() => tp.getSpriteState(8)).toThrow(RangeError)
+      expect(() => tp.getSpriteState(8)).toThrow(
+        'spriteNumber must be 0-7, got 8'
+      )
+    })
+
+    it('accepts spriteNumber at lower bound 0', async () => {
+      const tp = TestProgram.fromCode('10 END')
+      await tp.run()
+      // Should not throw; returns null because no sprite was defined
+      expect(tp.getSpriteState(0)).toEqual({ x: 0, y: 0, visible: false })
+    })
+
+    it('accepts spriteNumber at upper bound 7', async () => {
+      const tp = TestProgram.fromCode('10 END')
+      await tp.run()
+      expect(tp.getSpriteState(7)).toEqual({ x: 0, y: 0, visible: false })
+    })
+
+    it('throws before run() is called', () => {
+      const tp = TestProgram.fromCode('10 END')
+      expect(() => tp.getSpriteState(0)).toThrow(
+        'No interpreter available. Call run() first.'
+      )
+    })
+  })
+
   describe('options', () => {
     it('respects maxIterations option', async () => {
       const tp = TestProgram.fromCode(

--- a/test/integration/TestProgram.ts
+++ b/test/integration/TestProgram.ts
@@ -36,7 +36,7 @@ import { expect } from 'vitest'
 import { createSharedDisplayBuffer } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import { BasicInterpreter } from '@/core/BasicInterpreter'
-import { EXECUTION_LIMITS } from '@/core/constants'
+import { EXECUTION_LIMITS, SCREEN_DIMENSIONS } from '@/core/constants'
 import { getSampleCode } from '@/core/samples'
 
 import { SharedBufferTestAdapter } from '../adapters/SharedBufferTestAdapter'
@@ -343,6 +343,11 @@ export class TestProgram {
   getSpriteState(spriteNumber: number): { x: number; y: number; visible: boolean } | null {
     if (!this._interpreter) {
       throw new Error('No interpreter available. Call run() first.')
+    }
+    if (spriteNumber < 0 || spriteNumber >= SCREEN_DIMENSIONS.SPRITE_COUNT) {
+      throw new RangeError(
+        `spriteNumber must be 0-${SCREEN_DIMENSIONS.SPRITE_COUNT - 1}, got ${spriteNumber}`
+      )
     }
     const states = this._interpreter.getSpriteStates()
     const state = states.find((s) => s.spriteNumber === spriteNumber)


### PR DESCRIPTION
## Summary
- Fixes #502

## Changes
- Added bounds validation to `TestProgram.getSpriteState(spriteNumber)` — throws `RangeError` for values outside `[0, SPRITE_COUNT)` instead of silently returning `null`
- Added 5 test cases covering negative values, upper bound overflow, exact boundary values (0 and 7), and pre-existing interpreter guard

## Test plan
- [x] Targeted tests pass (3349 tests, 237 files)
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] CI passes