### PR TITLE
feat: resolve #616 - create PianoRoll grid component with note placement

### DIFF
--- a/src/features/ide/components/PianoRoll.vue
+++ b/src/features/ide/components/PianoRoll.vue
@@ -1,0 +1,266 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import type { NoteCellKey } from './pianoRollConstants'
+import {
+  BEAT_INTERVAL,
+  createNoteCellKey,
+  DEFAULT_STEPS,
+  isSharpNote,
+  NOTE_NAMES,
+} from './pianoRollConstants'
+
+defineOptions({
+  name: 'PianoRoll',
+})
+
+const props = withDefaults(
+  defineProps<{
+    /** Set of active note cells, keyed by "noteIndex-stepIndex". */
+    modelValue: Set<NoteCellKey>
+    /** Number of time step columns. */
+    steps?: 16 | 32
+  }>(),
+  {
+    modelValue: () => new Set<NoteCellKey>(),
+    steps: DEFAULT_STEPS,
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: Set<NoteCellKey>]
+}>()
+
+// ---------------------------------------------------------------------------
+// Drag state
+// ---------------------------------------------------------------------------
+
+/** Whether the user is currently dragging. */
+const isDragging = ref(false)
+
+/**
+ * The drag mode: 'paint' adds notes, 'erase' removes them.
+ * Determined by the state of the first cell clicked.
+ */
+const dragMode = ref<'paint' | 'erase'>('paint')
+
+// ---------------------------------------------------------------------------
+// Cell interaction
+// ---------------------------------------------------------------------------
+
+function handleCellMouseDown(noteIndex: number, stepIndex: number): void {
+  isDragging.value = true
+  const key = createNoteCellKey(noteIndex, stepIndex)
+  const isActive = props.modelValue.has(key)
+  dragMode.value = isActive ? 'erase' : 'paint'
+  toggleCell(noteIndex, stepIndex)
+}
+
+function handleCellMouseEnter(noteIndex: number, stepIndex: number): void {
+  if (!isDragging.value) return
+
+  const key = createNoteCellKey(noteIndex, stepIndex)
+  const nextNotes = new Set(props.modelValue)
+
+  if (dragMode.value === 'paint') {
+    nextNotes.add(key)
+  } else {
+    nextNotes.delete(key)
+  }
+
+  emit('update:modelValue', nextNotes)
+}
+
+function handleGridMouseUp(): void {
+  isDragging.value = false
+}
+
+/**
+ * Toggles a cell: adds it if inactive, removes it if active.
+ */
+function toggleCell(noteIndex: number, stepIndex: number): void {
+  const key = createNoteCellKey(noteIndex, stepIndex)
+  const nextNotes = new Set(props.modelValue)
+
+  if (nextNotes.has(key)) {
+    nextNotes.delete(key)
+  } else {
+    nextNotes.add(key)
+  }
+
+  emit('update:modelValue', nextNotes)
+}
+
+/**
+ * Checks whether a note at the given index is a sharp (black key).
+ */
+function isBlackKey(noteIndex: number): boolean {
+  return isSharpNote(NOTE_NAMES[noteIndex] ?? '')
+}
+
+/**
+ * Checks whether a step column should have a beat marker.
+ */
+function isBeatStart(stepIndex: number): boolean {
+  return stepIndex % BEAT_INTERVAL === 0
+}
+</script>
+
+<template>
+  <div class="piano-roll">
+    <!-- Step number headers -->
+    <div class="piano-roll__step-headers">
+      <div
+        v-for="step in steps"
+        :key="step"
+        class="piano-roll__step-header"
+        :class="{ 'piano-roll__step-header--beat': isBeatStart(step - 1) }"
+      >
+        {{ step }}
+      </div>
+    </div>
+
+    <!-- Grid rows -->
+    <div
+      class="piano-roll__grid"
+      @mouseup="handleGridMouseUp"
+    >
+      <div
+        v-for="(noteName, noteIndex) in NOTE_NAMES"
+        :key="noteName"
+        class="piano-roll__row"
+      >
+        <!-- Note label -->
+        <span
+          class="piano-roll__label"
+          :class="{
+            'piano-roll__label--sharp': isBlackKey(noteIndex),
+          }"
+        >
+          {{ noteName }}
+        </span>
+
+        <!-- Step cells -->
+        <div
+          v-for="stepIndex in steps"
+          :key="`${noteIndex}-${stepIndex - 1}`"
+          class="piano-roll__cell"
+          :class="{
+            'piano-roll__cell--active': modelValue.has(
+              createNoteCellKey(noteIndex, stepIndex - 1),
+            ),
+            'piano-roll__cell--black-key': isBlackKey(noteIndex),
+            'piano-roll__cell--beat-start': isBeatStart(stepIndex - 1),
+          }"
+          :data-note-index="noteIndex"
+          :data-step-index="stepIndex - 1"
+          @mousedown.prevent="handleCellMouseDown(noteIndex, stepIndex - 1)"
+          @mouseenter="handleCellMouseEnter(noteIndex, stepIndex - 1)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.piano-roll {
+  --piano-roll-cell-size: 20px;
+  --piano-roll-label-width: 48px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: var(--base-solid-gray-100, monospace);
+  font-size: 11px;
+  user-select: none;
+}
+
+/* Step headers row */
+.piano-roll__step-headers {
+  display: grid;
+  grid-template-columns: var(--piano-roll-label-width) repeat(
+      var(--steps-count, 16),
+      var(--piano-roll-cell-size)
+    );
+  gap: 1px;
+  padding-left: var(--piano-roll-label-width);
+  margin-left: calc(-1 * var(--piano-roll-label-width));
+}
+
+.piano-roll__step-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+  color: var(--game-text-tertiary);
+  font-size: 9px;
+}
+
+.piano-roll__step-header--beat {
+  color: var(--game-text-secondary);
+  font-weight: bold;
+}
+
+/* Grid */
+.piano-roll__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+/* Row (one note across all steps) */
+.piano-roll__row {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+}
+
+/* Note label */
+.piano-roll__label {
+  width: var(--piano-roll-label-width);
+  flex-shrink: 0;
+  text-align: right;
+  padding-right: 6px;
+  color: var(--game-text-secondary);
+  white-space: nowrap;
+}
+
+.piano-roll__label--sharp {
+  color: var(--game-text-tertiary);
+}
+
+/* Cell */
+.piano-roll__cell {
+  width: var(--piano-roll-cell-size);
+  height: var(--piano-roll-cell-size);
+  flex-shrink: 0;
+  border: 1px solid var(--base-solid-gray-30);
+  background-color: var(--base-solid-gray-10);
+  cursor: pointer;
+  transition: background-color 0.05s;
+}
+
+.piano-roll__cell:hover {
+  background-color: var(--base-solid-gray-20);
+}
+
+/* Black key row background */
+.piano-roll__cell--black-key {
+  background-color: var(--base-alpha-gray-00-30);
+}
+
+/* Beat marker */
+.piano-roll__cell--beat-start {
+  border-left: 2px solid var(--base-solid-gray-40);
+}
+
+/* Active note */
+.piano-roll__cell--active {
+  background-color: var(--base-solid-primary);
+  border-color: var(--base-solid-primary-70);
+}
+
+.piano-roll__cell--active:hover {
+  background-color: var(--base-solid-primary-80);
+}
+</style>

