### PR TITLE
enhancement: resolve #521 - add escape key support to dismiss InputModal

### DIFF
--- a/src/features/ide/components/InputModal.vue
+++ b/src/features/ide/components/InputModal.vue
@@ -56,6 +56,7 @@ watch(
     role="dialog"
     aria-modal="true"
     aria-labelledby="input-modal-prompt"
+    @keydown.escape="cancel"
   >
     <div class="input-modal">
       <p id="input-modal-prompt" class="input-modal-prompt">


### PR DESCRIPTION
## Summary
- Fixes #521

## Changes
- Added `@keydown.escape="cancel"` to the `.input-modal-overlay` div in InputModal.vue
- Escape key now dismisses the modal, same as clicking Cancel

## Test plan
- [ ] Type-check passes
- [ ] ESLint passes
- [ ] CI passes