### PR TITLE
refactor: resolve #565 - remove inline fallback strings from NotFoundPage.vue

### DIFF
--- a/src/features/error/NotFoundPage.vue
+++ b/src/features/error/NotFoundPage.vue
@@ -24,12 +24,12 @@ const goHome = () => {
   <GameLayout>
     <div class="not-found-content">
       <div class="error-code">404</div>
-      <h1 class="error-title">{{ t('errors.notFound.title', 'Page Not Found') }}</h1>
+      <h1 class="error-title">{{ t('errors.notFound.title') }}</h1>
       <p class="error-message">
-        {{ t('errors.notFound.message', 'The page you are looking for does not exist or has been moved.') }}
+        {{ t('errors.notFound.message') }}
       </p>
       <GameButton type="primary" @click="goHome">
-        {{ t('errors.notFound.goHome', 'Go to Home') }}
+        {{ t('errors.notFound.goHome') }}
       </GameButton>
     </div>
   </GameLayout>


### PR DESCRIPTION
## Summary
- Fixes #565

## Changes
- Removed inline fallback strings from 3 `t()` calls in NotFoundPage.vue
- Locale keys `errors.notFound.*` are now confirmed reliable (PR #562), eliminating dual-maintenance

## Test plan
- [ ] Targeted tests pass
- [ ] CI passes