### PR TITLE
feat: resolve #611 - create useScreenFilter composable with toggle and persistence

### DIFF
--- a/src/features/ide/composables/useScreenFilter.ts
+++ b/src/features/ide/composables/useScreenFilter.ts
@@ -1,0 +1,47 @@
+/**
+ * useScreenFilter composable
+ *
+ * Manages CRT/NTSC visual filter toggle state for the screen display.
+ * Step 1 of the CRT filter feature (#534).
+ *
+ * Uses VueUse's useLocalStorage for persistence across sessions.
+ * Designed to be extensible for Steps 2-5 (scanline, phosphor glow,
+ * curvature, vignette layers).
+ */
+
+import { useLocalStorage } from '@vueuse/core'
+import { computed } from 'vue'
+
+const FILTER_STORAGE_KEY = 'fbasic-screen-filter'
+
+/**
+ * Composable for managing the screen CRT filter state.
+ *
+ * Provides a reactive `filterEnabled` boolean that persists to localStorage.
+ * Future steps will add individual layer toggles (scanline, phosphor, etc.)
+ * on top of this master toggle.
+ */
+export function useScreenFilter() {
+  const isEnabled = useLocalStorage<boolean>(FILTER_STORAGE_KEY, false, {
+    serializer: {
+      read: (value: string): boolean => value === 'true',
+      write: (value: boolean): string => String(value),
+    },
+  })
+
+  const filterEnabled = computed(() => isEnabled.value)
+
+  function toggleFilter(): void {
+    isEnabled.value = !isEnabled.value
+  }
+
+  function setFilterEnabled(enabled: boolean): void {
+    isEnabled.value = enabled
+  }
+
+  return {
+    filterEnabled,
+    toggleFilter,
+    setFilterEnabled,
+  }
+}

--- a/test/features/ide/composables/useScreenFilter.test.ts
+++ b/test/features/ide/composables/useScreenFilter.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useScreenFilter } from '@/features/ide/composables/useScreenFilter'
+
+describe('useScreenFilter', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('default state', () => {
+    it('returns filterEnabled as false by default', () => {
+      const { filterEnabled } = useScreenFilter()
+
+      expect(filterEnabled.value).toEqual(false)
+    })
+  })
+
+  describe('toggleFilter', () => {
+    it('toggles filterEnabled from false to true', () => {
+      const { filterEnabled, toggleFilter } = useScreenFilter()
+
+      toggleFilter()
+
+      expect(filterEnabled.value).toEqual(true)
+    })
+
+    it('toggles filterEnabled from true back to false', () => {
+      const { filterEnabled, toggleFilter } = useScreenFilter()
+
+      toggleFilter()
+      expect(filterEnabled.value).toEqual(true)
+
+      toggleFilter()
+
+      expect(filterEnabled.value).toEqual(false)
+    })
+  })
+
+  describe('setFilterEnabled', () => {
+    it('sets filterEnabled to true', () => {
+      const { filterEnabled, setFilterEnabled } = useScreenFilter()
+
+      setFilterEnabled(true)
+
+      expect(filterEnabled.value).toEqual(true)
+    })
+
+    it('sets filterEnabled to false', () => {
+      const { filterEnabled, setFilterEnabled } = useScreenFilter()
+
+      setFilterEnabled(true)
+      setFilterEnabled(false)
+
+      expect(filterEnabled.value).toEqual(false)
+    })
+  })
+
+  describe('localStorage persistence', () => {
+    it('persists enabled state to localStorage', async () => {
+      const { setFilterEnabled } = useScreenFilter()
+
+      setFilterEnabled(true)
+
+      // VueUse's useLocalStorage writes to localStorage via watch (flush: post)
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      expect(localStorage.getItem('fbasic-screen-filter')).toEqual('true')
+    })
+
+    it('persists disabled state to localStorage', async () => {
+      const { setFilterEnabled } = useScreenFilter()
+
+      setFilterEnabled(false)
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      expect(localStorage.getItem('fbasic-screen-filter')).toEqual('false')
+    })
+
+    it('restores enabled state from localStorage on subsequent calls', async () => {
+      // First call: enable the filter
+      const { setFilterEnabled } = useScreenFilter()
+      setFilterEnabled(true)
+
+      // Wait for localStorage sync
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Second call: should restore from localStorage (same module-level ref)
+      const { filterEnabled } = useScreenFilter()
+
+      expect(filterEnabled.value).toEqual(true)
+    })
+
+    it('restores disabled state from localStorage on subsequent calls', () => {
+      // Pre-populate localStorage with false
+      localStorage.setItem('fbasic-screen-filter', 'false')
+
+      const { filterEnabled } = useScreenFilter()
+
+      expect(filterEnabled.value).toEqual(false)
+    })
+  })
+
+  describe('return type', () => {
+    it('returns reactive filterEnabled, toggleFilter, and setFilterEnabled', () => {
+      const result = useScreenFilter()
+
+      expect(result).toHaveProperty('filterEnabled')
+      expect(result).toHaveProperty('toggleFilter')
+      expect(result).toHaveProperty('setFilterEnabled')
+      expect(typeof result.toggleFilter).toEqual('function')
+      expect(typeof result.setFilterEnabled).toEqual('function')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #611 (Step 1 of 5 for #534 CRT filter feature)

## Changes
- Created `useScreenFilter.ts` composable with `filterEnabled` state, `toggleFilter()`, and `setFilterEnabled()` functions
- State persisted via `useLocalStorage` with `fbasic-screen-filter` key (follows `useDebugMode` pattern)
- 10 unit tests covering default state, toggle, set, localStorage persistence, and return type shape

## Test plan
- [ ] 10/10 useScreenFilter tests pass
- [ ] 19/19 existing composable tests pass (no regressions)
- [ ] CI passes