### PR TITLE
fix: resolve #570 - ignore .automation directory in Vite dev server file watcher

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
       'Cross-Origin-Embedder-Policy': 'require-corp',
       'Cross-Origin-Resource-Policy': 'cross-origin',
     },
+    watch: {
+      ignored: ['.automation/**'],
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Fixes #570

## Changes
- Added `server.watch.ignored: ['.automation/**']` to `vite.config.ts` to prevent Vite's file watcher from monitoring `.automation/worktrees/` directories
- This eliminates unnecessary HMR rebuilds triggered by changes in git worktrees

## Test plan
- [ ] `pnpm dev` no longer triggers rebuilds when files in `.automation/worktrees/` change
- [ ] CI passes