### PR TITLE
feat: resolve #535 - add shareable programs via URL

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, shallowRef, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
 
 import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
@@ -19,15 +20,17 @@ import IdeOutputPanel from './components/IdeOutputPanel.vue'
 import IdeSpriteViewerPanel from './components/IdeSpriteViewerPanel.vue'
 import InputModal from './components/InputModal.vue'
 import SampleSelector from './components/SampleSelector.vue'
+import type { CommandPaletteCommand } from './composables/commandPalette'
 import {
-  type CommandPaletteCommand,
   isEditableTarget,
   matchesAnyShortcut,
 } from './composables/commandPalette'
 import { useBasicIde as useBasicIdeEnhanced } from './composables/useBasicIdeEnhanced'
 import type { InputMode } from './composables/useBasicIdeState'
 import { useDevApi } from './composables/useDevApi'
+import { useIdeCommandPalette } from './composables/useIdeCommandPalette'
 import { provideScreenContext } from './composables/useScreenContext'
+import { useShareRoute } from './composables/useShareRoute'
 
 /**
  * IdePage component - The main IDE page for F-BASIC code editing and execution.
@@ -42,9 +45,14 @@ const { t } = useI18n()
 const isE2ELite =
   typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('e2e') === 'lite'
 
+const route = useRoute()
+
 const basicIde = isE2ELite ? null : useBasicIdeEnhanced()
 
+// Share route handling
 const code = basicIde?.code ?? ref('')
+const { shareError, handleShareRoute } = useShareRoute({ code })
+
 const isRunning = basicIde?.isRunning ?? ref(false)
 const output = basicIde?.output ?? ref<string[]>([])
 const errors =
@@ -215,96 +223,18 @@ async function restartCode() {
   await runCode()
 }
 
-const commandPaletteCommands = computed<CommandPaletteCommand[]>(() => [
-  {
-    id: 'run.start',
-    title: t('ide.commandPalette.commands.runStart.title'),
-    description: t('ide.commandPalette.commands.runStart.description'),
-    shortcut: 'Ctrl+Enter / Cmd+Enter',
-    keywords: ['execute', 'start', 'run'],
-    enabled: !isRunning.value,
-    execute: () => {
-      void runCode()
-    },
-  },
-  {
-    id: 'run.stop',
-    title: t('ide.commandPalette.commands.runStop.title'),
-    description: t('ide.commandPalette.commands.runStop.description'),
-    shortcut: 'Ctrl+Shift+Enter / Cmd+Shift+Enter',
-    keywords: ['halt', 'stop'],
-    enabled: isRunning.value,
-    execute: stopCode,
-  },
-  {
-    id: 'run.restart',
-    title: t('ide.commandPalette.commands.runRestart.title'),
-    description: t('ide.commandPalette.commands.runRestart.description'),
-    shortcut: 'Ctrl+Shift+R / Cmd+Shift+R',
-    keywords: ['restart', 'rerun'],
-    execute: () => {
-      void restartCode()
-    },
-  },
-  {
-    id: 'run.clearOutput',
-    title: t('ide.commandPalette.commands.runClearOutput.title'),
-    description: t('ide.commandPalette.commands.runClearOutput.description'),
-    keywords: ['clear', 'output', 'screen'],
-    execute: clearOutput,
-  },
-  {
-    id: 'view.openSampleSelector',
-    title: t('ide.commandPalette.commands.viewOpenSampleSelector.title'),
-    description: t('ide.commandPalette.commands.viewOpenSampleSelector.description'),
-    keywords: ['sample', 'demo'],
-    execute: () => {
-      sampleSelectorOpen.value = true
-    },
-  },
-  {
-    id: 'view.openLogFilters',
-    title: t('ide.commandPalette.commands.viewOpenLogFilters.title'),
-    description: t('ide.commandPalette.commands.viewOpenLogFilters.description'),
-    keywords: ['output', 'logs', 'filters'],
-    execute: () => {
-      logLevelPanelOpen.value = true
-    },
-  },
-  {
-    id: 'view.switchToCode',
-    title: t('ide.commandPalette.commands.viewSwitchToCode.title'),
-    description: t('ide.commandPalette.commands.viewSwitchToCode.description'),
-    keywords: ['code', 'editor'],
-    execute: () => {
-      editorView.value = 'code'
-    },
-  },
-  {
-    id: 'view.switchToBgEditor',
-    title: t('ide.commandPalette.commands.viewSwitchToBgEditor.title'),
-    description: t('ide.commandPalette.commands.viewSwitchToBgEditor.description'),
-    keywords: ['bg', 'background', 'editor'],
-    execute: () => {
-      editorView.value = 'bg'
-    },
-  },
-  {
-    id: 'input.toggleMode',
-    title: t('ide.commandPalette.commands.inputToggleMode.title'),
-    description: t('ide.commandPalette.commands.inputToggleMode.description'),
-    shortcut: 'F9',
-    keywords: ['input', 'keyboard', 'joystick'],
-    execute: toggleInputMode,
-  },
-  {
-    id: 'debug.toggle',
-    title: t('ide.commandPalette.commands.debugToggle.title'),
-    description: t('ide.commandPalette.commands.debugToggle.description'),
-    keywords: ['debug'],
-    execute: toggleDebugMode,
-  },
-])
+// Command palette commands
+const { commands: commandPaletteCommands } = useIdeCommandPalette({
+  isRunning,
+  runCode,
+  stopCode,
+  clearOutput,
+  toggleDebugMode,
+  toggleInputMode,
+  sampleSelectorOpen,
+  logLevelPanelOpen,
+  editorView,
+})
 
 async function handleExecuteCommandFromPalette(command: CommandPaletteCommand) {
   closeCommandPalette()
@@ -319,11 +249,16 @@ const canStop = isRunning
 const parserInfo = shallowRef<ParserInfo | null>(null)
 const highlighterInfo = shallowRef<HighlighterInfo | null>(null)
 
-// Initialize parser info
+// Initialize parser info and handle share route
 onMounted(() => {
   parserInfo.value = getParserCapabilities()
   highlighterInfo.value = getHighlighterCapabilities()
   window.addEventListener('keydown', handleGlobalKeydown)
+
+  // If we arrived via a share link, decode and load the program
+  if (route.name === 'Share') {
+    void handleShareRoute()
+  }
 })
 
 onUnmounted(() => {
@@ -432,6 +367,17 @@ function toggleInputMode() {
 
       <!-- INPUT/LINPUT modal overlay -->
       <Teleport v-if="!isE2ELite" to="body">
+        <!-- Share error notification -->
+        <div v-if="shareError" class="share-error-toast" data-testid="share-error-toast">
+          <span class="share-error-text">{{ t('ide.share.loadFailed') }}: {{ shareError }}</span>
+          <button
+            class="share-error-dismiss"
+            @click="shareError = ''"
+          >
+            &times;
+          </button>
+        </div>
+
         <InputModal
           :pending-request="pendingInputRequest"
           @respond="handleInputResponse"
@@ -486,5 +432,41 @@ function toggleInputMode() {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+.share-error-toast {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: var(--game-surface-bg-gradient);
+  border: 1px solid var(--semantic-solid-danger);
+  border-radius: 8px;
+  box-shadow: var(--game-shadow-base);
+  max-width: 80vw;
+}
+
+.share-error-text {
+  font-size: 0.8rem;
+  color: var(--semantic-solid-danger);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.share-error-dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--game-text-secondary);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  line-height: 1;
 }
 </style>

--- a/src/features/ide/components/ProgramToolbar.vue
+++ b/src/features/ide/components/ProgramToolbar.vue
@@ -6,12 +6,17 @@ import { useProgramStore } from '@/features/ide/composables/useProgramStore'
 import { ConfirmDialog, GameButton, GameIconButton } from '@/shared/components/ui'
 import GameIcon from '@/shared/components/ui/GameIcon.vue'
 
+import ShareDialog from './ShareDialog.vue'
+
 const props = withDefaults(defineProps<{ isCompact?: boolean }>(), {
   isCompact: false,
 })
 
 const { t } = useI18n()
 const programStore = useProgramStore()
+
+// Share dialog state
+const showShareDialog = ref(false)
 
 // Renaming state
 const editingName = ref(false)
@@ -215,6 +220,15 @@ onUnmounted(() => {
           data-testid="ide-save-button"
           @click="handleSave"
         />
+        <GameIconButton
+          type="default"
+          icon="mdi:share-variant"
+          size="small"
+          :disabled="isFileOperationPending"
+          :title="t('ide.share.title')"
+          data-testid="ide-share-button"
+          @click="showShareDialog = true"
+        />
       </template>
       <template v-else>
         <GameButton
@@ -246,6 +260,16 @@ onUnmounted(() => {
           @click="handleSave"
         >
           {{ t('ide.toolbar.export') }}
+        </GameButton>
+        <GameButton
+          type="default"
+          icon="mdi:share-variant"
+          size="small"
+          :disabled="isFileOperationPending"
+          data-testid="ide-share-button"
+          @click="showShareDialog = true"
+        >
+          {{ t('ide.share.title') }}
         </GameButton>
       </template>
     </div>
@@ -295,6 +319,14 @@ onUnmounted(() => {
       :message="t('ide.toolbar.discardConfirm')"
       @confirm="handleConfirmDiscard"
       @cancel="handleCancelDiscard"
+    />
+
+    <!-- Share dialog -->
+    <ShareDialog
+      :visible="showShareDialog"
+      :source="programStore.code"
+      :bg="programStore.currentProgram?.value?.bg"
+      @close="showShareDialog = false"
     />
   </div>
 </template>

--- a/src/features/ide/components/ShareDialog.vue
+++ b/src/features/ide/components/ShareDialog.vue
@@ -1,0 +1,302 @@
+<script setup lang="ts">
+/**
+ * ShareDialog - Shows a shareable URL for the current program and copies to clipboard.
+ */
+
+import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { CompactBg } from '@/core/types/program-types'
+import { encodeProgram } from '@/shared/utils/programCodec'
+
+const props = withDefaults(defineProps<{
+  visible: boolean
+  source: string
+  bg?: CompactBg
+}>(), {
+  bg: undefined,
+})
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const { t } = useI18n()
+const urlInputRef = useTemplateRef<HTMLInputElement>('urlInputRef')
+
+// State
+const shareUrl = ref('')
+const isEncoding = ref(false)
+const error = ref('')
+const tooLarge = ref(false)
+const copied = ref(false)
+let copiedTimer: ReturnType<typeof setTimeout> | null = null
+
+onUnmounted(() => {
+  if (copiedTimer !== null) {
+    clearTimeout(copiedTimer)
+  }
+})
+
+// Encode the program when dialog opens
+watch(
+  () => props.visible,
+  async (visible) => {
+    if (!visible) return
+
+    isEncoding.value = true
+    error.value = ''
+    tooLarge.value = false
+    copied.value = false
+
+    try {
+      const result = await encodeProgram(props.source, props.bg)
+      shareUrl.value = result.url
+      tooLarge.value = result.tooLarge
+
+      // Select the URL text after rendering
+      await nextTick()
+      urlInputRef.value?.select()
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err)
+    } finally {
+      isEncoding.value = false
+    }
+  },
+)
+
+async function handleCopy(): Promise<void> {
+  if (!shareUrl.value) return
+
+  try {
+    await navigator.clipboard.writeText(shareUrl.value)
+    copied.value = true
+    if (copiedTimer !== null) {
+      clearTimeout(copiedTimer)
+    }
+    copiedTimer = setTimeout(() => {
+      copied.value = false
+      copiedTimer = null
+    }, 2000)
+  } catch {
+    // Fallback: select the input text so user can manually copy
+    urlInputRef.value?.select()
+  }
+}
+
+function handleClose(): void {
+  emit('close')
+}
+
+function handleOverlayClick(e: MouseEvent): void {
+  if (e.target === e.currentTarget) {
+    handleClose()
+  }
+}
+
+function handleKeydown(e: KeyboardEvent): void {
+  if (!props.visible) return
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    handleClose()
+  }
+}
+
+const copyLabel = computed(() =>
+  copied.value
+    ? t('ide.share.copied')
+    : t('ide.share.copy'),
+)
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="visible"
+      class="share-dialog-overlay"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="t('ide.share.title')"
+      @click="handleOverlayClick"
+    >
+      <div class="share-dialog">
+        <h3 class="share-dialog-title">
+          {{ t('ide.share.title') }}
+        </h3>
+
+        <div v-if="isEncoding" class="share-dialog-loading">
+          {{ t('ide.share.encoding') }}
+        </div>
+
+        <div v-else-if="error" class="share-dialog-error">
+          {{ t('ide.share.encodeFailed') }}
+        </div>
+
+        <template v-else>
+          <p class="share-dialog-description">
+            {{ t('ide.share.description') }}
+          </p>
+
+          <div class="share-dialog-url-container">
+            <input
+              ref="urlInputRef"
+              v-model="shareUrl"
+              type="text"
+              class="share-dialog-url-input"
+              readonly
+              data-testid="share-url-input"
+            />
+          </div>
+
+          <p v-if="tooLarge" class="share-dialog-warning">
+            {{ t('ide.share.tooLarge') }}
+          </p>
+
+          <div class="share-dialog-actions">
+            <button
+              class="share-dialog-btn share-dialog-btn-copy"
+              data-testid="share-copy-button"
+              @click="handleCopy"
+            >
+              {{ copyLabel }}
+            </button>
+            <button
+              class="share-dialog-btn share-dialog-btn-close"
+              @click="handleClose"
+            >
+              {{ t('ide.share.close') }}
+            </button>
+          </div>
+        </template>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.share-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--base-alpha-gray-00-60);
+}
+
+.share-dialog {
+  background: var(--game-surface-bg-gradient);
+  border: 2px solid var(--game-surface-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  min-width: 420px;
+  max-width: 90vw;
+  box-shadow: var(--game-shadow-base);
+}
+
+.share-dialog-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--game-text-primary);
+}
+
+.share-dialog-description {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  color: var(--game-text-secondary);
+  line-height: 1.4;
+}
+
+.share-dialog-loading {
+  padding: 1rem 0;
+  text-align: center;
+  color: var(--game-text-secondary);
+  font-size: 0.875rem;
+}
+
+.share-dialog-error {
+  padding: 0.75rem;
+  color: var(--semantic-solid-danger);
+  font-size: 0.875rem;
+  background: var(--base-alpha-danger-10);
+  border-radius: 6px;
+}
+
+.share-dialog-url-container {
+  margin-bottom: 0.5rem;
+}
+
+.share-dialog-url-input {
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  font-size: 0.75rem;
+  font-family: monospace;
+  color: var(--game-text-primary);
+  background: var(--game-surface-bg-start);
+  border: 1px solid var(--game-surface-border);
+  border-radius: 6px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.share-dialog-url-input:focus {
+  border-color: var(--base-solid-primary);
+  box-shadow: 0 0 0 2px var(--base-alpha-primary-20);
+}
+
+.share-dialog-warning {
+  margin: 0.5rem 0 0.75rem;
+  font-size: 0.8rem;
+  color: var(--semantic-solid-warning);
+  line-height: 1.4;
+}
+
+.share-dialog-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.share-dialog-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--game-surface-border);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.share-dialog-btn:focus-visible {
+  outline: 2px solid var(--base-solid-primary);
+  outline-offset: 2px;
+}
+
+.share-dialog-btn-copy {
+  background: var(--base-solid-primary);
+  color: var(--game-text-contrast);
+  border-color: var(--base-solid-primary);
+}
+
+.share-dialog-btn-copy:hover {
+  opacity: 0.9;
+}
+
+.share-dialog-btn-close {
+  background: transparent;
+  color: var(--game-text-secondary);
+}
+
+.share-dialog-btn-close:hover {
+  background: var(--game-surface-bg-start);
+}
+</style>

