### PR TITLE
fix: resolve #555 - add THEN-less IF grammar alternative

### DIFF
--- a/src/core/parser/parser-statements-core.ts
+++ b/src/core/parser/parser-statements-core.ts
@@ -341,14 +341,16 @@ export function registerCoreStatementRules(
 
   // IF LogicalExpression THEN (CommandList | NumberLiteral)
   // IF LogicalExpression GOTO NumberLiteral
-  // Executes the commands after THEN or jumps to line number if condition is true
+  // IF LogicalExpression CommandList  (THEN-less IF — bare command)
+  // Executes the commands after THEN (or directly, if THEN is omitted) or jumps to line number if condition is true
   // Supports colon-separated statements: IF X THEN PRINT A: PRINT B
   // Supports line number jumps: IF X=10 THEN 500 or IF X=10 GOTO 500
   // Supports logical operators: IF X>0 AND Y<10 THEN 100, IF NOT X=0 THEN PRINT X
+  // Supports THEN-less form: IF X=1 PRINT "X=1", IF A=0 BEEP
   p.ifThenStatement = p.RULE('ifThenStatement', () => {
     p.CONSUME(If)
     p.SUBRULE(p.logicalExpression)
-    // THEN or GOTO (GOTO can be used without THEN)
+    // THEN, GOTO, or bare command (THEN-less IF)
     p.OR([
       {
         // IF ... THEN NumberLiteral (line number jump)
@@ -371,6 +373,14 @@ export function registerCoreStatementRules(
         ALT: () => {
           p.CONSUME(Goto)
           p.CONSUME2(NumberLiteral) // Use CONSUME2 for second occurrence
+        },
+      },
+      {
+        // IF ... CommandList (THEN-less IF — bare command after condition)
+        GATE: () =>
+          p.LA(1).tokenType !== Then && p.LA(1).tokenType !== Goto,
+        ALT: () => {
+          p.SUBRULE2(p.commandList)
         },
       },
     ])

--- a/test/parser/IfThenStatement.test.ts
+++ b/test/parser/IfThenStatement.test.ts
@@ -126,13 +126,60 @@ describe('IF-THEN Statement', () => {
       expect(result.success).toBe(true)
     })
 
-    it('should reject IF without THEN', () => {
-      const source = '10 IF X = 5 PRINT "Error"'
+    it('should parse IF without THEN (THEN-less IF with PRINT)', () => {
+      const source = '10 IF X = 1 PRINT "X=1"'
       const result = parseWithChevrotain(source)
 
-      expect(result.success).toBe(false)
-      expect(result.errors).toBeDefined()
-      expect(result.errors?.length).toBeGreaterThan(0)
+      expect(result.success).toBe(true)
+      expect(result.cst).toBeDefined()
+
+      const statements = result.cst?.children.statement
+      expect(statements).toBeDefined()
+
+      const statementCst = getFirstCstNode(statements)
+      expect(statementCst).toBeDefined()
+
+      if (!statementCst) return
+
+      const commandListCst = getFirstCstNode(statementCst.children.commandList)
+      expect(commandListCst).toBeDefined()
+
+      if (!commandListCst) return
+
+      const commandCst = getFirstCstNode(commandListCst.children.command)
+      expect(commandCst).toBeDefined()
+
+      if (!commandCst) return
+
+      const singleCommandCst = getFirstCstNode(commandCst.children.singleCommand)
+      expect(singleCommandCst).toBeDefined()
+
+      if (!singleCommandCst) return
+
+      const ifThenStmtCst = getFirstCstNode(singleCommandCst.children.ifThenStatement)
+      expect(ifThenStmtCst).toBeDefined()
+
+      if (!ifThenStmtCst) return
+
+      // THEN-less IF should have logicalExpression and commandList (no THEN token)
+      expect(ifThenStmtCst.children.logicalExpression).toBeDefined()
+      expect(ifThenStmtCst.children.commandList).toBeDefined()
+      // THEN token should NOT be present
+      expect(ifThenStmtCst.children.Then).toBeUndefined()
+    })
+
+    it('should parse IF without THEN with LET assignment', () => {
+      const source = '10 IF A = 0 Y = 10'
+      const result = parseWithChevrotain(source)
+
+      expect(result.success).toBe(true)
+    })
+
+    it('should parse IF without THEN with BEEP command', () => {
+      const source = '10 IF A = 0 BEEP'
+      const result = parseWithChevrotain(source)
+
+      expect(result.success).toBe(true)
     })
 
     it('should reject IF-THEN without condition', () => {


### PR DESCRIPTION
## Summary
- Fixes #555 — Step 1 of 3 for #549

## Changes
- Added 4th OR alternative to `ifThenStatement` grammar rule: bare `commandList` with GATE excluding `Then`/`Goto` tokens
- Replaced "should reject IF without THEN" test with "should parse IF without THEN" (with CST verification)
- Added 2 new acceptance tests: THEN-less IF with LET assignment and BEEP command
- Grammar change only — no runtime execution changes

## CST Structure
THEN-less IF produces same CST as `IF ... THEN CommandList`, but `children.Then` is `undefined` (absent). Runtime (Step 2) can use this to distinguish and implement colon-scoped execution.

## Test plan
- [x] `IfThenStatement.test.ts`: 22/22 pass
- [x] `IfThenLineNumber.test.ts`: 10/10 pass
- [x] `parser-statements-core.test.ts`: 73/73 pass
- [x] `IfThenExecutor.test.ts`: 31/31 pass
- [x] TypeScript type-check: pass
- [x] ESLint: pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)