### PR TITLE
feat: resolve #623 - create TutorialPanel.vue shell with toggle in IDE

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -20,6 +20,7 @@ import IdeOutputPanel from './components/IdeOutputPanel.vue'
 import IdeSpriteViewerPanel from './components/IdeSpriteViewerPanel.vue'
 import InputModal from './components/InputModal.vue'
 import SampleSelector from './components/SampleSelector.vue'
+import TutorialPanel from './components/TutorialPanel.vue'
 import type { CommandPaletteCommand } from './composables/commandPalette'
 import {
   isEditableTarget,
@@ -31,6 +32,7 @@ import { useDevApi } from './composables/useDevApi'
 import { useIdeCommandPalette } from './composables/useIdeCommandPalette'
 import { provideScreenContext } from './composables/useScreenContext'
 import { useShareRoute } from './composables/useShareRoute'
+import { useTutorialPanel } from './composables/useTutorialPanel'
 
 /**
  * IdePage component - The main IDE page for F-BASIC code editing and execution.
@@ -158,6 +160,9 @@ const commandPaletteOpen = shallowRef(false)
 const editorView = shallowRef<'code' | 'bg'>('code')
 const logLevelPanelOpen = shallowRef(false)
 const spriteViewerOpen = shallowRef(false)
+
+// Tutorial panel
+const tutorialPanel = useTutorialPanel()
 
 // Responsive toolbar - observe editor panel which expands with screen
 const editorPanelRef = useTemplateRef<HTMLDivElement>('editorPanelRef')
@@ -333,6 +338,7 @@ function toggleInputMode() {
             @toggle-debug="toggleDebugMode"
             @open-sample-selector="sampleSelectorOpen = true"
             @open-sprite-viewer="spriteViewerOpen = true"
+            @toggle-tutorial-panel="tutorialPanel.toggle()"
           />
         </div>
 
@@ -346,6 +352,16 @@ function toggleInputMode() {
           :variables="variables"
           :debug-output="debugOutput"
           :debug-mode="debugMode"
+        />
+
+        <!-- Right Side Panel - Tutorial -->
+        <TutorialPanel
+          v-if="tutorialPanel.isVisible.value"
+          :has-prev="tutorialPanel.hasPrev.value"
+          :has-next="tutorialPanel.hasNext.value"
+          @close="tutorialPanel.close()"
+          @prev="tutorialPanel.goToPrev()"
+          @next="tutorialPanel.goToNext()"
         />
       </div>
 

--- a/src/features/ide/components/IdeEditorPanel.vue
+++ b/src/features/ide/components/IdeEditorPanel.vue
@@ -31,6 +31,7 @@ const emit = defineEmits<{
   (e: 'toggleDebug'): void
   (e: 'openSampleSelector'): void
   (e: 'openSpriteViewer'): void
+  (e: 'toggleTutorialPanel'): void
 }>()
 
 const MonacoCodeEditor = defineAsyncComponent({
@@ -114,6 +115,14 @@ const useLiteEditor = computed(() => {
           :title="t('ide.spriteViewer.openTitle')"
           data-testid="ide-sprite-viewer-button"
           @click="emit('openSpriteViewer')"
+        />
+        <GameIconButton
+          type="default"
+          icon="mdi:book-open-variant"
+          size="small"
+          :title="t('ide.tutorial.title')"
+          data-testid="ide-tutorial-button"
+          @click="emit('toggleTutorialPanel')"
         />
         <IdeControls
           :is-running="props.isRunning"

--- a/src/features/ide/components/TutorialPanel.vue
+++ b/src/features/ide/components/TutorialPanel.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { GameIconButton } from '@/shared/components/ui'
+import GameIcon from '@/shared/components/ui/GameIcon.vue'
+
+defineOptions({
+  name: 'TutorialPanel',
+})
+
+const props = withDefaults(
+  defineProps<{
+    visible?: boolean
+    lessonTitle?: string
+    hasPrev?: boolean
+    hasNext?: boolean
+  }>(),
+  {
+    visible: false,
+    lessonTitle: '',
+    hasPrev: false,
+    hasNext: false,
+  },
+)
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'prev'): void
+  (e: 'next'): void
+}>()
+
+const { t } = useI18n()
+
+const panelRef = useTemplateRef<HTMLDivElement>('panelRef')
+
+function closePanel(): void {
+  emit('close')
+}
+
+function handlePrev(): void {
+  emit('prev')
+}
+
+function handleNext(): void {
+  emit('next')
+}
+
+function handleKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    closePanel()
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
+})
+</script>
+
+<template>
+  <div
+    v-if="props.visible"
+    ref="panelRef"
+    class="tutorial-panel"
+    role="complementary"
+    :aria-label="t('ide.tutorial.title')"
+  >
+    <div class="tutorial-panel-header">
+      <div class="tutorial-panel-title">
+        <GameIcon icon="mdi:book-open-variant" :size="18" />
+        <span class="tutorial-panel-title-text">
+          {{ props.lessonTitle || t('ide.tutorial.defaultTitle') }}
+        </span>
+      </div>
+      <GameIconButton
+        type="default"
+        icon="mdi:close"
+        size="small"
+        data-testid="tutorial-close-button"
+        :title="t('ide.tutorial.closeAriaLabel')"
+        @click="closePanel"
+      />
+    </div>
+
+    <div
+      class="tutorial-panel-content"
+      data-testid="tutorial-content-area"
+    >
+      <slot>
+        <p class="tutorial-panel-placeholder">{{ t('ide.tutorial.noContent') }}</p>
+      </slot>
+    </div>
+
+    <div class="tutorial-panel-nav">
+      <GameIconButton
+        type="default"
+        icon="mdi:chevron-left"
+        size="small"
+        data-testid="tutorial-prev-button"
+        :disabled="!props.hasPrev"
+        :title="t('ide.tutorial.prev')"
+        @click="handlePrev"
+      />
+      <GameIconButton
+        type="default"
+        icon="mdi:chevron-right"
+        size="small"
+        data-testid="tutorial-next-button"
+        :disabled="!props.hasNext"
+        :title="t('ide.tutorial.next')"
+        @click="handleNext"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tutorial-panel {
+  display: flex;
+  flex-direction: column;
+  width: 320px;
+  min-width: 240px;
+  max-width: 400px;
+  height: 100%;
+  border-left: 1px solid var(--game-surface-border);
+  background: var(--game-surface-bg-gradient);
+}
+
+.tutorial-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 0.75rem;
+  border-bottom: 1px solid var(--game-surface-border);
+  flex-shrink: 0;
+}
+
+.tutorial-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--game-text-primary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.tutorial-panel-title-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tutorial-panel-content {
+  flex: 1 1 0;
+  overflow-y: auto;
+  padding: 0.75rem;
+  min-height: 0;
+}
+
+.tutorial-panel-placeholder {
+  color: var(--game-text-tertiary);
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+.tutorial-panel-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--game-surface-border);
+  flex-shrink: 0;
+}
+</style>

--- a/src/features/ide/composables/useTutorialPanel.ts
+++ b/src/features/ide/composables/useTutorialPanel.ts
@@ -1,0 +1,78 @@
+import { computed, type Ref,ref } from 'vue'
+
+interface UseTutorialPanelOptions {
+  visible?: Ref<boolean>
+  totalLessons?: number
+}
+
+interface UseTutorialPanelReturn {
+  isVisible: Ref<boolean>
+  currentIndex: Ref<number>
+  hasPrev: Ref<boolean>
+  hasNext: Ref<boolean>
+  open: () => void
+  close: () => void
+  toggle: () => void
+  goToNext: () => void
+  goToPrev: () => void
+}
+
+export function useTutorialPanel(options: UseTutorialPanelOptions = {}): UseTutorialPanelReturn {
+  const { visible, totalLessons = 0 } = options
+
+  const internalVisible = ref(false)
+  const isVisible = visible ?? internalVisible
+
+  const currentIndex = ref(0)
+
+  const hasPrev = computed(() => currentIndex.value > 0)
+  const hasNext = computed(() => totalLessons === 0 || currentIndex.value < totalLessons - 1)
+
+  function open(): void {
+    if (visible) {
+      visible.value = true
+    } else {
+      internalVisible.value = true
+    }
+  }
+
+  function close(): void {
+    if (visible) {
+      visible.value = false
+    } else {
+      internalVisible.value = false
+    }
+  }
+
+  function toggle(): void {
+    if (isVisible.value) {
+      close()
+    } else {
+      open()
+    }
+  }
+
+  function goToNext(): void {
+    if (hasNext.value) {
+      currentIndex.value++
+    }
+  }
+
+  function goToPrev(): void {
+    if (hasPrev.value) {
+      currentIndex.value--
+    }
+  }
+
+  return {
+    isVisible,
+    currentIndex,
+    hasPrev,
+    hasNext,
+    open,
+    close,
+    toggle,
+    goToNext,
+    goToPrev,
+  }
+}

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -482,5 +482,13 @@
     "encodeFailed": "Failed to generate share URL.",
     "tooLarge": "This program is too large to share via URL.",
     "loadFailed": "Failed to load shared program"
+  },
+  "tutorial": {
+    "title": "Tutorial",
+    "defaultTitle": "F-BASIC Tutorial",
+    "closeAriaLabel": "Close tutorial",
+    "prev": "Previous lesson",
+    "next": "Next lesson",
+    "noContent": "No lesson content available."
   }
 }

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -482,5 +482,13 @@
     "encodeFailed": "共有URLの生成に失敗しました。",
     "tooLarge": "このプログラムはURLで共有するには大きすぎます。",
     "loadFailed": "共有プログラムの読み込みに失敗しました"
+  },
+  "tutorial": {
+    "title": "チュートリアル",
+    "defaultTitle": "F-BASICチュートリアル",
+    "closeAriaLabel": "チュートリアルを閉じる",
+    "prev": "前のレッスン",
+    "next": "次のレッスン",
+    "noContent": "レッスン内容はありません。"
   }
 }

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -482,5 +482,13 @@
     "encodeFailed": "无法生成分享链接。",
     "tooLarge": "此程序过大，无法通过链接分享。",
     "loadFailed": "加载分享程序失败"
+  },
+  "tutorial": {
+    "title": "教程",
+    "defaultTitle": "F-BASIC 教程",
+    "closeAriaLabel": "关闭教程",
+    "prev": "上一课",
+    "next": "下一课",
+    "noContent": "暂无课程内容。"
   }
 }

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -482,5 +482,13 @@
     "encodeFailed": "無法產生分享連結。",
     "tooLarge": "此程式過大，無法透過連結分享。",
     "loadFailed": "載入分享程式失敗"
+  },
+  "tutorial": {
+    "title": "教學",
+    "defaultTitle": "F-BASIC 教學",
+    "closeAriaLabel": "關閉教學",
+    "prev": "上一課",
+    "next": "下一課",
+    "noContent": "暫無課程內容。"
   }
 }

--- a/test/ide/TutorialPanel.test.ts
+++ b/test/ide/TutorialPanel.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import TutorialPanel from '@/features/ide/components/TutorialPanel.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const gameIconButtonStub = defineComponent({
+  props: ['variant', 'type', 'icon', 'size', 'title', 'disabled'],
+  emits: ['click'],
+  inheritAttrs: false,
+  template: '<button v-bind="$attrs" :title="title" :disabled="disabled" @click="$emit(\'click\')" />',
+})
+
+describe('TutorialPanel', () => {
+  it('renders with correct ARIA role as a complementary region', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    expect(wrapper.find('[role="complementary"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders with aria-label for accessibility', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const panel = wrapper.find('[role="complementary"]')
+    expect(panel.attributes('aria-label')).toEqual('ide.tutorial.title')
+    wrapper.unmount()
+  })
+
+  it('renders header with lesson title', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true, lessonTitle: 'Lesson 1: Hello World' },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Lesson 1: Hello World')
+    wrapper.unmount()
+  })
+
+  it('renders default lesson title when none provided', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    expect(wrapper.text()).toContain('ide.tutorial.defaultTitle')
+    wrapper.unmount()
+  })
+
+  it('renders prev and next navigation buttons', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const prevButton = wrapper.find('[data-testid="tutorial-prev-button"]')
+    const nextButton = wrapper.find('[data-testid="tutorial-next-button"]')
+    expect(prevButton.exists()).toBe(true)
+    expect(nextButton.exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders close button with correct title', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const closeButton = wrapper.find('[data-testid="tutorial-close-button"]')
+    expect(closeButton.exists()).toBe(true)
+    expect(closeButton.attributes('title')).toEqual('ide.tutorial.closeAriaLabel')
+    wrapper.unmount()
+  })
+
+  it('emits close event when close button is clicked', async () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const closeButton = wrapper.find('[data-testid="tutorial-close-button"]')
+    await closeButton.trigger('click')
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('emits prev event when prev button is clicked', async () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true, hasPrev: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const prevButton = wrapper.find('[data-testid="tutorial-prev-button"]')
+    await prevButton.trigger('click')
+    expect(wrapper.emitted('prev')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('emits next event when next button is clicked', async () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true, hasNext: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const nextButton = wrapper.find('[data-testid="tutorial-next-button"]')
+    await nextButton.trigger('click')
+    expect(wrapper.emitted('next')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('renders content area for lesson rendering', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const contentArea = wrapper.find('[data-testid="tutorial-content-area"]')
+    expect(contentArea.exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders slot content in the content area', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+      slots: {
+        default: '<p class="custom-lesson">Custom lesson content</p>',
+      },
+    })
+
+    const contentArea = wrapper.find('[data-testid="tutorial-content-area"]')
+    expect(contentArea.find('.custom-lesson').exists()).toBe(true)
+    expect(contentArea.text()).toContain('Custom lesson content')
+    wrapper.unmount()
+  })
+
+  it('disables prev button when hasPrev is false', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true, hasPrev: false },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const prevButton = wrapper.find('[data-testid="tutorial-prev-button"]')
+    expect(prevButton.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('enables prev button when hasPrev is true', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true, hasPrev: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const prevButton = wrapper.find('[data-testid="tutorial-prev-button"]')
+    expect(prevButton.attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('disables next button when hasNext is false', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true, hasNext: false },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const nextButton = wrapper.find('[data-testid="tutorial-next-button"]')
+    expect(nextButton.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('enables next button when hasNext is true', () => {
+    const wrapper = mount(TutorialPanel, {
+      props: { visible: true, hasNext: true },
+      global: {
+        stubs: { GameIconButton: gameIconButtonStub },
+      },
+    })
+
+    const nextButton = wrapper.find('[data-testid="tutorial-next-button"]')
+    expect(nextButton.attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+})

--- a/test/ide/useTutorialPanel.test.ts
+++ b/test/ide/useTutorialPanel.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+
+import { useTutorialPanel } from '@/features/ide/composables/useTutorialPanel'
+
+describe('useTutorialPanel', () => {
+  it('starts with panel closed by default', () => {
+    const { isVisible } = useTutorialPanel()
+    expect(isVisible.value).toBe(false)
+  })
+
+  it('opens the panel when open is called', () => {
+    const { isVisible, open } = useTutorialPanel()
+    open()
+    expect(isVisible.value).toBe(true)
+  })
+
+  it('closes the panel when close is called', () => {
+    const { isVisible, open, close } = useTutorialPanel()
+    open()
+    expect(isVisible.value).toBe(true)
+    close()
+    expect(isVisible.value).toBe(false)
+  })
+
+  it('toggles the panel visibility', () => {
+    const { isVisible, toggle } = useTutorialPanel()
+    expect(isVisible.value).toBe(false)
+    toggle()
+    expect(isVisible.value).toBe(true)
+    toggle()
+    expect(isVisible.value).toBe(false)
+  })
+
+  it('accepts external visibility ref', () => {
+    const externalVisible = ref(true)
+    const { isVisible } = useTutorialPanel({ visible: externalVisible })
+    expect(isVisible.value).toBe(true)
+    externalVisible.value = false
+    expect(isVisible.value).toBe(false)
+  })
+
+  it('tracks current lesson index starting at 0', () => {
+    const { currentIndex } = useTutorialPanel()
+    expect(currentIndex.value).toEqual(0)
+  })
+
+  it('navigates to next lesson', () => {
+    const { currentIndex, goToNext } = useTutorialPanel()
+    goToNext()
+    expect(currentIndex.value).toEqual(1)
+  })
+
+  it('navigates to previous lesson', () => {
+    const { currentIndex, goToNext, goToPrev } = useTutorialPanel()
+    goToNext()
+    goToNext()
+    expect(currentIndex.value).toEqual(2)
+    goToPrev()
+    expect(currentIndex.value).toEqual(1)
+  })
+
+  it('does not navigate below 0', () => {
+    const { currentIndex, goToPrev } = useTutorialPanel()
+    goToPrev()
+    expect(currentIndex.value).toEqual(0)
+  })
+
+  it('computes hasPrev correctly', () => {
+    const { hasPrev, goToNext, goToPrev } = useTutorialPanel()
+    expect(hasPrev.value).toBe(false)
+    goToNext()
+    expect(hasPrev.value).toBe(true)
+    goToPrev()
+    expect(hasPrev.value).toBe(false)
+  })
+
+  it('computes hasNext correctly based on totalLessons', () => {
+    const { hasNext, currentIndex, goToNext } = useTutorialPanel({ totalLessons: 3 })
+    expect(hasNext.value).toBe(true)
+    goToNext()
+    expect(hasNext.value).toBe(true)
+    goToNext()
+    expect(hasNext.value).toBe(false)
+  })
+
+  it('does not navigate beyond totalLessons', () => {
+    const { currentIndex, goToNext } = useTutorialPanel({ totalLessons: 2 })
+    goToNext()
+    expect(currentIndex.value).toEqual(1)
+    goToNext()
+    expect(currentIndex.value).toEqual(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #623 (Step 1 of 7 for #537 tutorial system)

## Changes
- Created `TutorialPanel.vue` — collapsible side panel with header, prev/next nav buttons, and content area (slot for lesson rendering)
- Created `useTutorialPanel.ts` composable — manages visibility, current lesson index, and navigation state
- Added toggle button in `IdeEditorPanel.vue` header with `mdi:book-open-variant` icon
- Wired TutorialPanel into `IdePage.vue` layout
- Added i18n keys across all 4 locales (en, ja, zh-CN, zh-TW)
- 27 unit tests (15 component + 12 composable)

## Test plan
- [ ] 27/27 new tests pass
- [ ] 291/291 IDE tests pass (no regressions)
- [ ] CI passes