### PR TITLE
refactor: resolve #528 - use SPRITE_COUNT constant in getSpriteState bounds test assertions

### DIFF
--- a/test/integration/TestProgram.test.ts
+++ b/test/integration/TestProgram.test.ts
@@ -7,6 +7,8 @@
 
 import { describe, expect, it } from 'vitest'
 
+import { SCREEN_DIMENSIONS } from '@/core/constants'
+
 import { TestProgram } from './TestProgram'
 
 describe('TestProgram', () => {
@@ -192,7 +194,7 @@ describe('TestProgram', () => {
       await tp.run()
       expect(() => tp.getSpriteState(-1)).toThrow(RangeError)
       expect(() => tp.getSpriteState(-1)).toThrow(
-        'spriteNumber must be 0-7, got -1'
+        `spriteNumber must be 0-${SCREEN_DIMENSIONS.SPRITE_COUNT - 1}, got -1`
       )
     })
 
@@ -201,7 +203,7 @@ describe('TestProgram', () => {
       await tp.run()
       expect(() => tp.getSpriteState(8)).toThrow(RangeError)
       expect(() => tp.getSpriteState(8)).toThrow(
-        'spriteNumber must be 0-7, got 8'
+        `spriteNumber must be 0-${SCREEN_DIMENSIONS.SPRITE_COUNT - 1}, got 8`
       )
     })
 


### PR DESCRIPTION
## Summary
- Fixes #528

## Changes
- Replaced 2 hardcoded `'0-7'` range strings in error message assertions with `` `0-${SCREEN_DIMENSIONS.SPRITE_COUNT - 1}` `` template literals
- Added `SCREEN_DIMENSIONS` import from `@/core/constants`

## Test plan
- [ ] Targeted tests pass
- [ ] CI passes