### PR TITLE
test: resolve #547 - add localStorage persistence test for useProgramStore setCode

### DIFF
--- a/test/ide/useProgramStore.test.ts
+++ b/test/ide/useProgramStore.test.ts
@@ -112,6 +112,21 @@ describe('useProgramStore', () => {
     expect(parsed.name).toBe('Twinkle Star')
   })
 
+  it('should persist code change to localStorage', async () => {
+    const { useProgramStore } = await import('@/features/ide/composables/useProgramStore')
+    const store = useProgramStore()
+
+    store.setCode('10 PRINT "HELLO"')
+
+    // Wait for VueUse's useLocalStorage to sync
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const stored = localStorage.getItem('program:current')
+    expect(stored).not.toBeNull()
+    const parsed = JSON.parse(stored!) as ProgramData
+    expect(parsed.code).toBe('10 PRINT "HELLO"')
+  })
+
   it('should load program and clear dirty', async () => {
     const { useProgramStore } = await import('@/features/ide/composables/useProgramStore')
     const store = useProgramStore()


### PR DESCRIPTION
## Summary
- Fixes #547

## Changes
- Added test verifying `setCode()` persists code changes to localStorage
- Mirrors the existing `setName()` persistence test pattern

## Test plan
- [x] Targeted tests pass (14/14 in useProgramStore.test.ts)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)