### PR TITLE
feat: resolve #603 - create BufferInspector shell component with tab integration

### DIFF
--- a/src/features/ide/components/BufferInspector.vue
+++ b/src/features/ide/components/BufferInspector.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+import { GameBlock } from '@/shared/components/ui'
+
+defineOptions({
+  name: 'BufferInspector',
+})
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <GameBlock
+    :title="t('ide.bufferInspector.title')"
+    title-icon="mdi:memory"
+    :hide-header="true"
+    class="buffer-inspector"
+  >
+    <div class="buffer-inspector-content" />
+  </GameBlock>
+</template>
+
+<style scoped>
+.buffer-inspector {
+  height: 100%;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.buffer-inspector :deep(.game-block-content) {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.buffer-inspector-content {
+  flex: 1 1 0;
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+</style>

--- a/src/features/ide/components/IdeBottomArea.vue
+++ b/src/features/ide/components/IdeBottomArea.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
-import { useTemplateRef } from 'vue'
+import { ref, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import type { SpriteState } from '@/core/sprite/types'
 import type { ScreenCell } from '@/core/types/execution-types'
+import { GameTabPane, GameTabs } from '@/shared/components/ui'
 
+import BufferInspector from './BufferInspector.vue'
 import JoystickControl from './JoystickControl.vue'
 import StateInspector from './StateInspector.vue'
 
 /**
- * IdeBottomArea - Bottom panel containing Joystick and StateInspector.
+ * IdeBottomArea - Bottom panel containing Joystick and inspector tabs.
  * Extracted from IdePage to reduce file size.
  */
 
@@ -37,6 +40,9 @@ interface Props {
   sharedDisplayBufferAccessor: SharedDisplayBufferAccessor
 }
 
+const { t } = useI18n()
+const activeTab = ref('state')
+
 // StateInspector ref for animation loop to call updateMoveSlotsData
 const stateInspectorRef = useTemplateRef<{ updateMoveSlotsData: () => void }>('stateInspectorRef')
 
@@ -55,19 +61,26 @@ defineExpose({
       />
     </div>
     <div class="bottom-right">
-      <StateInspector
-        ref="stateInspectorRef"
-        :screen-buffer="screenBuffer"
-        :cursor-x="cursorX"
-        :cursor-y="cursorY"
-        :bg-palette="bgPalette"
-        :sprite-palette="spritePalette"
-        :backdrop-color="backdropColor"
-        :cgen-mode="cgenMode"
-        :sprite-states="spriteStates"
-        :sprite-enabled="spriteEnabled"
-        :shared-display-buffer-accessor="sharedDisplayBufferAccessor"
-      />
+      <GameTabs v-model="activeTab" type="border-card" class="inspector-tabs">
+        <GameTabPane name="state" :label="t('ide.stateInspector.title')">
+          <StateInspector
+            ref="stateInspectorRef"
+            :screen-buffer="screenBuffer"
+            :cursor-x="cursorX"
+            :cursor-y="cursorY"
+            :bg-palette="bgPalette"
+            :sprite-palette="spritePalette"
+            :backdrop-color="backdropColor"
+            :cgen-mode="cgenMode"
+            :sprite-states="spriteStates"
+            :sprite-enabled="spriteEnabled"
+            :shared-display-buffer-accessor="sharedDisplayBufferAccessor"
+          />
+        </GameTabPane>
+        <GameTabPane name="buffer" :label="t('ide.bufferInspector.title')">
+          <BufferInspector />
+        </GameTabPane>
+      </GameTabs>
     </div>
   </div>
 </template>
@@ -92,5 +105,15 @@ defineExpose({
   min-height: 0;
   display: flex;
   flex-direction: column;
+}
+
+.inspector-tabs {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+  z-index: 1;
 }
 </style>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -402,6 +402,9 @@
     "cursor": "Cursor",
     "empty": "(none)"
   },
+  "bufferInspector": {
+    "title": "Buffer Inspector"
+  },
   "logLevels": {
     "title": "Log Levels",
     "description": "Set verbosity per area. {warn} = quiet; {debug} = verbose.",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -402,6 +402,9 @@
     "cursor": "カーソル",
     "empty": "（なし）"
   },
+  "bufferInspector": {
+    "title": "バッファインスペクタ"
+  },
   "logLevels": {
     "title": "ログレベル",
     "description": "各領域の詳細度を設定します。{warn} = 静か；{debug} = 詳細。",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -402,6 +402,9 @@
     "cursor": "光标",
     "empty": "（无）"
   },
+  "bufferInspector": {
+    "title": "缓冲区检查器"
+  },
   "logLevels": {
     "title": "日志级别",
     "description": "设置各区域的详细程度。{warn} = 安静；{debug} = 详细。",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -402,6 +402,9 @@
     "cursor": "游標",
     "empty": "（無）"
   },
+  "bufferInspector": {
+    "title": "緩衝區檢查器"
+  },
   "logLevels": {
     "title": "日誌級別",
     "description": "設定各區域的詳細程度。{warn} = 安靜；{debug} = 詳細。",

--- a/test/ide/BufferInspector.test.ts
+++ b/test/ide/BufferInspector.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
+import BufferInspector from '@/features/ide/components/BufferInspector.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+/** Minimal mock satisfying SharedDisplayBufferAccessor type (never called in stubbed tests) */
+const MOCK_ACCESSOR: SharedDisplayBufferAccessor = {} as SharedDisplayBufferAccessor
+
+describe('BufferInspector', () => {
+  it('renders without errors', () => {
+    const wrapper = mount(BufferInspector, {
+      global: {
+        stubs: {
+          GameBlock: defineComponent({ template: '<div><slot /></div>' }),
+        },
+      },
+    })
+
+    expect(wrapper.exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('has the correct component name', () => {
+    const wrapper = mount(BufferInspector, {
+      global: {
+        stubs: {
+          GameBlock: defineComponent({ template: '<div><slot /></div>' }),
+        },
+      },
+    })
+
+    expect(wrapper.vm.$options.name).toBe('BufferInspector')
+    wrapper.unmount()
+  })
+
+  it('displays the title from i18n key', () => {
+    const wrapper = mount(BufferInspector, {
+      global: {
+        stubs: {
+          GameBlock: defineComponent({
+            props: ['title'],
+            template: '<div class="game-block-stub" :data-title="title"><slot /></div>',
+          }),
+        },
+      },
+    })
+
+    const block = wrapper.find('.game-block-stub')
+    expect(block.exists()).toBe(true)
+    expect(block.attributes('data-title')).toBe('ide.bufferInspector.title')
+    wrapper.unmount()
+  })
+
+  it('renders empty content area', () => {
+    const wrapper = mount(BufferInspector, {
+      global: {
+        stubs: {
+          GameBlock: defineComponent({ template: '<div><slot /></div>' }),
+        },
+      },
+    })
+
+    // Component should exist with no errors, content is empty shell
+    expect(wrapper.find('.buffer-inspector-content').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})
+
+describe('IdeBottomArea tab integration', () => {
+  it('renders both StateInspector and BufferInspector tab panes', async () => {
+    // Dynamic import to avoid module caching issues
+    const ideBottomArea = (await import('@/features/ide/components/IdeBottomArea.vue')).default
+
+    const wrapper = mount(ideBottomArea, {
+      props: {
+        screenBuffer: [],
+        cursorX: 0,
+        cursorY: 0,
+        bgPalette: 1,
+        spritePalette: 1,
+        backdropColor: 0,
+        cgenMode: 2,
+        spriteStates: [],
+        spriteEnabled: false,
+        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+      },
+      global: {
+        stubs: {
+          JoystickControl: true,
+          StateInspector: true,
+          BufferInspector: true,
+          GameBlock: defineComponent({
+            props: ['title', 'titleIcon', 'hideHeader'],
+            template: '<div class="game-block-stub"><slot /></div>',
+          }),
+          GameTabs: defineComponent({
+            props: ['modelValue', 'type'],
+            template: '<div class="game-tabs-stub"><slot /></div>',
+          }),
+          GameTabPane: defineComponent({
+            props: ['name', 'label'],
+            template: '<div class="game-tab-pane-stub" :data-name="name"><slot /></div>',
+          }),
+        },
+      },
+    })
+
+    const tabPanes = wrapper.findAll('.game-tab-pane-stub')
+    expect(tabPanes.length).toBe(2)
+
+    const names = tabPanes.map(p => p.attributes('data-name'))
+    expect(names).toContain('state')
+    expect(names).toContain('buffer')
+
+    wrapper.unmount()
+  })
+
+  it('defaults to the state tab being active', async () => {
+    const ideBottomAreaComponent = (await import('@/features/ide/components/IdeBottomArea.vue')).default
+
+    const wrapper = mount(ideBottomAreaComponent, {
+      props: {
+        screenBuffer: [],
+        cursorX: 0,
+        cursorY: 0,
+        bgPalette: 1,
+        spritePalette: 1,
+        backdropColor: 0,
+        cgenMode: 2,
+        spriteStates: [],
+        spriteEnabled: false,
+        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+      },
+      global: {
+        stubs: {
+          JoystickControl: true,
+          StateInspector: true,
+          BufferInspector: true,
+          GameBlock: defineComponent({
+            props: ['title', 'titleIcon', 'hideHeader'],
+            template: '<div class="game-block-stub"><slot /></div>',
+          }),
+          GameTabs: defineComponent({
+            props: ['modelValue', 'type'],
+            template: '<div class="game-tabs-stub" :data-active="modelValue"><slot /></div>',
+          }),
+          GameTabPane: defineComponent({
+            props: ['name', 'label'],
+            template: '<div class="game-tab-pane-stub" :data-name="name"><slot /></div>',
+          }),
+        },
+      },
+    })
+
+    const tabs = wrapper.find('.game-tabs-stub')
+    expect(tabs.attributes('data-active')).toBe('state')
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #603 — Step 1 of 8 for #531

## Changes
- Created `BufferInspector.vue` shell component with GameBlock wrapper
- Added GameTabs wrapping StateInspector + BufferInspector in IdeBottomArea.vue
- Default active tab is "state" to preserve existing UX
- Added i18n keys for "Buffer Inspector" title in all 4 locales (en, ja, zh-CN, zh-TW)
- 6 unit tests covering component rendering and tab integration

## Test plan
- [ ] 8 targeted tests pass (6 new + 2 existing StateInspector)
- [ ] CI passes