### PR TITLE
chore: resolve #526 - approve esbuild build scripts in pnpm configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
## Summary
- Fixes #526

## Changes
- Created `pnpm-workspace.yaml` with `onlyBuiltDependencies: [esbuild]` to allow esbuild's native binary postinstall script
- Eliminates "Ignored build scripts: esbuild" warning from all CI jobs

## Test plan
- [ ] CI passes without esbuild warnings
- [ ] pnpm install --frozen-lockfile runs cleanly