### PR TITLE
test: resolve #520 - add screen content assertion to INKEY$ blocking E2E test

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -13,12 +13,22 @@ declare global {
       getWorkerUrl?: (workerId: string, label: string) => string
       getWorker?: (workerId: string, label: string) => Worker
     }
-    /** DEV-only API for headless test code injection. Undefined in production builds. */
+    /**
+     * API for headless test automation.
+     * getScreenText is available in all builds (DEV and production).
+     * State-mutating methods are DEV-only; absent in production builds.
+     */
     __fbasicIDE?: {
-      loadCode: (code: string) => void
-      run: () => Promise<void>
-      stop: () => void
-      respondToInput: (value: string) => void
+      /** DEV-only: set editor code. */
+      loadCode?: (code: string) => void
+      /** DEV-only: run the program. */
+      run?: () => Promise<void>
+      /** DEV-only: stop program execution. */
+      stop?: () => void
+      /** DEV-only: respond to a pending INPUT request. */
+      respondToInput?: (value: string) => void
+      /** Read screen buffer as array of trimmed row strings. */
+      getScreenText: () => string[]
     }
   }
 }

--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -139,6 +139,7 @@ useDevApi({
   stopCode,
   pendingInputRequest,
   respondToInputRequest,
+  screenBuffer,
 })
 
 // UI state

--- a/src/features/ide/composables/useDevApi.ts
+++ b/src/features/ide/composables/useDevApi.ts
@@ -1,14 +1,36 @@
 import { onMounted, onUnmounted,type Ref } from 'vue'
 