--- a/src/features/ide/composables/useIdeCommandPalette.ts
+++ b/src/features/ide/composables/useIdeCommandPalette.ts
@@ -1,0 +1,128 @@
+/**
+ * useIdeCommandPalette composable
+ *
+ * Defines the command palette commands available in the IDE,
+ * including run/stop controls, view switching, and debug toggles.
+ */
+
+import { computed, type Ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { CommandPaletteCommand } from './commandPalette'
+
+interface IdeCommandPaletteDeps {
+  isRunning: Readonly<Ref<boolean>>
+  runCode: () => Promise<void>
+  stopCode: () => void
+  clearOutput: () => void
+  toggleDebugMode: () => void
+  toggleInputMode: () => void
+  sampleSelectorOpen: Ref<boolean>
+  logLevelPanelOpen: Ref<boolean>
+  editorView: Ref<string>
+}
+
+/**
+ * Create command palette commands for the IDE.
+ */
+export function useIdeCommandPalette(deps: IdeCommandPaletteDeps) {
+  const { t } = useI18n()
+
+  async function restartCode(): Promise<void> {
+    deps.stopCode()
+    await deps.runCode()
+  }
+
+  const commands = computed<CommandPaletteCommand[]>(() => [
+    {
+      id: 'run.start',
+      title: t('ide.commandPalette.commands.runStart.title'),
+      description: t('ide.commandPalette.commands.runStart.description'),
+      shortcut: 'Ctrl+Enter / Cmd+Enter',
+      keywords: ['execute', 'start', 'run'],
+      enabled: !deps.isRunning.value,
+      execute: () => {
+        void deps.runCode()
+      },
+    },
+    {
+      id: 'run.stop',
+      title: t('ide.commandPalette.commands.runStop.title'),
+      description: t('ide.commandPalette.commands.runStop.description'),
+      shortcut: 'Ctrl+Shift+Enter / Cmd+Shift+Enter',
+      keywords: ['halt', 'stop'],
+      enabled: deps.isRunning.value,
+      execute: deps.stopCode,
+    },
+    {
+      id: 'run.restart',
+      title: t('ide.commandPalette.commands.runRestart.title'),
+      description: t('ide.commandPalette.commands.runRestart.description'),
+      shortcut: 'Ctrl+Shift+R / Cmd+Shift+R',
+      keywords: ['restart', 'rerun'],
+      execute: () => {
+        void restartCode()
+      },
+    },
+    {
+      id: 'run.clearOutput',
+      title: t('ide.commandPalette.commands.runClearOutput.title'),
+      description: t('ide.commandPalette.commands.runClearOutput.description'),
+      keywords: ['clear', 'output', 'screen'],
+      execute: deps.clearOutput,
+    },
+    {
+      id: 'view.openSampleSelector',
+      title: t('ide.commandPalette.commands.viewOpenSampleSelector.title'),
+      description: t('ide.commandPalette.commands.viewOpenSampleSelector.description'),
+      keywords: ['sample', 'demo'],
+      execute: () => {
+        deps.sampleSelectorOpen.value = true
+      },
+    },
+    {
+      id: 'view.openLogFilters',
+      title: t('ide.commandPalette.commands.viewOpenLogFilters.title'),
+      description: t('ide.commandPalette.commands.viewOpenLogFilters.description'),
+      keywords: ['output', 'logs', 'filters'],
+      execute: () => {
+        deps.logLevelPanelOpen.value = true
+      },
+    },
+    {
+      id: 'view.switchToCode',
+      title: t('ide.commandPalette.commands.viewSwitchToCode.title'),
+      description: t('ide.commandPalette.commands.viewSwitchToCode.description'),
+      keywords: ['code', 'editor'],
+      execute: () => {
+        deps.editorView.value = 'code'
+      },
+    },
+    {
+      id: 'view.switchToBgEditor',
+      title: t('ide.commandPalette.commands.viewSwitchToBgEditor.title'),
+      description: t('ide.commandPalette.commands.viewSwitchToBgEditor.description'),
+      keywords: ['bg', 'background', 'editor'],
+      execute: () => {
+        deps.editorView.value = 'bg'
+      },
+    },
+    {
+      id: 'input.toggleMode',
+      title: t('ide.commandPalette.commands.inputToggleMode.title'),
+      description: t('ide.commandPalette.commands.inputToggleMode.description'),
+      shortcut: 'F9',
+      keywords: ['input', 'keyboard', 'joystick'],
+      execute: deps.toggleInputMode,
+    },
+    {
+      id: 'debug.toggle',
+      title: t('ide.commandPalette.commands.debugToggle.title'),
+      description: t('ide.commandPalette.commands.debugToggle.description'),
+      keywords: ['debug'],
+      execute: deps.toggleDebugMode,
+    },
+  ])
+
+  return { commands }
+}

--- a/src/features/ide/composables/useShareRoute.ts
+++ b/src/features/ide/composables/useShareRoute.ts
@@ -1,0 +1,54 @@
+/**
+ * useShareRoute composable
+ *
+ * Handles decoding shared programs from the URL hash fragment
+ * and loading them into the IDE on page load.
+ */
+
+import { ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import { decodeProgram, ProgramDecodeError } from '@/shared/utils/programCodec'
+
+/**
+ * Composable for handling share route decoding.
+ *
+ * When the user navigates to `/#/share/<encoded-data>`,
+ * this decodes the program, loads it into the editor, and
+ * redirects to the normal IDE route.
+ *
+ * @param state - The IDE state to load the program code into
+ * @returns shareError - Reactive error message if decoding fails
+ */
+export function useShareRoute(state: { code: { value: string } }) {
+  const route = useRoute()
+  const router = useRouter()
+  const shareError = ref('')
+
+  async function handleShareRoute(): Promise<void> {
+    const shareData = route.params.data as string | undefined
+    if (!shareData) return
+
+    try {
+      const payload = await decodeProgram(shareData)
+
+      // Load the program code into IDE state (triggers sync to program store via watch)
+      state.code.value = payload.c
+
+      // Redirect to normal IDE route (clean URL)
+      void router.replace({ name: 'Ide' })
+    } catch (err) {
+      if (err instanceof ProgramDecodeError) {
+        shareError.value = err.message
+      } else {
+        shareError.value = String(err)
+      }
+      void router.replace({ name: 'Ide' })
+    }
+  }
+
+  return {
+    shareError,
+    handleShareRoute,
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -29,6 +29,18 @@ const routes: RouteRecordRaw[] = [
       group: 'main',
     },
   },
+  // ============================================
+  // Share Route
+  // ============================================
+  {
+    path: '/share/:data',
+    name: 'Share',
+    component: () => import('@/features/ide/IdePage.vue'),
+    meta: {
+      title: 'Shared Program',
+    },
+    props: true,
+  },
 
   // ============================================
   // Development Tools

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -471,5 +471,16 @@
     "title": "Sprite Viewer",
     "openTitle": "Open Sprite Viewer",
     "close": "Close"
+  },
+  "share": {
+    "title": "Share",
+    "description": "Copy this URL to share your program with others.",
+    "copy": "Copy URL",
+    "copied": "Copied!",
+    "close": "Close",
+    "encoding": "Generating share URL...",
+    "encodeFailed": "Failed to generate share URL.",
+    "tooLarge": "This program is too large to share via URL.",
+    "loadFailed": "Failed to load shared program"
   }
 }

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -471,5 +471,16 @@
     "title": "スプライトビューアー",
     "openTitle": "スプライトビューアーを開く",
     "close": "閉じる"
+  },
+  "share": {
+    "title": "共有",
+    "description": "このURLをコピーしてプログラムを共有しましょう。",
+    "copy": "URLをコピー",
+    "copied": "コピーしました！",
+    "close": "閉じる",
+    "encoding": "共有URLを生成中...",
+    "encodeFailed": "共有URLの生成に失敗しました。",
+    "tooLarge": "このプログラムはURLで共有するには大きすぎます。",
+    "loadFailed": "共有プログラムの読み込みに失敗しました"
   }
 }

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -471,5 +471,16 @@
     "title": "精灵查看器",
     "openTitle": "打开精灵查看器",
     "close": "关闭"
