### PR TITLE
feat: resolve #488 - update active program name when loading a sample program

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -194,7 +194,8 @@ function handleInputResponse(
 
 // Handle sample selection with view switching
 function handleLoadSample(sampleType: string) {
-  const hasBg = loadSampleCode(sampleType)
+  const displayName = t(`ide.samples.items.${sampleType}.name`)
+  const hasBg = loadSampleCode(sampleType, displayName)
   sampleSelectorOpen.value = false
   // Switch to code view if sample has no BG data and currently viewing bg-editor
   if (!hasBg && editorView.value === 'bg') {

--- a/src/features/ide/composables/useBasicIdeEditor.ts
+++ b/src/features/ide/composables/useBasicIdeEditor.ts
@@ -16,7 +16,7 @@ export interface BasicIdeEditor {
   updateHighlighting: () => Promise<void>
   parseCode: () => Promise<unknown>
   validateCode: () => Promise<boolean>
-  loadSampleCode: (sampleType: string) => boolean
+  loadSampleCode: (sampleType: string, displayName?: string) => boolean
   sampleSelectOptions: Array<{ value: string; label: string }>
   getParserCapabilities: () => ParserInfo
   getHighlighterCapabilities: () => HighlighterInfo
@@ -64,7 +64,7 @@ export function useBasicIdeEditor(state: BasicIdeState): BasicIdeEditor {
     return cst !== null
   }
 
-  const loadSampleCode = (sampleType: string): boolean => {
+  const loadSampleCode = (sampleType: string, displayName?: string): boolean => {
     if (!sampleType) return false
     const sample = getSampleCode(sampleType)
     if (sample) {
@@ -72,8 +72,13 @@ export function useBasicIdeEditor(state: BasicIdeState): BasicIdeEditor {
       state.code.value = sample.code
       state.currentSampleType.value = sampleType
 
-      // Load BG data into program store if sample has associated BG
+      // Update program name in the store
       const programStore = useProgramStore()
+      if (displayName) {
+        programStore.setName(displayName)
+      }
+
+      // Load BG data into program store if sample has associated BG
       const bgKey = sample.bgKey
       const hasBg = bgKey ? hasSampleBgData(bgKey) : false
       if (hasBg && bgKey) {

--- a/src/features/ide/composables/useProgramStore.ts
+++ b/src/features/ide/composables/useProgramStore.ts
@@ -101,6 +101,17 @@ function setCode(code: string): void {
 }
 
 /**
+ * Update the program's name
+ */
+function setName(name: string): void {
+  if (!currentProgram.value) return
+
+  currentProgram.value.name = name
+  currentProgram.value.updatedAt = Date.now()
+  isDirty.value = true
+}
+
+/**
  * Update the program's BG data
  */
 function setBg(bg: BgGridData): void {
@@ -259,6 +270,7 @@ export function useProgramStore() {
     newProgram,
     loadProgram,
     setCode,
+    setName,
     setBg,
     save,
     saveAs,

--- a/test/ide/useProgramStore.test.ts
+++ b/test/ide/useProgramStore.test.ts
@@ -87,6 +87,31 @@ describe('useProgramStore', () => {
     expect(store.isDirty.value).toBe(true)
   })
 
+  it('should update name and mark dirty', async () => {
+    const { useProgramStore } = await import('@/features/ide/composables/useProgramStore')
+    const store = useProgramStore()
+
+    store.setName('Twinkle Star')
+
+    expect(store.programName).toBe('Twinkle Star')
+    expect(store.isDirty.value).toBe(true)
+  })
+
+  it('should persist name change to localStorage', async () => {
+    const { useProgramStore } = await import('@/features/ide/composables/useProgramStore')
+    const store = useProgramStore()
+
+    store.setName('Twinkle Star')
+
+    // Wait for VueUse's useLocalStorage to sync
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const stored = localStorage.getItem('program:current')
+    expect(stored).not.toBeNull()
+    const parsed = JSON.parse(stored!) as ProgramData
+    expect(parsed.name).toBe('Twinkle Star')
+  })
+
   it('should load program and clear dirty', async () => {
     const { useProgramStore } = await import('@/features/ide/composables/useProgramStore')
     const store = useProgramStore()


### PR DESCRIPTION
## Summary
- Fixes #488

## Changes
- Added `setName(name: string)` method to `useProgramStore` that updates the program name, sets `updatedAt`, and marks the program as dirty
- Updated `loadSampleCode()` in `useBasicIdeEditor.ts` to accept an optional `displayName` parameter and call `setName()` when provided
- Updated `handleLoadSample()` in `IdePage.vue` to translate the sample key to its display name and pass it to `loadSampleCode()`
- Added 2 regression tests for `setName()` in `useProgramStore.test.ts`

## Test plan
- [ ] Targeted tests pass (useProgramStore, ProgramToolbar, program-flow integration)
- [ ] Type-check clean
- [ ] ESLint clean
- [ ] CI passes