### PR TITLE
refactor: resolve #515 - add tabBg to StateInspector tab header casing regression test

### DIFF
--- a/test/ide/StateInspector.test.ts
+++ b/test/ide/StateInspector.test.ts
@@ -90,14 +90,15 @@ describe('StateInspector MOVE tab data', () => {
 
 describe('StateInspector tab header casing consistency', () => {
   it('all inspector tab labels are uppercase in English locale', () => {
-    const { tabPalette, tabSprite, tabMove } = enIde.stateInspector
+    const { tabPalette, tabSprite, tabMove, tabBg } = enIde.stateInspector
 
     expect(tabPalette).toBe('PALETTE')
     expect(tabSprite).toBe('SPRITE')
     expect(tabMove).toBe('MOVE')
+    expect(tabBg).toBe('BG')
 
-    // Regression: all three tab labels must be fully uppercase (F-BASIC keyword style)
-    for (const label of [tabPalette, tabSprite, tabMove]) {
+    // Regression: all tab labels must be fully uppercase (F-BASIC keyword style)
+    for (const label of [tabPalette, tabSprite, tabMove, tabBg]) {
       expect(label).toBe(label.toUpperCase())
     }
   })


### PR DESCRIPTION
## Summary
- Fixes #515

## Changes
- Added `tabBg` to the StateInspector tab header casing consistency regression test
- Destructured `tabBg` from `enIde.stateInspector`, added `expect(tabBg).toBe('BG')` assertion
- Included `tabBg` in the uppercase regression loop
- Updated comment from "all three tab labels" to "all tab labels"

## Test plan
- [ ] `pnpm test:run -- test/ide/StateInspector.test.ts` passes
- [ ] CI passes