### PR TITLE
fix: resolve #529 - fill canvas border with backdrop color instead of black

### DIFF
--- a/src/features/ide/components/Screen.vue
+++ b/src/features/ide/components/Screen.vue
@@ -82,6 +82,9 @@ const backSpriteNodes = shallowRef<Map<number, Konva.Image>>(new Map())
 // Use shallowRef since the buffer array is replaced, not mutated
 const lastBackgroundBufferRef = shallowRef<ScreenCell[][] | null>(null)
 
+// Last backdrop color used for canvas rendering (to detect backdrop changes for dirty render)
+const lastBackdropColorRef = ref<number | null>(null)
+
 // Shared buffer path: last sequence and last decoded buffer (so we only decode when sequence changes)
 // Use shallowRef since the buffer array is replaced, not mutated
 const lastSequenceRef = ref(-1)
@@ -150,13 +153,22 @@ async function render(): Promise<void> {
 
     // Render background using Canvas2D to offscreen canvas (much faster than Konva for text grid)
     const lastBuffer = lastBackgroundBufferRef.value
+    const currentBackdropColor = ctx.backdropColor.value ?? 0
     if (lastBuffer && pendingRenderReasonRef.value === 'bufferOnly') {
-      // Dirty render: only changed cells
-      renderBackgroundToCanvasDirty(backgroundCanvas, bufferToRender, lastBuffer, paletteCode.value)
+      // Dirty render: only changed cells (falls back to full if backdrop changed)
+      renderBackgroundToCanvasDirty(
+        backgroundCanvas,
+        bufferToRender,
+        lastBuffer,
+        paletteCode.value,
+        currentBackdropColor,
+        lastBackdropColorRef.value
+      )
     } else {
       // Full render
-      renderBackgroundToCanvas(backgroundCanvas, bufferToRender, paletteCode.value)
+      renderBackgroundToCanvas(backgroundCanvas, bufferToRender, paletteCode.value, currentBackdropColor)
     }
+    lastBackdropColorRef.value = currentBackdropColor
 
     // Create/update Konva.Image from Canvas2D content to participate in layer stacking
     if (layers.value.backgroundLayer) {
@@ -174,18 +186,6 @@ async function render(): Promise<void> {
       layers.value.backgroundLayer.add(backgroundImage)
       layers.value.backgroundLayer.batchDraw()
     }
-
-    // Determine if background should be cached (static when no active movements)
-    // Pure Buffer Read: check isActive directly from shared buffer
-    ;(() => {
-      if (!ctx.sharedDisplayBufferAccessor) return false
-      for (let actionNumber = 0; actionNumber < 8; actionNumber++) {
-        if (ctx.sharedDisplayBufferAccessor.readSpriteIsActive(actionNumber)) {
-          return true
-        }
-      }
-      return false
-    })()
 
     // Render sprites using Konva
     const layersToRender: KonvaScreenLayers = {
@@ -341,10 +341,14 @@ watch(
 // Register buffer invalidation callback for palette changes (PALETB etc.)
 // Nullifying lastBackgroundBufferRef forces the dirty renderer to do a full redraw
 // since renderBackgroundToCanvasDirty falls back to full render when lastBuffer is null.
+// Also nullify lastBackdropColorRef so backdrop fill is always applied on invalidation.
 watch(
   () => ctx.registerInvalidateBackgroundBuffer,
   fn => {
-    if (fn) fn(() => { lastBackgroundBufferRef.value = null })
+    if (fn) fn(() => {
+      lastBackgroundBufferRef.value = null
+      lastBackdropColorRef.value = null
+    })
   },
   { immediate: true }
 )

--- a/src/features/ide/composables/useCanvasBackgroundRenderer.ts
+++ b/src/features/ide/composables/useCanvasBackgroundRenderer.ts
@@ -8,6 +8,9 @@ import type { ScreenCell } from '@/core/types/execution-types'
 import { BACKGROUND_PALETTES, COLORS } from '@/shared/data/palette'
 import { getBackgroundItemByChar, getCharacterByCode } from '@/shared/utils/backgroundLookup'
 
+/** Default backdrop color code (black) used when none is specified. */
+const DEFAULT_BACKDROP_COLOR = 0
+
 const CELL_SIZE = 8 // 8×8 pixels per character cell
 const COLS = 28 // Background screen: 28 columns
 const ROWS = 24 // Background screen: 24 rows
@@ -110,19 +113,35 @@ function createBackgroundTileImage(
 }
 
 /**
+ * Fill the entire canvas with the backdrop color.
+ * This covers the border area outside the 28x24 tile grid,
+ * ensuring the backdrop color fills the full 256x240 screen.
+ */
+function fillCanvasWithBackdrop(
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  backdropColorCode: number
+): void {
+  const color = COLORS[backdropColorCode] ?? COLORS[DEFAULT_BACKDROP_COLOR] ?? '#000000'
+  ctx.fillStyle = color
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+}
+
+/**
  * Render entire background grid to canvas (full redraw)
  * Uses direct Canvas2D drawImage() - much faster than Konva
  */
 export function renderBackgroundToCanvas(
   canvas: HTMLCanvasElement,
   buffer: ScreenCell[][],
-  paletteCode: number
+  paletteCode: number,
+  backdropColorCode: number = DEFAULT_BACKDROP_COLOR
 ): void {
   const ctx = canvas.getContext('2d', { alpha: false })
   if (!ctx) return
 
-  // Clear canvas
-  ctx.clearRect(0, 0, canvas.width, canvas.height)
+  // Fill entire canvas with backdrop color (covers border area)
+  fillCanvasWithBackdrop(ctx, canvas, backdropColorCode)
 
   // Render all cells
   for (let y = 0; y < ROWS; y++) {
@@ -142,16 +161,19 @@ export function renderBackgroundToCanvas(
 
 /**
  * Render only changed cells to canvas (dirty rendering)
- * Only redraws cells where character or colorPattern changed
+ * Only redraws cells where character or colorPattern changed.
+ * Falls back to full render when lastBuffer is null or backdrop color changed.
  */
 export function renderBackgroundToCanvasDirty(
   canvas: HTMLCanvasElement,
   buffer: ScreenCell[][],
   lastBuffer: ScreenCell[][] | null,
-  paletteCode: number
+  paletteCode: number,
+  backdropColorCode: number = DEFAULT_BACKDROP_COLOR,
+  lastBackdropColorCode: number | null = null
 ): void {
-  if (!lastBuffer) {
-    renderBackgroundToCanvas(canvas, buffer, paletteCode)
+  if (!lastBuffer || lastBackdropColorCode === null || lastBackdropColorCode !== backdropColorCode) {
+    renderBackgroundToCanvas(canvas, buffer, paletteCode, backdropColorCode)
     return
   }
 

--- a/test/program/screen/screen.test.ts
+++ b/test/program/screen/screen.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { TestProgram } from '../../integration/TestProgram'
 
@@ -19,5 +19,17 @@ describe('screen program', () => {
     tp.expectRowText(10, '*')
     // Row 22: "Done!" (LOCATE 0,22)
     tp.expectRowText(22, 'DONE!')
+  })
+
+  it('sets backdrop color via CGSET and PALETB (#529 regression)', async () => {
+    const tp = TestProgram.fromSample('screen')
+
+    const result = await tp.run()
+
+    tp.expectSuccess()
+    expect(result.snapshot).not.toBeNull()
+    // After CGSET 0 + PALETB 0, 1, 0, 0, 0: bgPalette=0, backdropColor=1
+    expect(result.snapshot!.scalars.bgPalette).toEqual(0)
+    expect(result.snapshot!.scalars.backdropColor).toEqual(1)
   })
 })


### PR DESCRIPTION
## Summary
- Fixes Bug 1 of #529: backdrop color now fills the entire 256x240 screen including the border area outside the 28x24 tile grid

## Changes
- **`useCanvasBackgroundRenderer.ts`**: Added `fillCanvasWithBackdrop()` helper; `renderBackgroundToCanvas()` and `renderBackgroundToCanvasDirty()` now fill the full canvas with backdrop color instead of using `clearRect()` (which filled with black)
- **`Screen.vue`**: Passes `backdropColor` to render functions; tracks `lastBackdropColorRef` for dirty render optimization; removed dead IIFE that checked sprite activity (return value was unused)
- **`screen.test.ts`**: Added regression test verifying `bgPalette=0` and `backdropColor=1` after CGSET 0 + PALETB

## Bug 2 Note
Text color appearing black instead of gray after CGSET 0 + PALETB requires real hardware verification. The current behavior is technically correct — `PALETB 0, 1, 0, 0, 0` sets C2=0 (black) for combination 0. If real hardware shows gray text, PALETB may only update C1 for combination 0, which would be a separate fix.

## Test plan
- [x] `test/program/screen/screen.test.ts` — 2/2 passed (including new regression test)
- [x] `test/program/screen/screen-fill.test.ts` — 1/1 passed
- [x] `test/program/screen/screen-read.test.ts` — 1/1 passed
- [x] TypeScript type-check clean
- [x] ESLint clean