### PR TITLE
refactor: resolve #590 - use data-testid for ShareDialog close button instead of position-based selection

### DIFF
--- a/src/features/ide/components/ShareDialog.vue
+++ b/src/features/ide/components/ShareDialog.vue
@@ -171,6 +171,7 @@ onUnmounted(() => {
             </button>
             <button
               class="share-dialog-btn share-dialog-btn-close"
+              data-testid="share-close-button"
               @click="handleClose"
             >
               {{ t('ide.share.close') }}

--- a/test/ide/ShareDialog.test.ts
+++ b/test/ide/ShareDialog.test.ts
@@ -275,9 +275,7 @@ describe('ShareDialog', () => {
     await openDialog(wrapper)
     await waitForEncoding()
 
-    const buttons = wrapper.findAll('.share-dialog-btn')
-    // Close button is the second button
-    await buttons[1]!.trigger('click')
+    await wrapper.find('[data-testid="share-close-button"]').trigger('click')
 
     expect(wrapper.emitted('close')).toHaveLength(1)
     wrapper.unmount()


### PR DESCRIPTION
## Summary
- Fixes #590
- Supersedes #589 (includes all 20 ShareDialog unit tests plus the testid improvement)

## Changes
- Added `data-testid="share-close-button"` to close button in ShareDialog.vue
- Replaced position-based `findAll('.share-dialog-btn')[1]` with `find('[data-testid="share-close-button"]')` in test
- Includes 20 unit tests for ShareDialog (from PR #589 review follow-up)

## Test plan
- [ ] Targeted tests pass (20/20 ShareDialog tests)
- [ ] CI passes