### PR TITLE
refactor: resolve #523 - remove redundant label field from PALETTE_REFS test data

### DIFF
--- a/test/features/ide/composables/useBasicIdeExecution.test.ts
+++ b/test/features/ide/composables/useBasicIdeExecution.test.ts
@@ -293,15 +293,15 @@ describe('useBasicIdeExecution', () => {
 
   /** Palette reactive refs that should be reset by clearOutput/runCode. */
   const PALETTE_REFS = [
-    { key: 'bgPalette', nonDefault: 0, expected: PALETTE_DEFAULTS.BG_PALETTE, label: 'bgPalette' },
-    { key: 'cgenMode', nonDefault: 0, expected: PALETTE_DEFAULTS.CGEN_MODE, label: 'cgenMode' },
-    { key: 'backdropColor', nonDefault: 1, expected: PALETTE_DEFAULTS.BACKDROP_COLOR, label: 'backdropColor' },
-    { key: 'spritePalette', nonDefault: 2, expected: PALETTE_DEFAULTS.SPRITE_PALETTE, label: 'spritePalette' },
+    { key: 'bgPalette', nonDefault: 0, expected: PALETTE_DEFAULTS.BG_PALETTE },
+    { key: 'cgenMode', nonDefault: 0, expected: PALETTE_DEFAULTS.CGEN_MODE },
+    { key: 'backdropColor', nonDefault: 1, expected: PALETTE_DEFAULTS.BACKDROP_COLOR },
+    { key: 'spritePalette', nonDefault: 2, expected: PALETTE_DEFAULTS.SPRITE_PALETTE },
   ] as const
 
   describe('clearOutput resets palette reactive state (issue #444)', () => {
     it.each(PALETTE_REFS)(
-      'should reset $label to default when clearOutput is called',
+      'should reset $key to default when clearOutput is called',
       ({ key, nonDefault, expected }) => {
         const state = createState()
         state[key].value = nonDefault
@@ -318,7 +318,7 @@ describe('useBasicIdeExecution', () => {
 
   describe('runCode resets palette reactive state (issue #435)', () => {
     it.each(PALETTE_REFS)(
-      'should reset $label to default when runCode is called',
+      'should reset $key to default when runCode is called',
       async ({ key, nonDefault, expected }) => {
         const state = createState()
         state[key].value = nonDefault


### PR DESCRIPTION
## Summary
- Fixes #523

## Changes
- Removed `label` property from all 4 `PALETTE_REFS` entries in `useBasicIdeExecution.test.ts` (identical to `key`)
- Updated `it.each` test names from `$label` to `$key`

## Test plan
- [x] useBasicIdeExecution.test.ts: 82/82 pass
- [x] All 3381 tests pass across 242 files (green-before and green-after)
- [x] TypeScript type-check: pass
- [x] ESLint: pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)