### PR TITLE
feat: resolve #612 - add scanline CSS filter layer to Screen.vue

### DIFF
--- a/src/features/ide/components/Screen.vue
+++ b/src/features/ide/components/Screen.vue
@@ -9,6 +9,7 @@ import { initializeKonvaLayers, type KonvaScreenLayers, renderAllScreenLayers } 
 import { useScreenAnimationLoopRenderOnly } from '@/features/ide/composables/useScreenAnimationLoopRenderOnly'
 import { useScreenContext } from '@/features/ide/composables/useScreenContext'
 import { useScreenDebug } from '@/features/ide/composables/useScreenDebug'
+import { useScreenFilter } from '@/features/ide/composables/useScreenFilter'
 import { useScreenZoom } from '@/features/ide/composables/useScreenZoom'
 import { COLORS } from '@/shared/data/palette'
 import { logScreen } from '@/shared/logger'
@@ -49,6 +50,9 @@ const { zoomLevel } = useScreenZoom()
 
 // Use debug settings composable
 const { showGrid } = useScreenDebug()
+
+// Use screen filter composable for CRT scanline toggle
+const { filterEnabled } = useScreenFilter()
 
 // Base screen dimensions (full backdrop/sprite screen: 256×240)
 const BASE_WIDTH = 256
@@ -445,7 +449,7 @@ onDeactivated(cleanupScreen)
   <div class="screen-display">
     <div class="crt-bezel">
       <div class="crt-screen">
-        <div class="crt-scanlines"></div>
+        <div v-if="filterEnabled" class="crt-scanlines"></div>
         <div
           class="screen-stage-wrapper"
           data-testid="ide-screen-stage"

--- a/test/ide/Screen.test.ts
+++ b/test/ide/Screen.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import Screen from '@/features/ide/components/Screen.vue'
+
+// Mock useScreenContext to satisfy Screen.vue's provide/inject dependency
+vi.mock('@/features/ide/composables/useScreenContext', () => ({
+  useScreenContext: () => ({
+    screenBuffer: ref([]),
+    cursorX: ref(0),
+    cursorY: ref(0),
+    bgPalette: ref(1),
+    backdropColor: ref(0),
+    spritePalette: ref(1),
+    cgenMode: ref(0),
+    spriteStates: ref([]),
+    spriteEnabled: ref(false),
+    movementPositionsFromBuffer: ref(new Map()),
+    externalFrontSpriteNodes: ref(new Map()),
+    externalBackSpriteNodes: ref(new Map()),
+    sharedDisplayViews: ref(undefined),
+    sharedDisplayBufferAccessor: null,
+    sharedAnimationBuffer: ref(undefined),
+    sharedJoystickBuffer: ref(undefined),
+    setDecodedScreenState: vi.fn(),
+    registerCallbacks: {
+      registerScheduleRender: vi.fn(),
+      registerInvalidateBackgroundBuffer: vi.fn(),
+    },
+    updateInspectorMoveSlots: vi.fn(),
+  }),
+}))
+
+// Mock useAnimationWorker — Screen.vue calls this but we don't need animation in tests
+vi.mock('@/features/ide/composables/useAnimationWorker', () => ({
+  useAnimationWorker: () => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    terminate: vi.fn(),
+  }),
+}))
+
+// Mock useScreenAnimationLoopRenderOnly — heavy dependency not needed for this test
+vi.mock('@/features/ide/composables/useScreenAnimationLoopRenderOnly', () => ({
+  useScreenAnimationLoopRenderOnly: () => vi.fn(),
+}))
+
+// Mock canvas background renderer — avoids DOM canvas creation in tests
+vi.mock('@/features/ide/composables/useCanvasBackgroundRenderer', () => ({
+  preInitializeBackgroundTiles: () => Promise.resolve(),
+  renderBackgroundToCanvas: vi.fn(),
+  renderBackgroundToCanvasDirty: vi.fn(),
+}))
+
+// Mock Konva screen renderer — avoids Konva initialization in tests
+vi.mock('@/features/ide/composables/useKonvaScreenRenderer', () => ({
+  initializeKonvaLayers: () => ({
+    backdropLayer: null,
+    spriteBackLayer: null,
+    backgroundLayer: null,
+    spriteFrontLayer: null,
+  }),
+  renderAllScreenLayers: vi.fn().mockResolvedValue({
+    frontSpriteNodes: new Map(),
+    backSpriteNodes: new Map(),
+  }),
+}))
+
+// Stub vue-konva components to avoid Konva canvas in tests
+// v-stage must expose getNode()/getStage() to prevent errors in initializeKonva
+const vStageStub = {
+  template: '<div class="v-stage-stub"><slot /></div>',
+  methods: {
+    getNode: vi.fn(() => null),
+    getStage: vi.fn(() => null),
+  },
+}
+const vLayerStub = {
+  template: '<div class="v-layer-stub"><slot /></div>',
+}
+const vRectStub = {
+  template: '<div class="v-rect-stub" />',
+}
+
+// Stub DebugGridOverlay
+vi.mock('@/features/ide/components/DebugGridOverlay.vue', () => ({
+  default: {
+    template: '<div class="debug-grid-overlay-stub" />',
+  },
+}))
+
+describe('Screen - scanline filter integration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('hides crt-scanlines when filterEnabled is false (default)', () => {
+    const wrapper = mount(Screen, {
+      global: {
+        stubs: {
+          'v-stage': vStageStub,
+          'v-layer': vLayerStub,
+          'v-rect': vRectStub,
+        },
+      },
+    })
+
+    // Sanity check: component rendered
+    expect(wrapper.find('.screen-display').exists()).toEqual(true)
+    // Scanlines should not be present when filter is disabled (default)
+    expect(wrapper.find('.crt-scanlines').exists()).toEqual(false)
+    wrapper.unmount()
+  })
+
+  it('shows crt-scanlines when filterEnabled is true', async () => {
+    localStorage.setItem('fbasic-screen-filter', 'true')
+
+    const wrapper = mount(Screen, {
+      global: {
+        stubs: {
+          'v-stage': vStageStub,
+          'v-layer': vLayerStub,
+          'v-rect': vRectStub,
+        },
+      },
+    })
+
+    // Allow VueUse useLocalStorage to read from localStorage
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(wrapper.find('.crt-scanlines').exists()).toEqual(true)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #612 — Wires up `useScreenFilter` composable to conditionally show CRT scanline overlay (Step 2 of 5 for #534)

## Changes
- `src/features/ide/components/Screen.vue` — Imported `useScreenFilter`, added `v-if="filterEnabled"` to `.crt-scanlines` div
- `test/ide/Screen.test.ts` (new, 135 lines) — 2 tests verifying scanline conditional rendering

## Test plan
- [x] 2 new Screen tests pass (filter off = no scanlines, filter on = scanlines present)
- [x] 10 useScreenFilter tests pass (no regression)
- [x] Type-check clean
- [x] ESLint clean
- [x] Screen.vue at exactly 500 lines (limit)
- [ ] CI passes