### PR TITLE
docs: resolve #660 - localize spriteSlotsDisabled key in zh-CN and zh-TW locales

### DIFF
--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -405,7 +405,7 @@
   "bufferInspector": {
     "title": "缓冲区检查器",
     "spriteSlotsTitle": "精灵槽位",
-    "spriteSlotsDisabled": "SPRITE OFF",
+    "spriteSlotsDisabled": "精灵已关闭",
     "spriteSlotsOn": "开",
     "spriteSlotsOff": "关",
     "spriteSlotsDefined": "已定义",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -405,7 +405,7 @@
   "bufferInspector": {
     "title": "緩衝區檢查器",
     "spriteSlotsTitle": "精靈槽位",
-    "spriteSlotsDisabled": "SPRITE OFF",
+    "spriteSlotsDisabled": "精靈已關閉",
     "spriteSlotsOn": "開",
     "spriteSlotsOff": "關",
     "spriteSlotsDefined": "已定義",


### PR DESCRIPTION
## Summary
- Fixes #660

## Changes
- Localized `spriteSlotsDisabled` i18n key from `"SPRITE OFF"` to `"精灵已关闭"` (zh-CN) and `"精靈已關閉"` (zh-TW)
- Left `ja/ide.json` unchanged — Japanese locale consistently uses English technical abbreviations (ON/OFF pattern)

## Test plan
- [ ] CI passes