### PR TITLE
refactor: resolve #496 - consolidate register-* callbacks into single registerCallbacks object

### DIFF
--- a/src/features/diagnostics/PerformanceDiagnosticsPage.vue
+++ b/src/features/diagnostics/PerformanceDiagnosticsPage.vue
@@ -52,7 +52,7 @@ const {
   sharedDisplayViews,
   sharedJoystickBuffer,
   setDecodedScreenState,
-  registerScheduleRender,
+  registerCallbacks,
 } = useBasicIdeEnhanced()
 
 provideScreenContext({
@@ -74,7 +74,7 @@ provideScreenContext({
   sharedAnimationBuffer: ref(sharedAnimationBuffer),
   sharedJoystickBuffer: ref(sharedJoystickBuffer),
   setDecodedScreenState,
-  registerScheduleRender,
+  registerCallbacks,
 })
 
 const {

--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -126,8 +126,10 @@ const sharedDisplayViews: SharedDisplayViews = basicIde?.sharedDisplayViews ?? {
 }
 const sharedJoystickBuffer = basicIde?.sharedJoystickBuffer ?? ({} as SharedArrayBuffer)
 const setDecodedScreenState = basicIde?.setDecodedScreenState ?? (() => {})
-const registerScheduleRender = basicIde?.registerScheduleRender ?? (() => {})
-const registerInvalidateBackgroundBuffer = basicIde?.registerInvalidateBackgroundBuffer ?? (() => {})
+const registerCallbacks = basicIde?.registerCallbacks ?? {
+  registerScheduleRender: () => {},
+  registerInvalidateBackgroundBuffer: () => {},
+}
 const pendingInputRequest = basicIde?.pendingInputRequest ?? ref<RequestInputMessage['data'] | null>(null)
 const respondToInputRequest =
   basicIde?.respondToInputRequest ?? ((_requestId: string, _values: string[], _cancelled: boolean) => {})
@@ -176,8 +178,7 @@ if (!isE2ELite && sharedDisplayViews && sharedDisplayBufferAccessor && sharedAni
     sharedAnimationBuffer: ref(sharedAnimationBuffer),
     sharedJoystickBuffer: ref(sharedJoystickBuffer),
     setDecodedScreenState,
-    registerScheduleRender,
-    registerInvalidateBackgroundBuffer,
+    registerCallbacks,
     // Callback for animation loop to update inspector MOVE tab data
     updateInspectorMoveSlots: () => bottomAreaRef.value?.updateMoveSlotsData(),
   })

--- a/src/features/ide/components/Screen.vue
+++ b/src/features/ide/components/Screen.vue
@@ -331,7 +331,7 @@ function cleanupRenderQueue() {
 
 // Register scheduleRender with parent so SCREEN_CHANGED can trigger a redraw (shared buffer path)
 watch(
-  () => ctx.registerScheduleRender,
+  () => ctx.registerCallbacks?.registerScheduleRender,
   fn => {
     if (fn) fn(scheduleRender)
   },
@@ -343,7 +343,7 @@ watch(
 // since renderBackgroundToCanvasDirty falls back to full render when lastBuffer is null.
 // Also nullify lastBackdropColorRef so backdrop fill is always applied on invalidation.
 watch(
-  () => ctx.registerInvalidateBackgroundBuffer,
+  () => ctx.registerCallbacks?.registerInvalidateBackgroundBuffer,
   fn => {
     if (fn) fn(() => {
       lastBackgroundBufferRef.value = null

--- a/src/features/ide/composables/useBasicIdeEnhanced.ts
+++ b/src/features/ide/composables/useBasicIdeEnhanced.ts
@@ -148,7 +148,6 @@ export function useBasicIde() {
     sharedDisplayViews: screen.sharedDisplayViews,
     sharedJoystickBuffer: screen.sharedJoystickBuffer,
     setDecodedScreenState: screen.setDecodedScreenState,
-    registerScheduleRender: screen.registerScheduleRender,
-    registerInvalidateBackgroundBuffer: screen.registerInvalidateBackgroundBuffer,
+    registerCallbacks: screen.registerCallbacks,
   }
 }

--- a/src/features/ide/composables/useBasicIdeScreenIntegration.ts
+++ b/src/features/ide/composables/useBasicIdeScreenIntegration.ts
@@ -23,6 +23,7 @@ import {
 } from '@/core/devices'
 
 import type { BasicIdeState } from './useBasicIdeState'
+import type { ScreenRenderCallbacks } from './useScreenContext'
 
 export interface BasicIdeScreenIntegration {
   sharedDisplayViews: SharedDisplayViews
@@ -31,9 +32,8 @@ export interface BasicIdeScreenIntegration {
   sharedJoystickBuffer: SharedArrayBuffer
   sharedKeyboardBuffer: SharedArrayBuffer
   sharedKeyboardBufferView: KeyboardBufferView
-  registerScheduleRender: (fn: () => void) => void
-  /** Register callback from Screen.vue to invalidate last-rendered background buffer. */
-  registerInvalidateBackgroundBuffer: (fn: () => void) => void
+  /** Register callbacks provided by Screen.vue. */
+  registerCallbacks: ScreenRenderCallbacks
   setDecodedScreenState: (decoded: DecodedScreenState) => void
   /** Invalidate last-rendered background buffer so next render does a full redraw. */
   invalidateBackgroundBuffer: () => void
@@ -164,8 +164,10 @@ export function useBasicIdeScreenIntegration(state: BasicIdeState): BasicIdeScre
     sharedJoystickBuffer,
     sharedKeyboardBuffer,
     sharedKeyboardBufferView,
-    registerScheduleRender,
-    registerInvalidateBackgroundBuffer,
+    registerCallbacks: {
+      registerScheduleRender,
+      registerInvalidateBackgroundBuffer,
+    },
     setDecodedScreenState,
     invalidateBackgroundBuffer,
     scheduleRender,

--- a/src/features/ide/composables/useScreenContext.ts
+++ b/src/features/ide/composables/useScreenContext.ts
@@ -11,6 +11,17 @@ import type { MovementState, SpriteState } from '@/core/sprite/types'
 import type { ScreenCell } from '@/core/types/execution-types'
 
 /**
+ * Register callbacks that Screen.vue provides to the composable chain.
+ * Grouped so the interface stays compact as more register-* callbacks accumulate.
+ */
+export interface ScreenRenderCallbacks {
+  /** Register callback to schedule a screen render (e.g. on SCREEN_CHANGED). */
+  registerScheduleRender: (fn: () => void) => void
+  /** Register callback to invalidate last-rendered background buffer for full redraw. */
+  registerInvalidateBackgroundBuffer: (fn: () => void) => void
+}
+
+/**
  * Screen context: refs and callbacks for the CRT screen and sprites.
  * Provided by IdePage, consumed by ScreenTab and Screen.
  */
@@ -40,9 +51,8 @@ export interface ScreenContextValue {
   /** Shared joystick buffer (main thread writes, workers read). */
   sharedJoystickBuffer: Ref<SharedArrayBuffer | undefined>
   setDecodedScreenState: (decoded: DecodedScreenState) => void
-  registerScheduleRender: (fn: () => void) => void
-  /** Register callback to invalidate last-rendered background buffer for full redraw. */
-  registerInvalidateBackgroundBuffer?: (fn: () => void) => void
+  /** Register callbacks provided by Screen.vue to the composable chain. */
+  registerCallbacks: ScreenRenderCallbacks
   /** Callback to update inspector MOVE tab data (called by animation loop every frame). */
   updateInspectorMoveSlots?: () => void
 }

--- a/src/features/testing/PositionSyncLoadTestPage.vue
+++ b/src/features/testing/PositionSyncLoadTestPage.vue
@@ -49,7 +49,7 @@ const {
   sharedDisplayViews,
   sharedJoystickBuffer,
   setDecodedScreenState,
-  registerScheduleRender,
+  registerCallbacks,
 } = useBasicIdeEnhanced()
 
 provideScreenContext({
@@ -71,7 +71,7 @@ provideScreenContext({
   sharedAnimationBuffer: ref(sharedAnimationBuffer),
   sharedJoystickBuffer: ref(sharedJoystickBuffer),
   setDecodedScreenState,
-  registerScheduleRender,
+  registerCallbacks,
 })
 
 // Load test: 8 DEF MOVE + 8 POSITION + 8 MOVE (all actions moving)

--- a/src/features/testing/PrintVsSpritesTestPage.vue
+++ b/src/features/testing/PrintVsSpritesTestPage.vue
@@ -49,7 +49,7 @@ const {
   sharedDisplayViews,
   sharedJoystickBuffer,
   setDecodedScreenState,
-  registerScheduleRender,
+  registerCallbacks,
 } = useBasicIdeEnhanced()
 
 provideScreenContext({
@@ -71,7 +71,7 @@ provideScreenContext({
   sharedAnimationBuffer: ref(sharedAnimationBuffer),
   sharedJoystickBuffer: ref(sharedJoystickBuffer),
   setDecodedScreenState,
-  registerScheduleRender,
+  registerCallbacks,
 })
 
 // Disable STDOUT display for FPS test (PRINT still runs; we avoid stdout DOM updates)


### PR DESCRIPTION
## Summary
- Fixes #496

## Changes
- Added `ScreenRenderCallbacks` interface in `useScreenContext.ts` grouping `registerScheduleRender` and `registerInvalidateBackgroundBuffer`
- Updated composable chain (useBasicIdeScreenIntegration → useBasicIdeEnhanced → ScreenContextValue) to pass a single `registerCallbacks` object instead of two separate properties
- Updated all 4 consumers (Screen.vue, IdePage.vue, PrintVsSpritesTestPage.vue, PositionSyncLoadTestPage.vue, PerformanceDiagnosticsPage.vue) to use the new object pattern

## Test plan
- [ ] Targeted tests pass
- [ ] CI passes