### PR TITLE
refactor: resolve #593 - use Partial<PaletteStateValues> type for makeRefs helper in constants test

### DIFF
--- a/test/core/constants.test.ts
+++ b/test/core/constants.test.ts
@@ -17,7 +17,7 @@ import {
 
 /** Create plain { value: number } wrappers — no Vue dependency needed. */
 function makeRefs(
-  values: Record<string, number>,
+  values: Partial<PaletteStateValues>,
 ): { [K in keyof PaletteStateValues]: { value: number } } {
   return {
     bgPalette: { value: values.bgPalette ?? 0 },


### PR DESCRIPTION
## Summary
- Fixes #593

## Changes
- Changed `makeRefs` helper parameter type from `Record<string, number>` to `Partial<PaletteStateValues>` for compile-time key validation

## Test plan
- [ ] Targeted tests pass (9/9 constants tests)
- [ ] CI passes