### PR TITLE
refactor: resolve #503 - make resetPaletteState pattern robust to new PALETTE_DEFAULTS fields

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -208,15 +208,62 @@ export const PALETTE_DEFAULTS = {
 } as const
 
 /**
- * Reset palette-related state fields to their default values.
- * Accepts a setter callback to support both direct field assignment
- * (e.g. ScreenStateManager private fields) and reactive ref assignment
- * (e.g. Vue .value refs in useBasicIdeExecution).
+ * Maps each PALETTE_DEFAULTS key to the camelCase property name used on
+ * state objects (ScreenStateManager fields, Vue reactive refs, etc.).
+ *
+ * When a new field is added to PALETTE_DEFAULTS, add a corresponding entry
+ * here -- all call sites of resetPaletteState() will automatically pick it up.
  */
-export function resetPaletteState(
-  setter: (defaults: typeof PALETTE_DEFAULTS) => void
-): void {
-  setter(PALETTE_DEFAULTS)
+export const PALETTE_STATE_KEY_MAP = {
+  BG_PALETTE: 'bgPalette',
+  SPRITE_PALETTE: 'spritePalette',
+  BACKDROP_COLOR: 'backdropColor',
+  CGEN_MODE: 'cgenMode',
+} as const satisfies Record<keyof typeof PALETTE_DEFAULTS, string>
+
+/** Writable palette state with camelCase property names. */
+export type PaletteStateValues = {
+  [K in (typeof PALETTE_STATE_KEY_MAP)[keyof typeof PALETTE_STATE_KEY_MAP]]: number
+}
+
+/**
+ * Reset palette-related state fields to their default values.
+ *
+ * Iterates over all PALETTE_DEFAULTS entries and assigns each to the target
+ * object using PALETTE_STATE_KEY_MAP to translate SCREAMING_CASE keys to the
+ * camelCase property names used by state objects. This ensures that adding
+ * a new field to PALETTE_DEFAULTS (and PALETTE_STATE_KEY_MAP) automatically
+ * resets it at every call site -- no per-site updates needed.
+ *
+ * Accepts a target object with writable number properties matching PaletteStateValues.
+ * For Vue reactive refs, wrap with a getter/setter adapter via createPaletteRefTarget().
+ */
+export function resetPaletteState(target: PaletteStateValues): void {
+  const mutable = target as { [key: string]: number }
+  for (const key of Object.keys(PALETTE_DEFAULTS) as (keyof typeof PALETTE_DEFAULTS)[]) {
+    mutable[PALETTE_STATE_KEY_MAP[key]] = PALETTE_DEFAULTS[key]
+  }
+}
+
+/**
+ * Create a palette state target backed by Vue reactive refs.
+ * Returns an object that proxies property reads/writes through .value,
+ * compatible with resetPaletteState().
+ */
+export function createPaletteRefTarget(
+  refs: { [K in keyof PaletteStateValues]: { value: number } },
+): PaletteStateValues {
+  const target = {} as PaletteStateValues
+  for (const key of Object.keys(refs) as (keyof PaletteStateValues)[]) {
+    Object.defineProperty(target, key, {
+      get: () => refs[key].value,
+      set: (value: number) => {
+        refs[key].value = value
+      },
+      enumerable: true,
+    })
+  }
+  return target
 }
 
 // Color patterns and codes

--- a/src/core/devices/ScreenStateManager.ts
+++ b/src/core/devices/ScreenStateManager.ts
@@ -4,7 +4,7 @@
  * Manages screen buffer, cursor position, and screen-related operations.
  */
 
-import { PALETTE_DEFAULTS, resetPaletteState } from '@/core/constants'
+import { PALETTE_DEFAULTS, type PaletteStateValues, resetPaletteState } from '@/core/constants'
 import type { ScreenCell } from '@/core/types/execution-types'
 import type { ScreenUpdateMessage } from '@/core/types/worker-messages'
 import { ORIGINAL_BACKGROUND_PALETTES, ORIGINAL_SPRITE_PALETTES } from '@/shared/data/palette'
@@ -80,12 +80,7 @@ export class ScreenStateManager {
     this.cursorX = 0
     this.cursorY = 0
     // Reset BG/screen state to defaults so stale data does not persist
-    resetPaletteState((d) => {
-      this.bgPalette = d.BG_PALETTE
-      this.spritePalette = d.SPRITE_PALETTE
-      this.backdropColor = d.BACKDROP_COLOR
-      this.cgenMode = d.CGEN_MODE
-    })
+    resetPaletteState(this as PaletteStateValues)
     // Reset palette combinations to original data
     this.resetPalettes()
   }

--- a/src/features/ide/composables/useBasicIdeExecution.ts
+++ b/src/features/ide/composables/useBasicIdeExecution.ts
@@ -3,7 +3,12 @@
  * Depends on state, worker integration, and parseCode from editor.
  */
 
-import { ERROR_MESSAGES, EXECUTION_LIMITS, resetPaletteState } from '@/core/constants'
+import {
+  createPaletteRefTarget,
+  ERROR_MESSAGES,
+  EXECUTION_LIMITS,
+  resetPaletteState,
+} from '@/core/constants'
 import type { BasicVariable } from '@/core/types/state-types'
 import { ExecutionError } from '@/features/ide/errors/ExecutionError'
 import { resetRuntimePalettes } from '@/shared/data/palette'
@@ -45,6 +50,13 @@ export function useBasicIdeExecution(
   parseCode: ParseCodeFn,
   options?: BasicIdeExecutionOptions
 ): BasicIdeExecution {
+  const paletteTarget = createPaletteRefTarget({
+    bgPalette: state.bgPalette,
+    spritePalette: state.spritePalette,
+    backdropColor: state.backdropColor,
+    cgenMode: state.cgenMode,
+  })
+
   const runCode = async () => {
     if (state.isRunning.value) return
 
@@ -59,12 +71,7 @@ export function useBasicIdeExecution(
     resetRuntimePalettes()
     // Reactive state (bgPalette, cgenMode, etc.) — the worker does not send
     // initial palette values at the start of execution, so we must reset here.
-    resetPaletteState((d) => {
-      state.bgPalette.value = d.BG_PALETTE
-      state.spritePalette.value = d.SPRITE_PALETTE
-      state.backdropColor.value = d.BACKDROP_COLOR
-      state.cgenMode.value = d.CGEN_MODE
-    })
+    resetPaletteState(paletteTarget)
 
     try {
       await worker.initializeWebWorker()
@@ -198,12 +205,7 @@ export function useBasicIdeExecution(
     state.cursorX.value = 0
     state.cursorY.value = 0
     // Reset BG/screen state to defaults so stale palettes, backdrop, and cgen do not persist
-    resetPaletteState((d) => {
-      state.bgPalette.value = d.BG_PALETTE
-      state.spritePalette.value = d.SPRITE_PALETTE
-      state.backdropColor.value = d.BACKDROP_COLOR
-      state.cgenMode.value = d.CGEN_MODE
-    })
+    resetPaletteState(paletteTarget)
     // Clear BG items (above), SPRITEs (DEF SPRITE + display)
     state.spriteStates.value = []
     // Do NOT clear spriteEnabled - SPRITE ON/OFF state should persist (Clear only clears display)


### PR DESCRIPTION
## Summary
- Fixes #503

## Changes
- Added `PALETTE_STATE_KEY_MAP` mapping SCREAMING_CASE PALETTE_DEFAULTS keys to camelCase state property names
- Added `PaletteStateValues` derived type for type safety at call sites
- Rewrote `resetPaletteState()` to iterate over keys instead of requiring manual field mapping
- Added `createPaletteRefTarget()` factory for Vue reactive ref targets
- Simplified ScreenStateManager and useBasicIdeExecution call sites — no more manual field listing

## Test plan
- [ ] Targeted tests pass (82/82 — 19 useBasicIdeExecution + 63 ScreenStateManager)
- [ ] CI passes