### PR TITLE
feat: resolve #617 - create ComposerControls component with tempo, duration, envelope

### DIFF
--- a/src/features/ide/components/ComposerControls.vue
+++ b/src/features/ide/components/ComposerControls.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import GameBlock from '@/shared/components/ui/GameBlock.vue'
+import type { GameSelectOption } from '@/shared/components/ui/GameSelect.types'
+import GameSelect from '@/shared/components/ui/GameSelect.vue'
+
+import {
+  DEFAULT_DURATION,
+  DEFAULT_ENVELOPE,
+  DEFAULT_OCTAVE,
+  DEFAULT_STEPS,
+  DEFAULT_TEMPO,
+  DURATION_OPTIONS,
+  ENVELOPE_OPTIONS,
+  OCTAVE_OPTIONS,
+  STEPS_OPTIONS,
+} from './composerControlsConstants'
+
+defineOptions({
+  name: 'ComposerControls',
+})
+
+withDefaults(
+  defineProps<{
+    /** BPM value (40-240). */
+    tempo?: number
+    /** Number of steps in the sequence. */
+    steps?: 16 | 32
+    /** Base octave (2-6). */
+    octave?: number
+  }>(),
+  {
+    tempo: DEFAULT_TEMPO,
+    steps: DEFAULT_STEPS,
+    octave: DEFAULT_OCTAVE,
+  }
+)
+
+const emit = defineEmits<{
+  'update:tempo': [value: number]
+  'update:steps': [value: number]
+  'update:octave': [value: number]
+  'update:duration': [value: string]
+  'update:envelope': [value: string]
+}>()
+
+const { t } = useI18n()
+
+// ---------------------------------------------------------------------------
+// Internal state for controls without props
+// ---------------------------------------------------------------------------
+
+const duration = computed(() => DEFAULT_DURATION)
+const envelope = computed(() => DEFAULT_ENVELOPE)
+
+// ---------------------------------------------------------------------------
+// Option lists
+// ---------------------------------------------------------------------------
+
+const stepsOptions: GameSelectOption[] = STEPS_OPTIONS.map((v) => ({
+  label: String(v),
+  value: v,
+}))
+
+const octaveOptions: GameSelectOption[] = OCTAVE_OPTIONS.map((v) => ({
+  label: String(v),
+  value: v,
+}))
+
+const durationOptions: GameSelectOption[] = DURATION_OPTIONS.map((v) => ({
+  label: v,
+  value: v,
+}))
+
+const envelopeOptions: GameSelectOption[] = ENVELOPE_OPTIONS.map((v) => ({
+  label: t(`ide.composer.envelopes.${v}`),
+  value: v,
+}))
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+function onTempoInput(event: Event): void {
+  const value = Number.parseInt((event.target as HTMLInputElement).value, 10)
+  emit('update:tempo', value)
+}
+
+function onStepsChange(value: string | number): void {
+  emit('update:steps', Number(value))
+}
+
+function onOctaveChange(value: string | number): void {
+  emit('update:octave', Number(value))
+}
+
+function onDurationChange(value: string | number): void {
+  emit('update:duration', String(value))
+}
+
+function onEnvelopeChange(value: string | number): void {
+  emit('update:envelope', String(value))
+}
+</script>
+
+<template>
+  <GameBlock :title="t('ide.composer.title')" class="composer-controls">
+    <div class="composer-controls__grid">
+      <!-- Tempo slider -->
+      <div class="composer-controls__tempo">
+        <label class="composer-controls__label">
+          {{ t('ide.composer.tempo') }}
+        </label>
+        <div class="composer-controls__tempo-row">
+          <input
+            type="range"
+            class="composer-controls__tempo-slider"
+            min="40"
+            max="240"
+            :value="tempo"
+            @input="onTempoInput"
+          />
+          <span class="composer-controls__tempo-value">
+            {{ tempo }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Steps -->
+      <div class="composer-controls__steps">
+        <label class="composer-controls__label">
+          {{ t('ide.composer.steps') }}
+        </label>
+        <GameSelect
+          :model-value="steps"
+          :options="stepsOptions"
+          size="small"
+          @update:model-value="onStepsChange"
+        />
+      </div>
+
+      <!-- Octave -->
+      <div class="composer-controls__octave">
+        <label class="composer-controls__label">
+          {{ t('ide.composer.octave') }}
+        </label>
+        <GameSelect
+          :model-value="octave"
+          :options="octaveOptions"
+          size="small"
+          @update:model-value="onOctaveChange"
+        />
+      </div>
+
+      <!-- Duration -->
+      <div class="composer-controls__duration">
+        <label class="composer-controls__label">
+          {{ t('ide.composer.duration') }}
+        </label>
+        <GameSelect
+          :model-value="duration"
+          :options="durationOptions"
+          size="small"
+          @update:model-value="onDurationChange"
+        />
+      </div>
+
+      <!-- Envelope -->
+      <div class="composer-controls__envelope">
+        <label class="composer-controls__label">
+          {{ t('ide.composer.envelope') }}
+        </label>
+        <GameSelect
+          :model-value="envelope"
+          :options="envelopeOptions"
+          size="small"
+          @update:model-value="onEnvelopeChange"
+        />
+      </div>
+    </div>
+  </GameBlock>
+</template>
+
+<style scoped>
+.composer-controls__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.composer-controls__tempo,
+.composer-controls__steps,
+.composer-controls__octave,
+.composer-controls__duration,
+.composer-controls__envelope {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 80px;
+}
+
+.composer-controls__label {
+  font-size: 0.7rem;
+  color: var(--game-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.composer-controls__tempo-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.composer-controls__tempo-slider {
+  width: 120px;
+  accent-color: var(--base-solid-primary);
+  cursor: pointer;
+}
+
+.composer-controls__tempo-value {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--game-text-primary);
+  min-width: 2.5rem;
+  text-align: right;
+}
+</style>

--- a/src/features/ide/components/composerControlsConstants.ts
+++ b/src/features/ide/components/composerControlsConstants.ts
@@ -1,0 +1,40 @@
+/**
+ * Constants and types for the ComposerControls component.
+ *
+ * Extracted for clarity and testability, and so future steps
+ * (state management, playback) can import them without pulling
+ * in the component.
+ */
+
+/** Default tempo in BPM. */
+export const DEFAULT_TEMPO = 120
+
+/** Minimum tempo (BPM). */
+export const MIN_TEMPO = 40
+
+/** Maximum tempo (BPM). */
+export const MAX_TEMPO = 240
+
+/** Default number of sequence steps. */
+export const DEFAULT_STEPS = 16 as const
+
+/** All valid step counts. */
+export const STEPS_OPTIONS = [16, 32] as const
+
+/** Default base octave. */
+export const DEFAULT_OCTAVE = 4
+
+/** All valid octave values. */
+export const OCTAVE_OPTIONS = [2, 3, 4, 5, 6] as const
+
+/** Default note duration. */
+export const DEFAULT_DURATION = '1/4'
+
+/** All valid note duration values. */
+export const DURATION_OPTIONS = ['1/16', '1/8', '1/4', '1/2', '1'] as const
+
+/** Default envelope preset. */
+export const DEFAULT_ENVELOPE = 'none'
+
+/** All valid envelope preset values. */
+export const ENVELOPE_OPTIONS = ['none', 'short', 'medium', 'long'] as const

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -405,6 +405,20 @@
   "bufferInspector": {
     "title": "Buffer Inspector"
   },
+  "composer": {
+    "title": "Controls",
+    "tempo": "Tempo",
+    "steps": "Steps",
+    "octave": "Octave",
+    "duration": "Duration",
+    "envelope": "Envelope",
+    "envelopes": {
+      "none": "None",
+      "short": "Short",
+      "medium": "Medium",
+      "long": "Long"
+    }
+  },
   "logLevels": {
     "title": "Log Levels",
     "description": "Set verbosity per area. {warn} = quiet; {debug} = verbose.",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -405,6 +405,20 @@
   "bufferInspector": {
     "title": "バッファインスペクタ"
   },
+  "composer": {
+    "title": "コントロール",
+    "tempo": "テンポ",
+    "steps": "ステップ",
+    "octave": "オクターブ",
+    "duration": "デュレーション",
+    "envelope": "エンベロープ",
+    "envelopes": {
+      "none": "なし",
+      "short": "短",
+      "medium": "中",
+      "long": "長"
+    }
+  },
   "logLevels": {
     "title": "ログレベル",
     "description": "各領域の詳細度を設定します。{warn} = 静か；{debug} = 詳細。",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -405,6 +405,20 @@
   "bufferInspector": {
     "title": "缓冲区检查器"
   },
+  "composer": {
+    "title": "控制",
+    "tempo": "速度",
+    "steps": "步数",
+    "octave": "八度",
+    "duration": "时值",
+    "envelope": "包络",
+    "envelopes": {
+      "none": "无",
+      "short": "短",
+      "medium": "中",
+      "long": "长"
+    }
+  },
   "logLevels": {
     "title": "日志级别",
     "description": "设置各区域的详细程度。{warn} = 安静；{debug} = 详细。",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -405,6 +405,20 @@
   "bufferInspector": {
     "title": "緩衝區檢查器"
   },
+  "composer": {
+    "title": "控制",
+    "tempo": "速度",
+    "steps": "步數",
+    "octave": "八度",
+    "duration": "時值",
+    "envelope": "包絡",
+    "envelopes": {
+      "none": "無",
+      "short": "短",
+      "medium": "中",
+      "long": "長"
+    }
+  },
   "logLevels": {
     "title": "日誌級別",
     "description": "設定各區域的詳細程度。{warn} = 安靜；{debug} = 詳細。",

--- a/test/ide/ComposerControls.test.ts
+++ b/test/ide/ComposerControls.test.ts
@@ -1,0 +1,317 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import ComposerControls from '@/features/ide/components/ComposerControls.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Stubs for child components
+// ---------------------------------------------------------------------------
+
+const gameBlockStub = defineComponent({
+  template: '<div class="game-block-stub"><slot /></div>',
+})
+
+/**
+ * GameSelect stub that renders a real <select> for testability.
+ * Expects modelValue, options, and emits update:modelValue.
+ */
+const gameSelectStub = defineComponent({
+  name: 'GameSelect',
+  props: {
+    modelValue: { type: [String, Number], required: true },
+    options: { type: Array, default: () => [] },
+    size: { type: String, default: 'small' },
+    width: { type: String, default: '' },
+  },
+  emits: ['update:modelValue'],
+  template: `
+    <select
+      :value="modelValue"
+      data-testid="game-select"
+      @change="$emit('update:modelValue', $event.target.value)"
+    >
+      <option
+        v-for="opt in options"
+        :key="String(opt.value)"
+        :value="opt.value"
+      >
+        {{ opt.label }}
+      </option>
+    </select>
+  `,
+})
+
+const GLOBAL_STUBS = {
+  GameBlock: gameBlockStub,
+  GameSelect: gameSelectStub,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CONTAINER_SELECTOR = '.composer-controls'
+const TEMPO_SLIDER_SELECTOR = '.composer-controls__tempo-slider'
+const TEMPO_VALUE_SELECTOR = '.composer-controls__tempo-value'
+const STEPS_SELECT_SELECTOR = '.composer-controls__steps select'
+const OCTAVE_SELECT_SELECTOR = '.composer-controls__octave select'
+const DURATION_SELECT_SELECTOR = '.composer-controls__duration select'
+const ENVELOPE_SELECT_SELECTOR = '.composer-controls__envelope select'
+
+function mountComposerControls(props: {
+  tempo?: number
+  steps?: 16 | 32
+  octave?: number
+} = {}) {
+  return mount(ComposerControls, {
+    props: {
+      tempo: props.tempo ?? 120,
+      steps: props.steps ?? 16,
+      octave: props.octave ?? 4,
+    },
+    global: { stubs: GLOBAL_STUBS },
+    attrs: {
+      'data-testid': 'composer-controls',
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ComposerControls', () => {
+  describe('rendering', () => {
+    it('renders the container element', () => {
+      const wrapper = mountComposerControls()
+
+      expect(wrapper.find(CONTAINER_SELECTOR).exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('renders the tempo slider', () => {
+      const wrapper = mountComposerControls()
+
+      const slider = wrapper.find(TEMPO_SLIDER_SELECTOR)
+      expect(slider.exists()).toBe(true)
+      expect(slider.attributes('type')).toEqual('range')
+      expect(slider.attributes('min')).toEqual('40')
+      expect(slider.attributes('max')).toEqual('240')
+      wrapper.unmount()
+    })
+
+    it('renders the tempo value display', () => {
+      const wrapper = mountComposerControls()
+
+      const valueDisplay = wrapper.find(TEMPO_VALUE_SELECTOR)
+      expect(valueDisplay.exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('renders the steps dropdown', () => {
+      const wrapper = mountComposerControls()
+
+      expect(wrapper.find(STEPS_SELECT_SELECTOR).exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('renders the octave dropdown', () => {
+      const wrapper = mountComposerControls()
+
+      expect(wrapper.find(OCTAVE_SELECT_SELECTOR).exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('renders the duration dropdown', () => {
+      const wrapper = mountComposerControls()
+
+      expect(wrapper.find(DURATION_SELECT_SELECTOR).exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('renders the envelope dropdown', () => {
+      const wrapper = mountComposerControls()
+
+      expect(wrapper.find(ENVELOPE_SELECT_SELECTOR).exists()).toBe(true)
+      wrapper.unmount()
+    })
+  })
+
+  describe('default values', () => {
+    it('shows default tempo of 120 on the slider', () => {
+      const wrapper = mountComposerControls()
+
+      const slider = wrapper.find<HTMLInputElement>(TEMPO_SLIDER_SELECTOR)
+      expect(slider.element.value).toEqual('120')
+      wrapper.unmount()
+    })
+
+    it('displays default tempo value as "120"', () => {
+      const wrapper = mountComposerControls()
+
+      const valueDisplay = wrapper.find(TEMPO_VALUE_SELECTOR)
+      expect(valueDisplay.text()).toEqual('120')
+      wrapper.unmount()
+    })
+
+    it('shows default steps of 16 in the dropdown', () => {
+      const wrapper = mountComposerControls()
+
+      const select = wrapper.find<HTMLSelectElement>(STEPS_SELECT_SELECTOR)
+      expect(select.element.value).toEqual('16')
+      wrapper.unmount()
+    })
+
+    it('shows default octave of 4 in the dropdown', () => {
+      const wrapper = mountComposerControls()
+
+      const select = wrapper.find<HTMLSelectElement>(OCTAVE_SELECT_SELECTOR)
+      expect(select.element.value).toEqual('4')
+      wrapper.unmount()
+    })
+  })
+
+  describe('tempo slider', () => {
+    it('reflects a custom tempo prop on the slider', () => {
+      const wrapper = mountComposerControls({ tempo: 180 })
+
+      const slider = wrapper.find<HTMLInputElement>(TEMPO_SLIDER_SELECTOR)
+      expect(slider.element.value).toEqual('180')
+      wrapper.unmount()
+    })
+
+    it('displays custom tempo value', () => {
+      const wrapper = mountComposerControls({ tempo: 80 })
+
+      const valueDisplay = wrapper.find(TEMPO_VALUE_SELECTOR)
+      expect(valueDisplay.text()).toEqual('80')
+      wrapper.unmount()
+    })
+
+    it('emits update:tempo when slider value changes', async () => {
+      const wrapper = mountComposerControls({ tempo: 120 })
+
+      const slider = wrapper.find(TEMPO_SLIDER_SELECTOR)
+      await slider.setValue('150')
+
+      expect(wrapper.emitted('update:tempo')).toBeTruthy()
+      const emitted = wrapper.emitted<number[]>('update:tempo')!
+      expect(emitted[0]![0]).toEqual(150)
+      wrapper.unmount()
+    })
+  })
+
+  describe('steps dropdown', () => {
+    it('reflects a custom steps prop', () => {
+      const wrapper = mountComposerControls({ steps: 32 })
+
+      const select = wrapper.find<HTMLSelectElement>(STEPS_SELECT_SELECTOR)
+      expect(select.element.value).toEqual('32')
+      wrapper.unmount()
+    })
+
+    it('emits update:steps when selection changes', async () => {
+      const wrapper = mountComposerControls({ steps: 16 })
+
+      const select = wrapper.find(STEPS_SELECT_SELECTOR)
+      await select.setValue('32')
+
+      expect(wrapper.emitted('update:steps')).toBeTruthy()
+      const emitted = wrapper.emitted<number[]>('update:steps')!
+      expect(emitted[0]![0]).toEqual(32)
+      wrapper.unmount()
+    })
+  })
+
+  describe('octave dropdown', () => {
+    it('reflects a custom octave prop', () => {
+      const wrapper = mountComposerControls({ octave: 3 })
+
+      const select = wrapper.find<HTMLSelectElement>(OCTAVE_SELECT_SELECTOR)
+      expect(select.element.value).toEqual('3')
+      wrapper.unmount()
+    })
+
+    it('emits update:octave when selection changes', async () => {
+      const wrapper = mountComposerControls({ octave: 4 })
+
+      const select = wrapper.find(OCTAVE_SELECT_SELECTOR)
+      await select.setValue('5')
+
+      expect(wrapper.emitted('update:octave')).toBeTruthy()
+      const emitted = wrapper.emitted<number[]>('update:octave')!
+      expect(emitted[0]![0]).toEqual(5)
+      wrapper.unmount()
+    })
+  })
+
+  describe('duration dropdown', () => {
+    it('has correct duration options', () => {
+      const wrapper = mountComposerControls()
+
+      const options = wrapper.findAll(`${DURATION_SELECT_SELECTOR} option`)
+      const values = options.map((o) => o.attributes('value'))
+      expect(values).toEqual(['1/16', '1/8', '1/4', '1/2', '1'])
+      wrapper.unmount()
+    })
+
+    it('defaults to quarter note (1/4)', () => {
+      const wrapper = mountComposerControls()
+
+      const select = wrapper.find<HTMLSelectElement>(DURATION_SELECT_SELECTOR)
+      expect(select.element.value).toEqual('1/4')
+      wrapper.unmount()
+    })
+
+    it('emits update:duration when selection changes', async () => {
+      const wrapper = mountComposerControls()
+
+      const select = wrapper.find(DURATION_SELECT_SELECTOR)
+      await select.setValue('1/8')
+
+      expect(wrapper.emitted('update:duration')).toBeTruthy()
+      const emitted = wrapper.emitted<string[]>('update:duration')!
+      expect(emitted[0]![0]).toEqual('1/8')
+      wrapper.unmount()
+    })
+  })
+
+  describe('envelope dropdown', () => {
+    it('has correct envelope options', () => {
+      const wrapper = mountComposerControls()
+
+      const options = wrapper.findAll(`${ENVELOPE_SELECT_SELECTOR} option`)
+      const values = options.map((o) => o.attributes('value'))
+      expect(values).toEqual(['none', 'short', 'medium', 'long'])
+      wrapper.unmount()
+    })
+
+    it('defaults to none envelope', () => {
+      const wrapper = mountComposerControls()
+
+      const select = wrapper.find<HTMLSelectElement>(ENVELOPE_SELECT_SELECTOR)
+      expect(select.element.value).toEqual('none')
+      wrapper.unmount()
+    })
+
+    it('emits update:envelope when selection changes', async () => {
+      const wrapper = mountComposerControls()
+
+      const select = wrapper.find(ENVELOPE_SELECT_SELECTOR)
+      await select.setValue('short')
+
+      expect(wrapper.emitted('update:envelope')).toBeTruthy()
+      const emitted = wrapper.emitted<string[]>('update:envelope')!
+      expect(emitted[0]![0]).toEqual('short')
+      wrapper.unmount()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #617 — Creates ComposerControls component with tempo slider, steps/octave/duration/envelope selectors (Step 2 of 7 for #536)

## Changes
- New `ComposerControls.vue` (231 lines) — Compact control panel with tempo range slider, steps/octave/duration/envelope dropdowns
- New `composerControlsConstants.ts` (40 lines) — Tempo, octave, duration, envelope option definitions
- New `test/ide/ComposerControls.test.ts` (317 lines) — 24 unit tests covering all controls and events
- 4 locale files — 14 new i18n keys under `composer` namespace

## Test plan
- [x] 24 new tests pass
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes