### PR TITLE
chore: resolve #525 - upgrade CI actions to resolve Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.18.2
           run_install: false
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.18.2
           run_install: false
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.18.2
           run_install: false
@@ -115,7 +115,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.18.2
           run_install: false
@@ -130,7 +130,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
## Summary
- Fixes #525

## Changes
- Upgrade `pnpm/action-setup@v4` → `pnpm/action-setup@v5` in all 4 CI jobs (lint-and-typecheck, test, build, e2e)
- Upgrade `actions/cache@v4` → `actions/cache@v5` in e2e job
- Both v5 releases run on Node.js 24, resolving deprecation warnings

## Test plan
- [ ] CI passes with upgraded actions