### PR TITLE
refactor: resolve #542 - simplify overly defensive triple fallback in fillCanvasWithBackdrop

### DIFF
--- a/src/features/ide/composables/useCanvasBackgroundRenderer.ts
+++ b/src/features/ide/composables/useCanvasBackgroundRenderer.ts
@@ -122,7 +122,7 @@ function fillCanvasWithBackdrop(
   canvas: HTMLCanvasElement,
   backdropColorCode: number
 ): void {
-  const color = COLORS[backdropColorCode] ?? COLORS[DEFAULT_BACKDROP_COLOR] ?? '#000000'
+  const color = COLORS[backdropColorCode] ?? COLORS[DEFAULT_BACKDROP_COLOR]!
   ctx.fillStyle = color
   ctx.fillRect(0, 0, canvas.width, canvas.height)
 }


### PR DESCRIPTION
## Summary
- Fixes #542

## Changes
- Simplified triple fallback `COLORS[backdropColorCode] ?? COLORS[DEFAULT_BACKDROP_COLOR] ?? '#000000'` to `COLORS[backdropColorCode] ?? COLORS[DEFAULT_BACKDROP_COLOR]!`
- Removed redundant `?? '#000000'` since `COLORS[0]` is a hardcoded array entry that always exists
- Added non-null assertion (`!`) to satisfy TypeScript strict typing on array index access

## Test plan
- [x] Targeted tests pass (3383 tests, 242 files)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)