+import type { ScreenCell } from '@/core/types/execution-types'
 import type { RequestInputMessage } from '@/core/types/worker-messages'
 
 /**
- * DEV-only global API exposed on `window.__fbasicIDE` for headless test
- * code injection. This avoids clipboard hacks when automating the IDE
- * in browser-based E2E tests.
+ * Read-only screen API exposed on `window.__fbasicIDE` in all builds
+ * (DEV and production) for E2E screen content assertions.
+ */
+interface FbasicIDEScreenAPI {
+  /** Read screen buffer as array of trimmed row strings. */
+  getScreenText: () => string[]
+}
+
+/**
+ * Full DEV-only API that extends the screen API with state-mutating methods.
+ * In production builds only the screen API subset is exposed.
+ */
+type FbasicIDEFullAPI = FbasicIDEScreenAPI & {
+  loadCode: (code: string) => void
+  run: () => Promise<void>
+  stop: () => void
+  respondToInput: (value: string) => void
+}
+
+/**
+ * Global API exposed on `window.__fbasicIDE` for headless test automation.
  *
- * In production builds `import.meta.env.DEV` is `false`, so the
- * composable body is completely eliminated by Vite tree-shaking.
+ * The read-only `getScreenText()` method is available in all builds (DEV and
+ * production) so that E2E tests running against production builds can assert
+ * screen content. State-mutating methods (`loadCode`, `run`, `stop`,
+ * `respondToInput`) are DEV-only and eliminated by Vite tree-shaking in
+ * production builds.
  */
 export function useDevApi(options: {
   code: Ref<string>
@@ -16,36 +38,64 @@ export function useDevApi(options: {
   stopCode: () => void
   pendingInputRequest: Ref<RequestInputMessage['data'] | null>
   respondToInputRequest: (requestId: string, values: string[], cancelled: boolean) => void
+  screenBuffer: Ref<ScreenCell[][]>
 }): void {
-  if (!import.meta.env.DEV) {
-    return
+  /**
+   * Read the current screen buffer and return an array of row strings.
+   * Each row is the concatenated characters from the screen buffer cells,
+   * trimmed of trailing spaces.
+   *
+   * Available in all builds (DEV and production) for E2E assertions.
+   */
+  function getScreenText(): string[] {
+    const buffer = options.screenBuffer.value
+    return buffer.map(row =>
+      (row ?? [])
+        .map(cell => cell?.character ?? ' ')
+        .join('')
+        .trimEnd()
+    )
   }
 
-  function loadCode(code: string): void {
-    options.code.value = code
-  }
+  const screenApi: FbasicIDEScreenAPI = { getScreenText }
 
-  function respondToInput(value: string): void {
-    const request = options.pendingInputRequest.value
-    if (!request) {
-      console.warn('[__fbasicIDE] respondToInput called but no pending input request')
-      return
+  if (import.meta.env.DEV) {
+    function loadCode(code: string): void {
+      options.code.value = code
     }
-    options.respondToInputRequest(request.requestId, [value], false)
+
+    function respondToInput(value: string): void {
+      const request = options.pendingInputRequest.value
+      if (!request) {
+        console.warn('[__fbasicIDE] respondToInput called but no pending input request')
+        return
+      }
+      options.respondToInputRequest(request.requestId, [value], false)
+    }
+
+    const fullApi: FbasicIDEFullAPI = {
+      ...screenApi,
+      loadCode,
+      run: options.runCode,
+      stop: options.stopCode,
+      respondToInput,
+    }
+
+    onMounted(() => {
+      window.__fbasicIDE = fullApi
+    })
+
+    onUnmounted(() => {
+      window.__fbasicIDE = undefined
+    })
+  } else {
+    // Production: expose only the read-only screen API for E2E tests
+    onMounted(() => {
+      window.__fbasicIDE = screenApi
+    })
+
+    onUnmounted(() => {
+      window.__fbasicIDE = undefined
+    })
   }
-
-  const api = {
-    loadCode,
-    run: options.runCode,
-    stop: options.stopCode,
-    respondToInput,
-  }
-
-  onMounted(() => {
-    window.__fbasicIDE = api
-  })
-
-  onUnmounted(() => {
-    window.__fbasicIDE = undefined
-  })
 }

--- a/test/e2e/ide-inkey-blocking.pw.ts
+++ b/test/e2e/ide-inkey-blocking.pw.ts
@@ -69,11 +69,19 @@ test.describe('INKEY$ blocking mode', () => {
     // Wait for the program to loop back to the next INKEY$(0) call
     await page.waitForTimeout(KEY_PRESS_INTERVAL_MS)
 
-    // Send 'Q' key - program should read it, detect Q, print "Done!", and END
+    // Send 'Q' key - program should read it, detect Q, print "DONE!", and END
     await page.keyboard.press('Q')
 
     // Wait for program to complete: run button should become enabled again
     await expect(runButton).toBeEnabled({ timeout: COMPLETION_TIMEOUT_MS })
+
+    // Verify "DONE!" appears on the virtual screen after Q exits the loop
+    const screenText = await page.evaluate(() => window.__fbasicIDE?.getScreenText())
+    expect(screenText, 'Screen buffer should be readable via dev API').toBeDefined()
+    expect(
+      screenText!.some(row => row.includes('DONE!')),
+      `Expected "DONE!" on screen. Got: ${JSON.stringify(screenText)}`
+    ).toEqual(true)
 
     // Verify no uncaught page errors occurred during execution
     expect(

--- a/test/ide/useDevApi.test.ts
+++ b/test/ide/useDevApi.test.ts
@@ -19,6 +19,11 @@ function mountWithDevApi(options: Parameters<typeof useDevApi>[0]) {
   return mount(testHost)
 }
 
+/** Shared screenBuffer ref for tests that don't exercise screen reading. */
+function emptyScreenBuffer() {
+  return ref([])
+}
+
 describe('useDevApi', () => {
   beforeEach(() => {
     window.__fbasicIDE = undefined
@@ -34,8 +39,9 @@ describe('useDevApi', () => {
     const stopCode = vi.fn()
     const pendingInputRequest = ref(null)
     const respondToInputRequest = vi.fn()
+    const screenBuffer = emptyScreenBuffer()
 
-    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest, screenBuffer })
 
     expect(window.__fbasicIDE).toBeDefined()
   })
@@ -46,6 +52,7 @@ describe('useDevApi', () => {
     const stopCode = vi.fn()
     const pendingInputRequest = ref(null)
     const respondToInputRequest = vi.fn()
+    const screenBuffer = emptyScreenBuffer()
 
     const wrapper = mountWithDevApi({
       code,
@@ -53,6 +60,7 @@ describe('useDevApi', () => {
       stopCode,
       pendingInputRequest,
       respondToInputRequest,
+      screenBuffer,
     })
     expect(window.__fbasicIDE).toBeDefined()
 
@@ -66,10 +74,11 @@ describe('useDevApi', () => {
     const stopCode = vi.fn()
     const pendingInputRequest = ref(null)
     const respondToInputRequest = vi.fn()
+    const screenBuffer = emptyScreenBuffer()
 
-    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest, screenBuffer })
 
-    window.__fbasicIDE!.loadCode('10 PRINT "HELLO"')
+    window.__fbasicIDE!.loadCode!('10 PRINT "HELLO"')
     expect(code.value).toEqual('10 PRINT "HELLO"')
   })
 
@@ -79,10 +88,11 @@ describe('useDevApi', () => {
     const stopCode = vi.fn()
     const pendingInputRequest = ref(null)
     const respondToInputRequest = vi.fn()
+    const screenBuffer = emptyScreenBuffer()
 
-    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest, screenBuffer })
 
-    void window.__fbasicIDE!.run()
+    void window.__fbasicIDE!.run!()
     expect(runCode).toHaveBeenCalledOnce()
   })
 
@@ -92,10 +102,11 @@ describe('useDevApi', () => {
     const stopCode = vi.fn()
     const pendingInputRequest = ref(null)
     const respondToInputRequest = vi.fn()
+    const screenBuffer = emptyScreenBuffer()
 
-    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest, screenBuffer })
 
-    window.__fbasicIDE!.stop()
+    window.__fbasicIDE!.stop!()
     expect(stopCode).toHaveBeenCalledOnce()
   })
 
@@ -111,10 +122,11 @@ describe('useDevApi', () => {
       isLinput: false,
     })
     const respondToInputRequest = vi.fn()
+    const screenBuffer = emptyScreenBuffer()
 
-    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest, screenBuffer })
 
-    window.__fbasicIDE!.respondToInput('hello')
+    window.__fbasicIDE!.respondToInput!('hello')
     expect(respondToInputRequest).toHaveBeenCalledWith('req-42', ['hello'], false)
   })
 
@@ -124,16 +136,44 @@ describe('useDevApi', () => {
     const stopCode = vi.fn()
     const pendingInputRequest = ref(null)
     const respondToInputRequest = vi.fn()
+    const screenBuffer = emptyScreenBuffer()
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest })
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest, screenBuffer })
 
-    window.__fbasicIDE!.respondToInput('hello')
+    window.__fbasicIDE!.respondToInput!('hello')
     expect(respondToInputRequest).not.toHaveBeenCalled()
     expect(warnSpy).toHaveBeenCalledWith(
       '[__fbasicIDE] respondToInput called but no pending input request',
     )
 
     warnSpy.mockRestore()
+  })
+
+  it('getScreenText returns trimmed row strings from screen buffer', () => {
+    const code = ref('')
+    const runCode = vi.fn().mockResolvedValue(undefined)
+    const stopCode = vi.fn()
+    const pendingInputRequest = ref(null)
+    const respondToInputRequest = vi.fn()
+    const screenBuffer = ref([
+      [
+        { character: 'H', colorPattern: 0, x: 0, y: 0 },
+        { character: 'I', colorPattern: 0, x: 1, y: 0 },
+        { character: ' ', colorPattern: 0, x: 2, y: 0 },
+      ],
+      [
+        { character: 'D', colorPattern: 0, x: 0, y: 1 },
+        { character: 'o', colorPattern: 0, x: 1, y: 1 },
+        { character: 'n', colorPattern: 0, x: 2, y: 1 },
+        { character: 'e', colorPattern: 0, x: 3, y: 1 },
+        { character: '!', colorPattern: 0, x: 4, y: 1 },
+      ],
+    ])
+
+    mountWithDevApi({ code, runCode, stopCode, pendingInputRequest, respondToInputRequest, screenBuffer })
+
+    const rows = window.__fbasicIDE!.getScreenText()
+    expect(rows).toEqual(['HI', 'Done!'])
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #520

## Changes
- Added `getScreenText()` to `useDevApi.ts` for reading virtual screen content via `window.__fbasicIDE.getScreenText()`
- Restructured `useDevApi` so `getScreenText` is available in all builds (DEV + production) while state-mutating methods remain DEV-only
- Updated `env.d.ts` type definitions — DEV-only methods now optional, `getScreenText` required
- Added screen content assertion to INKEY$ blocking E2E test verifying "DONE!" appears after program completion
- Updated `useDevApi` unit tests with `screenBuffer` parameter and added new `getScreenText` test

## Test plan
- [ ] useDevApi unit tests pass (8/8)
- [ ] E2E test passes with screen content assertion
- [ ] CI passes