### PR TITLE
refactor: resolve #586 - use LOCAL_STORAGE_SYNC_DELAY_MS in setCode persistence test

### DIFF
--- a/test/ide/useProgramStore.test.ts
+++ b/test/ide/useProgramStore.test.ts
@@ -155,7 +155,7 @@ describe('useProgramStore', () => {
     store.setCode('10 PRINT "HELLO"')
 
     // Wait for VueUse's useLocalStorage to sync
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await new Promise((resolve) => setTimeout(resolve, LOCAL_STORAGE_SYNC_DELAY_MS))
 
     const stored = localStorage.getItem('program:current')
     expect(stored).not.toBeNull()


### PR DESCRIPTION
## Summary
- Fixes #586

## Changes
- Replaced raw `50` magic number with `LOCAL_STORAGE_SYNC_DELAY_MS` constant in the setCode localStorage persistence test

## Test plan
- [ ] Targeted tests pass (19/19 useProgramStore tests)
- [ ] CI passes