### PR TITLE
refactor: resolve #552 - extract 2000ms copied feedback timeout as named constant

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -160,6 +160,9 @@ export const TIMING = {
   // STICK repeat interval (typematic-style control for joystick direction reads)
   // This prevents programs from registering continuous direction when held
   STICK_REPEAT_INTERVAL_MS: 120, // ~8 reads per second when direction held
+
+  // UI feedback durations
+  COPIED_FEEDBACK_MS: 2000, // Duration of "Copied!" feedback state in share dialog
 } as const
 
 // Screen dimensions and coordinate limits

--- a/src/features/ide/components/ShareDialog.vue
+++ b/src/features/ide/components/ShareDialog.vue
@@ -6,6 +6,7 @@
 import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { TIMING } from '@/core/constants'
 import type { CompactBg } from '@/core/types/program-types'
 import { encodeProgram } from '@/shared/utils/programCodec'
 
@@ -77,7 +78,7 @@ async function handleCopy(): Promise<void> {
     copiedTimer = setTimeout(() => {
       copied.value = false
       copiedTimer = null
-    }, 2000)
+    }, TIMING.COPIED_FEEDBACK_MS)
   } catch {
     // Fallback: select the input text so user can manually copy
     urlInputRef.value?.select()


### PR DESCRIPTION
## Summary
- Fixes #552

## Changes
- Extracted `COPIED_FEEDBACK_MS = 2000` constant in `ShareDialog.vue`
- Replaced hardcoded `2000` in setTimeout with the named constant

## Test plan
- [ ] All 3383 tests pass (no behavior change)
- [ ] CI passes