### PR TITLE
refactor: resolve #509 - extract LONG_STABLE_TIMEOUT_MS constant in sprite-control test

### DIFF
--- a/test/integration/TestProgram.ts
+++ b/test/integration/TestProgram.ts
@@ -94,6 +94,12 @@ const DEFAULT_OPTIONS: Required<TestProgramOptions> = {
 export const EXTENDED_STABLE_TIMEOUT_MS = 5000
 
 /**
+ * Long timeout for programs with very long cumulative PAUSE durations (10s vs default 1s).
+ * Use with spread-override: `{ ...DEFAULT_STABLE_OPTIONS, timeoutMs: LONG_STABLE_TIMEOUT_MS }`
+ */
+export const LONG_STABLE_TIMEOUT_MS = 10_000
+
+/**
  * Shared stable-wait defaults for headless program tests.
  * Spread-override as needed: `{ ...DEFAULT_STABLE_OPTIONS, timeoutMs: EXTENDED_STABLE_TIMEOUT_MS }`
  */

--- a/test/program/sprites/sprite-control.test.ts
+++ b/test/program/sprites/sprite-control.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from 'vitest'
 
-import { TestProgram } from '../../integration/TestProgram'
+import {
+  DEFAULT_STABLE_OPTIONS,
+  LONG_STABLE_TIMEOUT_MS,
+  TestProgram,
+} from '../../integration/TestProgram'
 
 describe('sprite-control program', () => {
   // 8 directions × (PAUSE 150 + PAUSE 120) = ~36s of pauses, very long program.
@@ -9,7 +13,7 @@ describe('sprite-control program', () => {
   it('runs successfully and tests all 8 directions', async () => {
     const tp = TestProgram.fromSample('spriteControl')
 
-    await tp.run({ stableOptions: { stablePolls: 3, intervalMs: 20, timeoutMs: 10000 } })
+    await tp.run({ stableOptions: { ...DEFAULT_STABLE_OPTIONS, timeoutMs: LONG_STABLE_TIMEOUT_MS } })
 
     tp.expectSuccess()
 


### PR DESCRIPTION
## Summary
- Fixes #509

## Changes
- Added `LONG_STABLE_TIMEOUT_MS = 10_000` constant to `TestProgram.ts`, following the pattern established by `EXTENDED_STABLE_TIMEOUT_MS` from PR #508
- Replaced inline magic number `{ stablePolls: 3, intervalMs: 20, timeoutMs: 10000 }` in `sprite-control.test.ts` with spread-override pattern `{ ...DEFAULT_STABLE_OPTIONS, timeoutMs: LONG_STABLE_TIMEOUT_MS }`

## Test plan
- [x] Targeted tests pass (sprite-control.test.ts, all 3344 tests)
- [ ] CI passes