+  },
+  "share": {
+    "title": "分享",
+    "description": "复制此链接以分享您的程序。",
+    "copy": "复制链接",
+    "copied": "已复制！",
+    "close": "关闭",
+    "encoding": "正在生成分享链接...",
+    "encodeFailed": "无法生成分享链接。",
+    "tooLarge": "此程序过大，无法通过链接分享。",
+    "loadFailed": "加载分享程序失败"
   }
 }

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -471,5 +471,16 @@
     "title": "精靈檢視器",
     "openTitle": "開啟精靈檢視器",
     "close": "關閉"
+  },
+  "share": {
+    "title": "分享",
+    "description": "複製此連結以分享您的程式。",
+    "copy": "複製連結",
+    "copied": "已複製！",
+    "close": "關閉",
+    "encoding": "正在產生分享連結...",
+    "encodeFailed": "無法產生分享連結。",
+    "tooLarge": "此程式過大，無法透過連結分享。",
+    "loadFailed": "載入分享程式失敗"
   }
 }

--- a/src/shared/utils/programCodec.ts
+++ b/src/shared/utils/programCodec.ts
@@ -1,0 +1,260 @@
+/**
+ * Program Codec
+ *
+ * Encodes/decodes F-BASIC programs to/from URL-safe strings for sharing.
+ *
+ * Encoding strategy:
+ * - Small programs (< 2000 chars source): plain base64url
+ * - Larger programs: gzip-compressed then base64url
+ *
+ * Format: base64url(JSON({c: source, b?: CompactBg}))
+ * Compressed: base64url(gzip(JSON({c: source, b?: CompactBg})))
+ */
+
+import type { CompactBg } from '@/core/types/program-types'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Payload stored in the share URL */
+export interface SharePayload {
+  /** F-BASIC source code */
+  c: string
+  /** Compressed BG data (optional) */
+  b?: CompactBg
+}
+
+/** Result of encoding a program for sharing */
+export interface EncodeResult {
+  /** The encoded URL-safe string */
+  encoded: string
+  /** Whether compression was used */
+  compressed: boolean
+  /** The full share URL */
+  url: string
+  /** Whether the program is too large to share (~32KB URL limit) */
+  tooLarge: boolean
+}
+
+/** Error thrown when decoding a shared program fails */
+export class ProgramDecodeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ProgramDecodeError'
+  }
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Source length threshold below which compression is skipped */
+const COMPRESSION_THRESHOLD = 2000
+
+/** Maximum safe URL length (browsers handle ~2MB but we limit for usability) */
+const MAX_URL_LENGTH = 32_000
+
+/** Version byte prepended to compressed payloads to future-proof the format */
+const FORMAT_VERSION = 0x01
+
+// ============================================================================
+// Base64URL Encoding/Decoding
+// ============================================================================
+
+/**
+ * Encode a Uint8Array to a base64url string (no padding)
+ */
+function uint8ToBase64Url(data: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < data.length; i++) {
+    binary += String.fromCharCode(data[i] as number)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * Decode a base64url string to a Uint8Array
+ */
+function base64UrlToUint8(base64url: string): Uint8Array {
+  // Restore standard base64 characters
+  let base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+  // Restore padding
+  const pad = (4 - (base64.length % 4)) % 4
+  base64 += '='.repeat(pad)
+
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+// ============================================================================
+// Compression (gzip via CompressionStream API)
+// ============================================================================
+
+/**
+ * Compress data using gzip.
+ * Prepends a version byte for future format evolution.
+ */
+async function gzipCompress(data: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([data.buffer as ArrayBuffer]).stream().pipeThrough(
+    new CompressionStream('gzip')
+  )
+  const compressed = new Uint8Array(await new Response(stream).arrayBuffer())
+  // Prepend version byte
+  const result = new Uint8Array(1 + compressed.length)
+  result[0] = FORMAT_VERSION as number
+  result.set(compressed, 1)
+  return result
+}
+
+/**
+ * Decompress gzip data.
+ * Reads the version byte and validates it.
+ */
+async function gzipDecompress(data: Uint8Array): Promise<Uint8Array> {
+  if (data.length < 1) {
+    throw new ProgramDecodeError('Compressed data is empty')
+  }
+
+  const version = data[0] as number
+  if (version !== FORMAT_VERSION) {
+    throw new ProgramDecodeError(
+      `Unsupported format version: ${version}`
+    )
+  }
+
+  const payload = data.slice(1)
+  const stream = new Blob([payload.buffer]).stream().pipeThrough(
+    new DecompressionStream('gzip')
+  )
+  return new Uint8Array(await new Response(stream).arrayBuffer())
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Encode a program for sharing via URL.
+ *
+ * @param source - The F-BASIC source code
+ * @param bg - Optional compressed BG data
+ * @param options - Optional encoding options
+ * @param options.baseUrl - Custom base URL (defaults to current page origin)
+ * @returns EncodeResult with the encoded string and metadata
+ */
+export async function encodeProgram(
+  source: string,
+  bg?: CompactBg,
+  options?: { baseUrl?: string },
+): Promise<EncodeResult> {
+  const payload: SharePayload = { c: source }
+  if (bg) {
+    payload.b = bg
+  }
+
+  const json = JSON.stringify(payload)
+  const jsonBytes = new TextEncoder().encode(json)
+
+  // Decide whether to compress based on source length
+  const useCompression = source.length >= COMPRESSION_THRESHOLD
+
+  let encoded: string
+  if (useCompression) {
+    const compressed = await gzipCompress(jsonBytes)
+    encoded = `z${  uint8ToBase64Url(compressed)}`
+  } else {
+    encoded = uint8ToBase64Url(jsonBytes)
+  }
+
+  const baseUrl = options?.baseUrl
+    ?? `${window.location.origin}${window.location.pathname}#/share/`
+  const fullUrl = baseUrl + encoded
+
+  return {
+    encoded,
+    compressed: useCompression,
+    url: fullUrl,
+    tooLarge: fullUrl.length > MAX_URL_LENGTH,
+  }
+}
+
+/**
+ * Decode a shared program from a URL-safe string.
+ *
+ * @param encoded - The encoded string (without the "z" prefix or route path)
+ * @returns The decoded program payload
+ * @throws ProgramDecodeError if the data is invalid
+ */
+export async function decodeProgram(encoded: string): Promise<SharePayload> {
+  if (!encoded || encoded.length === 0) {
+    throw new ProgramDecodeError('No program data provided')
+  }
+
+  const isCompressed = encoded.startsWith('z')
+  const data = isCompressed ? encoded.slice(1) : encoded
+
+  let bytes: Uint8Array
+  try {
+    bytes = base64UrlToUint8(data)
+  } catch {
+    throw new ProgramDecodeError('Invalid program data: not valid base64')
+  }
+
+  let jsonBytes: Uint8Array
+  try {
+    jsonBytes = isCompressed
+      ? await gzipDecompress(bytes)
+      : bytes
+  } catch (err) {
+    if (err instanceof ProgramDecodeError) throw err
+    throw new ProgramDecodeError(
+      `Invalid program data: decompression failed`
+    )
+  }
+
+  const json = new TextDecoder().decode(jsonBytes)
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    throw new ProgramDecodeError('Invalid program data: not valid JSON')
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new ProgramDecodeError('Invalid program data: expected an object')
+  }
+
+  const obj = parsed as Record<string, unknown>
+
+  if (typeof obj.c !== 'string') {
+    throw new ProgramDecodeError('Invalid program data: missing source code')
+  }
+
+  const payload: SharePayload = { c: obj.c }
+
+  // BG data is optional — validate structure if present
+  if (obj.b !== undefined && typeof obj.b === 'object' && obj.b !== null) {
+    const bg = obj.b as Record<string, unknown>
+    if (
+      typeof bg.format === 'string' &&
+      typeof bg.data === 'string' &&
+      typeof bg.width === 'number' &&
+      typeof bg.height === 'number'
+    ) {
+      payload.b = {
+        format: bg.format as CompactBg['format'],
+        data: bg.data,
+        width: 28,
+        height: 21,
+      }
+    }
+  }
+
+  return payload
+}

--- a/test/ide/ProgramToolbar.test.ts
+++ b/test/ide/ProgramToolbar.test.ts
@@ -22,6 +22,14 @@ vi.mock('vue-i18n', () => ({
         'ide.toolbar.unsavedChanges': 'Unsaved changes',
         'ide.toolbar.openFailed': 'Failed to open file',
         'ide.toolbar.saveFailed': 'Failed to save file',
+        'ide.share.title': 'Share',
+        'ide.share.description': 'Copy this URL to share your program.',
+        'ide.share.copy': 'Copy URL',
+        'ide.share.copied': 'Copied!',
+        'ide.share.close': 'Close',
+        'ide.share.encoding': 'Generating share URL...',
+        'ide.share.encodeFailed': 'Failed to generate share URL.',
+        'ide.share.tooLarge': 'This program is too large to share.',
         'common.confirmDialog.confirm': 'OK',
         'common.confirmDialog.cancel': 'Cancel',
       }
@@ -35,11 +43,21 @@ vi.mock('@/features/ide/composables/useProgramStore', () => ({
   useProgramStore: () => ({
     isDirty: isDirtyRef,
     programName: 'Test Program',
+    code: '10 PRINT "HELLO"',
     newProgram: mockNewProgram,
     open: mockOpen,
     save: mockSave,
     currentProgram: ref(null),
     loadProgram: vi.fn(),
+  }),
+}))
+
+vi.mock('@/shared/utils/programCodec', () => ({
+  encodeProgram: vi.fn().mockResolvedValue({
+    encoded: 'test-encoded',
+    compressed: false,
+    url: 'https://example.com/#/share/test-encoded',
+    tooLarge: false,
   }),
 }))
 

--- a/test/shared/utils/programCodec.test.ts
+++ b/test/shared/utils/programCodec.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Tests for programCodec utility
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import type { CompactBg } from '@/core/types/program-types'
+import {
+  decodeProgram,
+  encodeProgram,
+  ProgramDecodeError,
+} from '@/shared/utils/programCodec'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Create a fake CompactBg for testing */
+function makeFakeBg(): CompactBg {
+  return {
+    format: 'sparse1',
+    data: '0,0,65,1',
+    width: 28,
+    height: 21,
+  }
+}
+
+/** Create a long source string of a given length */
+function longSource(length: number): string {
+  const line = '10 REM A line of padding text for testing\n'
+  let result = ''
+  while (result.length < length) {
+    result += line
+  }
+  return result.slice(0, length)
+}
+
+/** Base URL for test environments where window.location is unavailable */
+const TEST_BASE_URL = 'https://example.com/#/share/'
+
+describe('programCodec', () => {
+  // ========================================================================
+  // encodeProgram - plain (small programs)
+  // ========================================================================
+
+  describe('encodeProgram (plain)', () => {
+    it('encodes a simple program without compression', async () => {
+      const result = await encodeProgram('10 PRINT "HELLO"', undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      expect(result.compressed).toBe(false)
+      expect(result.encoded.startsWith('z')).toBe(false)
+      expect(result.url).toContain('#/share/')
+      expect(result.tooLarge).toBe(false)
+    })
+
+    it('encodes program with BG data', async () => {
+      const bg = makeFakeBg()
+      const result = await encodeProgram('10 PRINT "HI"', bg, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      expect(result.compressed).toBe(false)
+      // The encoded string should contain the BG data when decoded
+      const decoded = await decodeProgram(result.encoded)
+      expect(decoded.b).toEqual(bg)
+    })
+
+    it('produces round-trip compatible output for tiny programs', async () => {
+      const source = '10 PRINT "HELLO WORLD"'
+      const result = await encodeProgram(source, undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      const decoded = await decodeProgram(result.encoded)
+      expect(decoded.c).toEqual(source)
+      expect(decoded.b).toBeUndefined()
+    })
+
+    it('produces round-trip compatible output with BG data', async () => {
+      const source = '20 LOCATE 10,10:PRINT "X"'
+      const bg = makeFakeBg()
+      const result = await encodeProgram(source, bg, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      const decoded = await decodeProgram(result.encoded)
+      expect(decoded.c).toEqual(source)
+      expect(decoded.b).toEqual(bg)
+    })
+  })
+
+  // ========================================================================
+  // encodeProgram - compressed (large programs)
+  // ========================================================================
+
+  describe('encodeProgram (compressed)', () => {
+    it('compresses programs with source >= 2000 chars', async () => {
+      const source = longSource(2000)
+      const result = await encodeProgram(source, undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      expect(result.compressed).toBe(true)
+      expect(result.encoded.startsWith('z')).toBe(true)
+      expect(result.tooLarge).toBe(false)
+    })
+
+    it('does not compress programs with source < 2000 chars', async () => {
+      const source = longSource(1999)
+      const result = await encodeProgram(source, undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      expect(result.compressed).toBe(false)
+    })
+
+    it('round-trips compressed programs with BG data', async () => {
+      const source = longSource(3000)
+      const bg = makeFakeBg()
+      const result = await encodeProgram(source, bg, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      const decoded = await decodeProgram(result.encoded)
+      expect(decoded.c).toEqual(source)
+      expect(decoded.b).toEqual(bg)
+    })
+
+    it('produces shorter output for compressible data', async () => {
+      // A program with lots of repetition compresses well
+      const source = '10 PRINT "AAAAAAAAAAAAAAAAAAAAAAAAAAA"\n'.repeat(200)
+      const result = await encodeProgram(source, undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      // Compressed payload should exist and start with 'z'
+      expect(result.compressed).toBe(true)
+      expect(result.encoded.startsWith('z')).toBe(true)
+
+      // The encoded length should be reasonable
+      expect(result.encoded.length).toBeLessThan(source.length)
+    })
+  })
+
+  // ========================================================================
+  // encodeProgram - URL construction
+  // ========================================================================
+
+  describe('encodeProgram (URL)', () => {
+    it('constructs correct share URL', async () => {
+      const result = await encodeProgram('10 PRINT "TEST"', undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      expect(result.url).toEqual(
+        `https://example.com/#/share/${result.encoded}`
+      )
+    })
+
+    it('reports tooLarge for extremely large programs', async () => {
+      // Generate enough source to exceed 32KB URL limit after compression.
+      // Use non-repetitive content so compression is less effective.
+      const parts: string[] = []
+      for (let i = 0; i < 5000; i++) {
+        parts.push(`${i} REM line ${i} unique content ${Math.random()}\n`)
+      }
+      const source = parts.join('')
+      const result = await encodeProgram(source, undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      expect(result.tooLarge).toBe(true)
+    })
+
+    it('reports not tooLarge for small programs', async () => {
+      const result = await encodeProgram('10 PRINT "HI"', undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      expect(result.tooLarge).toBe(false)
+    })
+  })
+
+  // ========================================================================
+  // decodeProgram - plain
+  // ========================================================================
+
+  describe('decodeProgram (plain)', () => {
+    it('decodes a plain-encoded program', async () => {
+      const source = '10 LET A=5\n20 PRINT A'
+      const encoded = await encodeProgram(source, undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+      const decoded = await decodeProgram(encoded.encoded)
+
+      expect(decoded.c).toEqual(source)
+    })
+
+    it('decodes empty source code', async () => {
+      const encoded = await encodeProgram('', undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+      const decoded = await decodeProgram(encoded.encoded)
+
+      expect(decoded.c).toEqual('')
+    })
+
+    it('preserves special characters in source', async () => {
+      const source = '10 PRINT "Hello!@#$%^&*()_+-={}[]|:;<>,.?/~`\n20 REM \u00e9\u00e8\u00ea'
+      const encoded = await encodeProgram(source, undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+      const decoded = await decodeProgram(encoded.encoded)
+
+      expect(decoded.c).toEqual(source)
+    })
+  })
+
+  // ========================================================================
+  // decodeProgram - compressed
+  // ========================================================================
+
+  describe('decodeProgram (compressed)', () => {
+    it('decodes a compressed program', async () => {
+      const source = longSource(5000)
+      const encoded = await encodeProgram(source, undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+      const decoded = await decodeProgram(encoded.encoded)
+
+      expect(decoded.c).toEqual(source)
+    })
+  })
+
+  // ========================================================================
+  // decodeProgram - error handling
+  // ========================================================================
+
+  describe('decodeProgram (errors)', () => {
+    it('throws ProgramDecodeError for empty string', async () => {
+      await expect(decodeProgram('')).rejects.toThrow(ProgramDecodeError)
+      await expect(decodeProgram('')).rejects.toThrow('No program data provided')
+    })
+
+    it('throws ProgramDecodeError for invalid base64', async () => {
+      await expect(decodeProgram('!!!invalid-base64!!!')).rejects.toThrow(ProgramDecodeError)
+      await expect(decodeProgram('!!!invalid-base64!!!')).rejects.toThrow('not valid base64')
+    })
+
+    it('throws ProgramDecodeError for valid base64 but invalid JSON', async () => {
+      // "AAAA" decodes to 3 null bytes, which is not valid JSON
+      await expect(decodeProgram('AAAA')).rejects.toThrow(ProgramDecodeError)
+      await expect(decodeProgram('AAAA')).rejects.toThrow('not valid JSON')
+    })
+
+    it('throws ProgramDecodeError for JSON without source code', async () => {
+      // '{"x":1}' is valid JSON but has no "c" field
+      const encoded = btoa(JSON.stringify({ x: 1 }))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+      await expect(decodeProgram(encoded)).rejects.toThrow('missing source code')
+    })
+
+    it('throws ProgramDecodeError for invalid version byte', async () => {
+      // Create a compressed payload with wrong version byte
+      const json = new TextEncoder().encode(JSON.stringify({ c: 'test' }))
+      const blob = new Blob([json])
+      const stream = blob.stream().pipeThrough(new CompressionStream('gzip'))
+      const compressed = new Uint8Array(await new Response(stream).arrayBuffer())
+
+      // Prepend wrong version (0xFF instead of 0x01)
+      const payload = new Uint8Array(1 + compressed.length)
+      payload[0] = 0xFF
+      payload.set(compressed, 1)
+
+      // Encode as base64url with 'z' prefix
+      let binary = ''
+      for (let i = 0; i < payload.length; i++) {
+        binary += String.fromCharCode(payload[i] as number)
+      }
+      const encoded = `z${  btoa(binary)
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')}`
+
+      await expect(decodeProgram(encoded)).rejects.toThrow('Unsupported format version')
+    })
+
+    it('throws ProgramDecodeError for truncated compressed data', async () => {
+      // Just the 'z' prefix with incomplete data
+      await expect(decodeProgram('zAQID')).rejects.toThrow(ProgramDecodeError)
+      await expect(decodeProgram('zAQID')).rejects.toThrow('decompression failed')
+    })
+
+    it('ignores invalid BG data gracefully', async () => {
+      // Valid JSON with source but malformed BG data
+      const payload = { c: '10 PRINT "X"', b: { bad: true } }
+      const encoded = btoa(JSON.stringify(payload))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+      const decoded = await decodeProgram(encoded)
+      expect(decoded.c).toEqual('10 PRINT "X"')
+      expect(decoded.b).toBeUndefined()
+    })
+  })
+
+  // ========================================================================
+  // Cross-format round-trip
+  // ============================================================================
+
+  describe('round-trip across formats', () => {
+    it('medium program with BG data round-trips correctly', async () => {
+      const source = longSource(2500)
+      const bg = makeFakeBg()
+      const result = await encodeProgram(source, bg, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      const decoded = await decodeProgram(result.encoded)
+      expect(decoded.c).toEqual(source)
+      expect(decoded.b).toEqual(bg)
+    })
+
+    it('unicode content round-trips correctly', async () => {
+      const source = '10 REM \u3053\u3093\u306b\u3061\u306f\u4e16\u754c\n20 PRINT "\u00dc\u00f6\u00e4"'
+      const result = await encodeProgram(source, undefined, {
+        baseUrl: TEST_BASE_URL,
+      })
+
+      const decoded = await decodeProgram(result.encoded)
+      expect(decoded.c).toEqual(source)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #535

## Changes
- Add `programCodec.ts` utility for encoding/decoding programs to URL-safe strings with optional gzip compression
- Add `ShareDialog.vue` component with URL display and copy-to-clipboard
- Add `useShareRoute.ts` composable to decode shared programs from URL hash on page load
- Extract `useIdeCommandPalette.ts` composable from IdePage.vue to stay under 500-line limit
- Add Share button to ProgramToolbar (compact + full modes)
- Add `/share/:data` route to router
- Add `share.*` i18n keys for all 4 locales (en, ja, zh-CN, zh-TW)
- Add 24 unit tests for programCodec covering encoding, decoding, compression, error handling, and round-trips

## Test plan
- [ ] 24 new programCodec tests pass
- [ ] 12 existing ProgramToolbar tests pass
- [ ] 10 existing IdeEditorPanel tests pass
- [ ] Full suite: 3379 tests pass
- [ ] TypeScript type-check clean
- [ ] ESLint clean