### PR TITLE
i18n: resolve #505 - localize hardcoded default program name in useProgramStore

### DIFF
--- a/src/features/ide/components/ProgramToolbar.vue
+++ b/src/features/ide/components/ProgramToolbar.vue
@@ -11,7 +11,7 @@ const props = withDefaults(defineProps<{ isCompact?: boolean }>(), {
 })
 
 const { t } = useI18n()
-const programStore = useProgramStore()
+const programStore = useProgramStore(t('common.defaultProgramName'))
 
 // Renaming state
 const editingName = ref(false)
@@ -73,7 +73,8 @@ function handleCancelDiscard(): void {
 
 // File operations
 function handleNew() {
-  confirmDiscard(() => programStore.newProgram())
+  const defaultName = t('common.defaultProgramName')
+  confirmDiscard(() => programStore.newProgram(defaultName))
 }
 
 function handleOpen() {

--- a/src/features/ide/composables/useProgramStore.ts
+++ b/src/features/ide/composables/useProgramStore.ts
@@ -27,6 +27,7 @@ import { useProgramLibrary } from './useProgramLibrary'
 // ============================================================================
 
 const STORAGE_KEY = 'program:current'
+const FALLBACK_PROGRAM_NAME = 'Untitled'
 
 /** Current active program - auto-persisted to localStorage */
 const currentProgram = useLocalStorage<ProgramData | null>(STORAGE_KEY, null, {
@@ -50,12 +51,12 @@ const isInitialized = ref(false)
 /**
  * Create a new empty program
  */
-function newProgram(): void {
+function newProgram(displayName?: string): void {
   const now = Date.now()
   currentProgram.value = {
     version: 1,
     id: generateSessionId(),
-    name: 'Untitled',
+    name: displayName ?? FALLBACK_PROGRAM_NAME,
     code: '',
     bg: compressBg(createEmptyGrid()),
     createdAt: now,
@@ -67,7 +68,7 @@ function newProgram(): void {
 /**
  * Ensure a program exists - restore from localStorage or create new
  */
-function ensureProgram(): void {
+function ensureProgram(displayName?: string): void {
   if (isInitialized.value) return
   isInitialized.value = true
 
@@ -78,7 +79,7 @@ function ensureProgram(): void {
   }
 
   // No program found, create new one
-  newProgram()
+  newProgram(displayName)
 }
 
 /**
@@ -232,9 +233,9 @@ function getBg(): BgGridData {
  * - Dirty state tracking
  * - Auto-persistence to localStorage (via VueUse)
  */
-export function useProgramStore() {
+export function useProgramStore(displayName?: string) {
   // Initialize on first use
-  ensureProgram()
+  ensureProgram(displayName)
 
   return {
     // State (readonly to prevent direct mutation)
@@ -246,7 +247,7 @@ export function useProgramStore() {
       return currentProgram.value?.id ?? null
     },
     get programName() {
-      return currentProgram.value?.name ?? 'Untitled'
+      return currentProgram.value?.name ?? FALLBACK_PROGRAM_NAME
     },
     get code() {
       return currentProgram.value?.code ?? ''

--- a/src/shared/i18n/locales/en/common.json
+++ b/src/shared/i18n/locales/en/common.json
@@ -37,5 +37,6 @@
     "toggleCollapse": "Toggle collapse",
     "clear": "Clear",
     "close": "Close"
-  }
+  },
+  "defaultProgramName": "Untitled"
 }

--- a/src/shared/i18n/locales/ja/common.json
+++ b/src/shared/i18n/locales/ja/common.json
@@ -37,5 +37,6 @@
     "toggleCollapse": "折りたたみの切り替え",
     "clear": "クリア",
     "close": "閉じる"
-  }
+  },
+  "defaultProgramName": "無題"
 }

--- a/src/shared/i18n/locales/zh-CN/common.json
+++ b/src/shared/i18n/locales/zh-CN/common.json
@@ -37,5 +37,6 @@
     "toggleCollapse": "切换折叠",
     "clear": "清除",
     "close": "关闭"
-  }
+  },
+  "defaultProgramName": "未命名"
 }

--- a/src/shared/i18n/locales/zh-TW/common.json
+++ b/src/shared/i18n/locales/zh-TW/common.json
@@ -37,5 +37,6 @@
     "toggleCollapse": "切換摺疊",
     "clear": "清除",
     "close": "關閉"
-  }
+  },
+  "defaultProgramName": "未命名"
 }


### PR DESCRIPTION
## Summary
- Fixes #505

## Changes
- Added `defaultProgramName` key to all 4 locale `common.json` files (en: "Untitled", ja: "無題", zh-CN: "未命名", zh-TW: "未命名")
- Added `FALLBACK_PROGRAM_NAME` constant and `displayName?: string` parameter to `newProgram()`, `ensureProgram()`, and `useProgramStore()`
- `ProgramToolbar.vue` passes `t('common.defaultProgramName')` when creating new programs

## Test plan
- [ ] Targeted tests pass (11/11 useProgramStore)
- [ ] Full test suite passes (3355/3355)
- [ ] CI passes