--- a/src/features/ide/components/pianoRollConstants.ts
+++ b/src/features/ide/components/pianoRollConstants.ts
@@ -1,0 +1,79 @@
+/**
+ * Constants and types for the PianoRoll grid component.
+ *
+ * These are extracted from PianoRoll.vue for clarity and testability,
+ * and so future steps (state management, playback, code generation)
+ * can import them without pulling in the component.
+ */
+
+// ---------------------------------------------------------------------------
+// Note names (ascending order: C3 -> B5)
+// ---------------------------------------------------------------------------
+
+const NOTE_NAMES_ASCENDING = [
+  'C3', 'C#3', 'D3', 'D#3', 'E3', 'F3', 'F#3', 'G3', 'G#3', 'A3', 'A#3', 'B3',
+  'C4', 'C#4', 'D4', 'D#4', 'E4', 'F4', 'F#4', 'G4', 'G#4', 'A4', 'A#4', 'B4',
+  'C5', 'C#5', 'D5', 'D#5', 'E5', 'F5', 'F#5', 'G5', 'G#5', 'A5', 'A#5', 'B5',
+] as const
+
+/**
+ * Note names displayed top-to-bottom on the piano roll grid.
+ * Index 0 = B5 (highest), last index = C3 (lowest).
+ */
+export const NOTE_NAMES: readonly string[] = [...NOTE_NAMES_ASCENDING].reverse()
+
+/** Number of notes in the grid (3 octaves x 12 semitones). */
+export const NOTE_COUNT = NOTE_NAMES.length
+
+/** Default number of time steps per row. */
+export const DEFAULT_STEPS = 16
+
+/** All valid step counts. */
+export const VALID_STEPS = [16, 32] as const
+
+/** Interval at which a beat marker column appears. */
+export const BEAT_INTERVAL = 4
+
+// ---------------------------------------------------------------------------
+// Note cell key
+// ---------------------------------------------------------------------------
+
+/**
+ * Key format for identifying a note cell in the grid.
+ * Used as the identifier in the `modelValue` Set.
+ *
+ * Format: "{noteIndex}-{stepIndex}"
+ * - noteIndex: 0-based index into NOTE_NAMES (0 = B5, 35 = C3)
+ * - stepIndex: 0-based time step column
+ */
+export type NoteCellKey = `${number}-${number}`
+
+/**
+ * Creates a cell key from note and step indices.
+ */
+export function createNoteCellKey(
+  noteIndex: number,
+  stepIndex: number
+): NoteCellKey {
+  return `${noteIndex}-${stepIndex}`
+}
+
+/**
+ * Parses a cell key into its note and step indices.
+ */
+export function parseNoteCellKey(key: NoteCellKey): {
+  noteIndex: number
+  stepIndex: number
+} {
+  const dashIndex = key.indexOf('-')
+  const noteIndex = Number.parseInt(key.slice(0, dashIndex), 10)
+  const stepIndex = Number.parseInt(key.slice(dashIndex + 1), 10)
+  return { noteIndex, stepIndex }
+}
+
+/**
+ * Checks whether a note name represents a sharp (black key).
+ */
+export function isSharpNote(noteName: string): boolean {
+  return noteName.includes('#')
+}

--- a/test/ide/PianoRoll.test.ts
+++ b/test/ide/PianoRoll.test.ts
@@ -1,0 +1,347 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import PianoRoll from '@/features/ide/components/PianoRoll.vue'
+import type { NoteCellKey } from '@/features/ide/components/pianoRollConstants'
+
+const WRAPPER_SELECTOR = '.piano-roll'
+const GRID_SELECTOR = '.piano-roll__grid'
+const CELL_SELECTOR = '.piano-roll__cell'
+const LABEL_SELECTOR = '.piano-roll__label'
+const ACTIVE_SELECTOR = '.piano-roll__cell--active'
+
+function cellKey(noteIndex: number, stepIndex: number): NoteCellKey {
+  return `${noteIndex}-${stepIndex}`
+}
+
+function mountPianoRoll(props: {
+  modelValue?: Set<NoteCellKey>
+  steps?: 16 | 32
+} = {}) {
+  return mount(PianoRoll, {
+    props: {
+      modelValue: props.modelValue ?? new Set<NoteCellKey>(),
+      steps: props.steps ?? 16,
+    },
+  })
+}
+
+describe('PianoRoll', () => {
+  describe('grid rendering', () => {
+    it('renders the piano roll container', () => {
+      const wrapper = mountPianoRoll()
+
+      expect(wrapper.find(WRAPPER_SELECTOR).exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('renders the CSS grid', () => {
+      const wrapper = mountPianoRoll()
+
+      expect(wrapper.find(GRID_SELECTOR).exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('renders 36 note labels (C3 to B5)', () => {
+      const wrapper = mountPianoRoll()
+
+      const labels = wrapper.findAll(LABEL_SELECTOR)
+      expect(labels).toHaveLength(36)
+      // Top row should be B5 (highest note displayed first)
+      expect(labels[0]!.text()).toEqual('B5')
+      // Bottom row should be C3 (lowest note)
+      expect(labels[35]!.text()).toEqual('C3')
+      wrapper.unmount()
+    })
+
+    it('renders correct number of cells (36 notes x 16 steps default)', () => {
+      const wrapper = mountPianoRoll()
+
+      const cells = wrapper.findAll(CELL_SELECTOR)
+      expect(cells).toHaveLength(36 * 16)
+      wrapper.unmount()
+    })
+
+    it('renders correct number of cells with 32 steps prop', () => {
+      const wrapper = mountPianoRoll({ steps: 32 })
+
+      const cells = wrapper.findAll(CELL_SELECTOR)
+      expect(cells).toHaveLength(36 * 32)
+      wrapper.unmount()
+    })
+  })
+
+  describe('note label order (top to bottom: B5 down to C3)', () => {
+    it('has C#3 after C3 (ascending within octave)', () => {
+      const wrapper = mountPianoRoll()
+      const labels = wrapper.findAll(LABEL_SELECTOR)
+
+      // C3 is at index 35 (bottom), C#3 is at index 34
+      expect(labels[35]!.text()).toEqual('C3')
+      expect(labels[34]!.text()).toEqual('C#3')
+      wrapper.unmount()
+    })
+
+    it('has C4 after B3 (octave boundary)', () => {
+      const wrapper = mountPianoRoll()
+      const labels = wrapper.findAll(LABEL_SELECTOR)
+
+      // B3 is at index 24, C4 is at index 23
+      expect(labels[24]!.text()).toEqual('B3')
+      expect(labels[23]!.text()).toEqual('C4')
+      wrapper.unmount()
+    })
+
+    it('has full correct sequence for first and last few labels', () => {
+      const wrapper = mountPianoRoll()
+      const labels = wrapper.findAll(LABEL_SELECTOR)
+      const texts = labels.map((l) => l.text())
+
+      // Top 5: B5, A#5, A5, G#5, G5
+      expect(texts.slice(0, 5)).toEqual(['B5', 'A#5', 'A5', 'G#5', 'G5'])
+      // Bottom 5: E3, D#3, D3, C#3, C3
+      expect(texts.slice(-5)).toEqual(['E3', 'D#3', 'D3', 'C#3', 'C3'])
+      wrapper.unmount()
+    })
+  })
+
+  describe('cell data attributes', () => {
+    it('sets data-note-index and data-step-index on each cell', () => {
+      const wrapper = mountPianoRoll()
+
+      // Check first cell (top-left: note 0 = B5, step 0)
+      const firstCell = wrapper.find(CELL_SELECTOR)
+      expect(firstCell.attributes('data-note-index')).toEqual('0')
+      expect(firstCell.attributes('data-step-index')).toEqual('0')
+
+      // Check a cell in the middle (note 18 = C4, step 4)
+      const cell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="18"][data-step-index="4"]`
+      )
+      expect(cell.exists()).toBe(true)
+      wrapper.unmount()
+    })
+  })
+
+  describe('active note display', () => {
+    it('marks active notes with the active class', () => {
+      const activeNotes = new Set<NoteCellKey>([
+        cellKey(0, 0),
+        cellKey(18, 4),
+      ])
+      const wrapper = mountPianoRoll({ modelValue: activeNotes })
+
+      const activeCells = wrapper.findAll(ACTIVE_SELECTOR)
+      expect(activeCells).toHaveLength(2)
+      wrapper.unmount()
+    })
+
+    it('does not mark inactive notes', () => {
+      const activeNotes = new Set<NoteCellKey>([cellKey(0, 0)])
+      const wrapper = mountPianoRoll({ modelValue: activeNotes })
+
+      // Cell at note 0, step 1 should not be active
+      const inactiveCell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="1"]`
+      )
+      expect(inactiveCell.classes()).not.toContain('piano-roll__cell--active')
+      wrapper.unmount()
+    })
+  })
+
+  describe('black key styling', () => {
+    it('applies black-key class to sharp notes', () => {
+      const wrapper = mountPianoRoll()
+
+      // C#3 is noteIndex 34 (in reversed display)
+      const cSharp3Cell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="34"][data-step-index="0"]`
+      )
+      expect(cSharp3Cell.classes()).toContain('piano-roll__cell--black-key')
+
+      // C3 is noteIndex 35 (natural note)
+      const c3Cell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="35"][data-step-index="0"]`
+      )
+      expect(c3Cell.classes()).not.toContain('piano-roll__cell--black-key')
+      wrapper.unmount()
+    })
+  })
+
+  describe('beat markers', () => {
+    it('applies beat-marker class every 4 steps', () => {
+      const wrapper = mountPianoRoll()
+
+      // Step 0 should have beat marker
+      const step0 = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="0"]`
+      )
+      expect(step0.classes()).toContain('piano-roll__cell--beat-start')
+
+      // Step 4 should have beat marker
+      const step4 = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="4"]`
+      )
+      expect(step4.classes()).toContain('piano-roll__cell--beat-start')
+
+      // Step 3 should NOT have beat marker
+      const step3 = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="3"]`
+      )
+      expect(step3.classes()).not.toContain('piano-roll__cell--beat-start')
+      wrapper.unmount()
+    })
+  })
+
+  describe('click to toggle note', () => {
+    it('emits update:modelValue with added note when clicking empty cell', async () => {
+      const wrapper = mountPianoRoll()
+
+      const cell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="0"]`
+      )
+      await cell.trigger('mousedown')
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      const emitted = wrapper.emitted<
+        [Set<NoteCellKey>]
+      >('update:modelValue')![0]![0]
+      expect(emitted.has(cellKey(0, 0))).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('emits update:modelValue with removed note when clicking active cell', async () => {
+      const activeNotes = new Set<NoteCellKey>([cellKey(0, 0)])
+      const wrapper = mountPianoRoll({ modelValue: activeNotes })
+
+      const cell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="0"]`
+      )
+      await cell.trigger('mousedown')
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      const emitted = wrapper.emitted<
+        [Set<NoteCellKey>]
+      >('update:modelValue')![0]![0]
+      expect(emitted.has(cellKey(0, 0))).toBe(false)
+      wrapper.unmount()
+    })
+
+    it('preserves other active notes when toggling one', async () => {
+      const activeNotes = new Set<NoteCellKey>([
+        cellKey(0, 0),
+        cellKey(18, 4),
+      ])
+      const wrapper = mountPianoRoll({ modelValue: activeNotes })
+
+      const cell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="0"]`
+      )
+      await cell.trigger('mousedown')
+
+      const emitted = wrapper.emitted<
+        [Set<NoteCellKey>]
+      >('update:modelValue')![0]![0]
+      // cellKey(0, 0) removed, cellKey(18, 4) preserved
+      expect(emitted.has(cellKey(0, 0))).toBe(false)
+      expect(emitted.has(cellKey(18, 4))).toBe(true)
+      wrapper.unmount()
+    })
+  })
+
+  describe('drag to paint notes', () => {
+    it('adds note on mousedown + mouseenter', async () => {
+      const wrapper = mountPianoRoll()
+
+      const cell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="0"]`
+      )
+      await cell.trigger('mousedown')
+
+      const nextCell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="1"]`
+      )
+      await nextCell.trigger('mouseenter')
+
+      // Should have two emissions: one for mousedown, one for mouseenter
+      const emissions = wrapper.emitted<[Set<NoteCellKey>]>(
+        'update:modelValue'
+      )!
+      expect(emissions).toHaveLength(2)
+
+      // The second emission (mouseenter) should include the painted cell
+      const secondEmission = emissions[1]![0]
+      expect(secondEmission.has(cellKey(0, 1))).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('does not paint when dragging starts on an active note (erase mode)', async () => {
+      const activeNotes = new Set<NoteCellKey>([cellKey(0, 0)])
+      const wrapper = mountPianoRoll({ modelValue: activeNotes })
+
+      // Start drag on active note (erase mode)
+      const activeCell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="0"]`
+      )
+      await activeCell.trigger('mousedown')
+
+      // Drag over inactive cell — should remove it (erase mode)
+      const nextCell = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="1"]`
+      )
+      await nextCell.trigger('mouseenter')
+
+      const emissions = wrapper.emitted<[Set<NoteCellKey>]>(
+        'update:modelValue'
+      )!
+      expect(emissions).toHaveLength(2)
+
+      // mousedown emission: removed cellKey(0,0)
+      expect(emissions[0]![0].has(cellKey(0, 0))).toBe(false)
+
+      // mouseenter emission: should NOT add cellKey(0,1) since we're in erase mode
+      expect(emissions[1]![0].has(cellKey(0, 1))).toBe(false)
+      wrapper.unmount()
+    })
+  })
+
+  describe('mouseup resets drag state', () => {
+    it('stops painting after mouseup event on the grid', async () => {
+      const wrapper = mountPianoRoll()
+
+      const cell1 = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="0"]`
+      )
+      await cell1.trigger('mousedown')
+
+      // Emit mouseup on the grid
+      await wrapper.find(GRID_SELECTOR).trigger('mouseup')
+
+      // Now mouseenter should NOT paint
+      const cell2 = wrapper.find(
+        `${CELL_SELECTOR}[data-note-index="0"][data-step-index="1"]`
+      )
+      await cell2.trigger('mouseenter')
+
+      // Only 1 emission (from mousedown), not 2
+      const emissions = wrapper.emitted<[Set<NoteCellKey>]>(
+        'update:modelValue'
+      )!
+      expect(emissions).toHaveLength(1)
+      wrapper.unmount()
+    })
+  })
+
+  describe('step column headers', () => {
+    it('renders step number headers', () => {
+      const wrapper = mountPianoRoll()
+
+      const headers = wrapper.findAll('.piano-roll__step-header')
+      expect(headers).toHaveLength(16)
+      expect(headers[0]!.text()).toEqual('1')
+      expect(headers[15]!.text()).toEqual('16')
+      wrapper.unmount()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #616 — Step 1 of 7 for #536

## Changes
- Created `PianoRoll.vue` CSS Grid component (X-axis: time steps, Y-axis: 36 notes C3-B5)
- Created `pianoRollConstants.ts` with note definitions, types, and helpers
- Click to place/remove notes, drag to paint, mousedown interaction
- v-model support via `modelValue` (Set<NoteCellKey>) and `update:modelValue` event
- Configurable step count (16 or 32) via prop
- 20 unit tests covering rendering, interaction, and edge cases

## Test plan
- [ ] 20/20 unit tests pass
- [ ] CI passes