### PR TITLE
feat: resolve #605 - implement screen chars and patterns grid views in BufferInspector

### DIFF
--- a/src/features/ide/components/BufferInspector.vue
+++ b/src/features/ide/components/BufferInspector.vue
@@ -4,7 +4,9 @@ import { useI18n } from 'vue-i18n'
 import type { SpriteState } from '@/core/sprite/types'
 import { GameBlock } from '@/shared/components/ui'
 
+import DisplayBufferSection from './DisplayBufferSection.vue'
 import SpriteSlotsSection from './SpriteSlotsSection.vue'
+import type { ScreenBufferReader } from './types'
 
 defineOptions({
   name: 'BufferInspector',
@@ -13,6 +15,7 @@ defineOptions({
 defineProps<{
   spriteStates: SpriteState[]
   spriteEnabled: boolean
+  sharedDisplayBufferAccessor: ScreenBufferReader
 }>()
 
 const { t } = useI18n()
@@ -26,6 +29,7 @@ const { t } = useI18n()
     class="buffer-inspector"
   >
     <div class="buffer-inspector-content">
+      <DisplayBufferSection :shared-display-buffer-accessor="sharedDisplayBufferAccessor" />
       <SpriteSlotsSection :sprite-states="spriteStates" :sprite-enabled="spriteEnabled" />
     </div>
   </GameBlock>

--- a/src/features/ide/components/DisplayBufferSection.vue
+++ b/src/features/ide/components/DisplayBufferSection.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { SCREEN_DIMENSIONS } from '@/core/constants'
+
+import type { ScreenBufferReader } from './types'
+
+defineOptions({
+  name: 'DisplayBufferSection',
+})
+
+const props = defineProps<{
+  sharedDisplayBufferAccessor: ScreenBufferReader
+}>()
+
+const { t } = useI18n()
+
+const COLS = SCREEN_DIMENSIONS.BACKGROUND.COLUMNS
+const ROWS = SCREEN_DIMENSIONS.BACKGROUND.LINES
+
+const SPACE_CHAR = 0x20
+
+/** Build a 2D grid of character codes read from the shared display buffer. */
+const charGrid = computed(() => {
+  const grid: number[][] = []
+  for (let y = 0; y < ROWS; y++) {
+    const row: number[] = []
+    for (let x = 0; x < COLS; x++) {
+      row.push(props.sharedDisplayBufferAccessor.readScreenChar(x, y))
+    }
+    grid.push(row)
+  }
+  return grid
+})
+
+/** Build a 2D grid of color pattern values read from the shared display buffer. */
+const patternGrid = computed(() => {
+  const grid: number[][] = []
+  for (let y = 0; y < ROWS; y++) {
+    const row: number[] = []
+    for (let x = 0; x < COLS; x++) {
+      row.push(props.sharedDisplayBufferAccessor.readScreenPattern(x, y))
+    }
+    grid.push(row)
+  }
+  return grid
+})
+
+/** Format a character code as 2-digit hex. */
+function formatCharCode(code: number): string {
+  return code.toString(16).toUpperCase().padStart(2, '0')
+}
+
+/** Format a row index as 2-digit hex. */
+function formatRowIndex(index: number): string {
+  return index.toString(16).toUpperCase().padStart(2, '0')
+}
+</script>
+
+<template>
+  <div class="display-buffer-section">
+    <div class="display-buffer-grid-section">
+      <div class="display-buffer-char-title">
+        {{ t('ide.bufferInspector.displayBufferCharTitle') }}
+      </div>
+      <div class="display-buffer-grid">
+        <div
+          v-for="(row, y) in charGrid"
+          :key="`char-row-${y}`"
+          class="display-buffer-char-row"
+        >
+          <span class="display-buffer-char-row-label">
+            {{ formatRowIndex(y) }}
+          </span>
+          <span
+            v-for="(code, x) in row"
+            :key="`char-${x}-${y}`"
+            class="display-buffer-char-cell"
+            :class="{
+              'display-buffer-cell-highlighted': code !== SPACE_CHAR,
+            }"
+          >
+            {{ formatCharCode(code) }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <div class="display-buffer-grid-section">
+      <div class="display-buffer-pattern-title">
+        {{ t('ide.bufferInspector.displayBufferPatternTitle') }}
+      </div>
+      <div class="display-buffer-grid">
+        <div
+          v-for="(row, y) in patternGrid"
+          :key="`pattern-row-${y}`"
+          class="display-buffer-pattern-row"
+        >
+          <span class="display-buffer-pattern-row-label">
+            {{ formatRowIndex(y) }}
+          </span>
+          <span
+            v-for="(pattern, x) in row"
+            :key="`pattern-${x}-${y}`"
+            class="display-buffer-pattern-cell"
+            :class="{
+              'display-buffer-cell-highlighted': pattern !== 0,
+            }"
+          >
+            {{ pattern }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.display-buffer-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.display-buffer-grid-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.display-buffer-char-title,
+.display-buffer-pattern-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--game-text-secondary);
+}
+
+.display-buffer-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  overflow: auto;
+  font-size: 0.55rem;
+  font-family: monospace;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.display-buffer-char-row,
+.display-buffer-pattern-row {
+  display: flex;
+  gap: 1px;
+}
+
+.display-buffer-char-row-label,
+.display-buffer-pattern-row-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 1.5rem;
+  flex-shrink: 0;
+  color: var(--game-text-tertiary);
+  font-size: 0.5rem;
+}
+
+.display-buffer-char-cell,
+.display-buffer-pattern-cell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.2rem;
+  flex-shrink: 0;
+  color: var(--game-text-tertiary);
+  background: var(--game-surface-bg-start);
+}
+
+.display-buffer-cell-highlighted {
+  color: var(--game-text-primary);
+  background: var(--game-surface-accent);
+}
+</style>

--- a/src/features/ide/components/IdeBottomArea.vue
+++ b/src/features/ide/components/IdeBottomArea.vue
@@ -78,7 +78,11 @@ defineExpose({
           />
         </GameTabPane>
         <GameTabPane name="buffer" :label="t('ide.bufferInspector.title')">
-          <BufferInspector :sprite-states="spriteStates" :sprite-enabled="spriteEnabled" />
+          <BufferInspector
+            :sprite-states="spriteStates"
+            :sprite-enabled="spriteEnabled"
+            :shared-display-buffer-accessor="sharedDisplayBufferAccessor"
+          />
         </GameTabPane>
       </GameTabs>
     </div>

--- a/src/features/ide/components/types.ts
+++ b/src/features/ide/components/types.ts
@@ -1,0 +1,5 @@
+/** Minimal interface for reading screen character and pattern data from the shared display buffer. */
+export interface ScreenBufferReader {
+  readScreenChar(x: number, y: number): number
+  readScreenPattern(x: number, y: number): number
+}

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -415,7 +415,9 @@
     "spriteSlotsColY": "Y",
     "spriteSlotsColVisible": "Visible",
     "spriteSlotsColPriority": "Priority",
-    "spriteSlotsColDefinition": "Definition"
+    "spriteSlotsColDefinition": "Definition",
+    "displayBufferCharTitle": "Character Codes",
+    "displayBufferPatternTitle": "Color Patterns"
   },
   "composer": {
     "title": "Controls",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -415,7 +415,9 @@
     "spriteSlotsColY": "Y",
     "spriteSlotsColVisible": "表示",
     "spriteSlotsColPriority": "優先度",
-    "spriteSlotsColDefinition": "定義"
+    "spriteSlotsColDefinition": "定義",
+    "displayBufferCharTitle": "キャラクタコード",
+    "displayBufferPatternTitle": "カラーパターン"
   },
   "composer": {
     "title": "コントロール",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -415,7 +415,9 @@
     "spriteSlotsColY": "Y",
     "spriteSlotsColVisible": "可见",
     "spriteSlotsColPriority": "优先级",
-    "spriteSlotsColDefinition": "定义"
+    "spriteSlotsColDefinition": "定义",
+    "displayBufferCharTitle": "字符代码",
+    "displayBufferPatternTitle": "颜色图案"
   },
   "composer": {
     "title": "控制",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -415,7 +415,9 @@
     "spriteSlotsColY": "Y",
     "spriteSlotsColVisible": "可見",
     "spriteSlotsColPriority": "優先順序",
-    "spriteSlotsColDefinition": "定義"
+    "spriteSlotsColDefinition": "定義",
+    "displayBufferCharTitle": "字元代碼",
+    "displayBufferPatternTitle": "顏色圖案"
   },
   "composer": {
     "title": "控制",

--- a/test/ide/BufferInspector.test.ts
+++ b/test/ide/BufferInspector.test.ts
@@ -3,8 +3,10 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 
-import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
+import { SHARED_DISPLAY_BUFFER_BYTES } from '@/core/animation/sharedDisplayBuffer'
+import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import BufferInspector from '@/features/ide/components/BufferInspector.vue'
+import type { ScreenBufferReader } from '@/features/ide/components/types'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -12,8 +14,15 @@ vi.mock('vue-i18n', () => ({
   }),
 }))
 
-/** Minimal mock satisfying SharedDisplayBufferAccessor type (never called in stubbed tests) */
-const MOCK_ACCESSOR: SharedDisplayBufferAccessor = {} as SharedDisplayBufferAccessor
+/** Minimal mock satisfying ScreenBufferReader type */
+const MOCK_ACCESSOR: ScreenBufferReader = {
+  readScreenChar: () => 0x20,
+  readScreenPattern: () => 0,
+}
+
+/** Real accessor instance for IdeBottomArea tests (StateInspector needs the full type) */
+const testBuffer = new SharedArrayBuffer(SHARED_DISPLAY_BUFFER_BYTES)
+const MOCK_FULL_ACCESSOR = new SharedDisplayBufferAccessor(testBuffer)
 
 describe('BufferInspector', () => {
   it('renders without errors', () => {
@@ -21,6 +30,7 @@ describe('BufferInspector', () => {
       props: {
         spriteStates: [],
         spriteEnabled: false,
+        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
       },
       global: {
         stubs: {
@@ -38,6 +48,7 @@ describe('BufferInspector', () => {
       props: {
         spriteStates: [],
         spriteEnabled: false,
+        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
       },
       global: {
         stubs: {
@@ -55,6 +66,7 @@ describe('BufferInspector', () => {
       props: {
         spriteStates: [],
         spriteEnabled: false,
+        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
       },
       global: {
         stubs: {
@@ -72,11 +84,12 @@ describe('BufferInspector', () => {
     wrapper.unmount()
   })
 
-  it('renders content area with SpriteSlotsSection', () => {
+  it('renders content area with DisplayBufferSection and SpriteSlotsSection', () => {
     const wrapper = mount(BufferInspector, {
       props: {
         spriteStates: [],
         spriteEnabled: false,
+        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
       },
       global: {
         stubs: {
@@ -86,7 +99,28 @@ describe('BufferInspector', () => {
     })
 
     expect(wrapper.find('.buffer-inspector-content').exists()).toBe(true)
+    expect(wrapper.find('.display-buffer-section').exists()).toBe(true)
     expect(wrapper.find('.sprite-slots-section').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('passes sharedDisplayBufferAccessor to DisplayBufferSection', () => {
+    const wrapper = mount(BufferInspector, {
+      props: {
+        spriteStates: [],
+        spriteEnabled: false,
+        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+      },
+      global: {
+        stubs: {
+          GameBlock: defineComponent({ template: '<div><slot /></div>' }),
+        },
+      },
+    })
+
+    const section = wrapper.findComponent({ name: 'DisplayBufferSection' })
+    expect(section.exists()).toBe(true)
+    expect(section.props('sharedDisplayBufferAccessor')).toEqual(MOCK_ACCESSOR)
     wrapper.unmount()
   })
 
@@ -97,6 +131,7 @@ describe('BufferInspector', () => {
           { spriteNumber: 0, x: 10, y: 20, visible: true, priority: 0, definition: null },
         ],
         spriteEnabled: true,
+        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
       },
       global: {
         stubs: {
@@ -131,7 +166,7 @@ describe('IdeBottomArea tab integration', () => {
         cgenMode: 2,
         spriteStates: [],
         spriteEnabled: false,
-        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedDisplayBufferAccessor: MOCK_FULL_ACCESSOR,
       },
       global: {
         stubs: {
@@ -178,7 +213,7 @@ describe('IdeBottomArea tab integration', () => {
         cgenMode: 2,
         spriteStates: [],
         spriteEnabled: false,
-        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedDisplayBufferAccessor: MOCK_FULL_ACCESSOR,
       },
       global: {
         stubs: {

--- a/test/ide/DisplayBufferSection.test.ts
+++ b/test/ide/DisplayBufferSection.test.ts
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import DisplayBufferSection from '@/features/ide/components/DisplayBufferSection.vue'
+import type { ScreenBufferReader } from '@/features/ide/components/types'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+/** Create a mock accessor with screen char/pattern data */
+function makeMockAccessor(overrides: {
+  chars?: number[][]
+  patterns?: number[][]
+} = {}): ScreenBufferReader {
+  const allSpaceChars = Array.from({ length: 24 }, () =>
+    Array.from({ length: 28 }, () => 0x20),
+  )
+  const allZeroPatterns = Array.from({ length: 24 }, () =>
+    Array.from({ length: 28 }, () => 0),
+  )
+
+  const chars = overrides.chars ?? allSpaceChars
+  const patterns = overrides.patterns ?? allZeroPatterns
+
+  return {
+    readScreenChar: (x: number, y: number) => chars[y]?.[x] ?? 0x20,
+    readScreenPattern: (x: number, y: number) => (patterns[y]?.[x] ?? 0) & 3,
+  }
+}
+
+describe('DisplayBufferSection', () => {
+  it('has the correct component name', () => {
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor(),
+      },
+    })
+
+    expect(wrapper.vm.$options.name).toBe('DisplayBufferSection')
+    wrapper.unmount()
+  })
+
+  it('renders section title for character codes grid', () => {
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor(),
+      },
+    })
+
+    const charTitle = wrapper.find('.display-buffer-char-title')
+    expect(charTitle.exists()).toBe(true)
+    expect(charTitle.text()).toBe('ide.bufferInspector.displayBufferCharTitle')
+    wrapper.unmount()
+  })
+
+  it('renders section title for color patterns grid', () => {
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor(),
+      },
+    })
+
+    const patternTitle = wrapper.find('.display-buffer-pattern-title')
+    expect(patternTitle.exists()).toBe(true)
+    expect(patternTitle.text()).toBe('ide.bufferInspector.displayBufferPatternTitle')
+    wrapper.unmount()
+  })
+
+  it('renders 24 rows for character codes grid (28x24)', () => {
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor(),
+      },
+    })
+
+    const charRows = wrapper.findAll('.display-buffer-char-row')
+    expect(charRows.length).toBe(24)
+    wrapper.unmount()
+  })
+
+  it('renders 28 cells per row in character codes grid', () => {
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor(),
+      },
+    })
+
+    const firstRow = wrapper.find('.display-buffer-char-row')
+    const cells = firstRow.findAll('.display-buffer-char-cell')
+    expect(cells.length).toBe(28)
+    wrapper.unmount()
+  })
+
+  it('renders 24 rows for color patterns grid (28x24)', () => {
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor(),
+      },
+    })
+
+    const patternRows = wrapper.findAll('.display-buffer-pattern-row')
+    expect(patternRows.length).toBe(24)
+    wrapper.unmount()
+  })
+
+  it('renders 28 cells per row in color patterns grid', () => {
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor(),
+      },
+    })
+
+    const firstRow = wrapper.find('.display-buffer-pattern-row')
+    const cells = firstRow.findAll('.display-buffer-pattern-cell')
+    expect(cells.length).toBe(28)
+    wrapper.unmount()
+  })
+
+  it('displays hex character code values in each cell', () => {
+    const chars = Array.from({ length: 24 }, () =>
+      Array.from({ length: 28 }, () => 0x20),
+    )
+    // Place 'A' (0x41) at position (0, 0)
+    chars[0]![0] = 0x41
+    // Place 'Z' (0x5A) at position (5, 3)
+    chars[3]![5] = 0x5A
+
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor({ chars }),
+      },
+    })
+
+    const charCells = wrapper.findAll('.display-buffer-char-cell')
+    expect(charCells[0]!.text()).toBe('41')
+    // Position (5, 3) -> row 3, col 5 -> index 3*28 + 5 = 89
+    expect(charCells[89]!.text()).toBe('5A')
+    wrapper.unmount()
+  })
+
+  it('displays decimal color pattern values in each cell', () => {
+    const patterns = Array.from({ length: 24 }, () =>
+      Array.from({ length: 28 }, () => 0),
+    )
+    // Set pattern 2 at position (0, 0)
+    patterns[0]![0] = 2
+    // Set pattern 3 at position (10, 5)
+    patterns[5]![10] = 3
+
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor({ patterns }),
+      },
+    })
+
+    const patternCells = wrapper.findAll('.display-buffer-pattern-cell')
+    expect(patternCells[0]!.text()).toBe('2')
+    // Position (10, 5) -> row 5, col 10 -> index 5*28 + 10 = 150
+    expect(patternCells[150]!.text()).toBe('3')
+    wrapper.unmount()
+  })
+
+  it('highlights non-space cells with CSS class in character grid', () => {
+    const chars = Array.from({ length: 24 }, () =>
+      Array.from({ length: 28 }, () => 0x20),
+    )
+    chars[0]![0] = 0x41 // 'A' at (0, 0) - non-space
+    chars[0]![1] = 0x20 // space at (1, 0)
+    chars[1]![0] = 0x00 // null at (0, 1) - non-space
+
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor({ chars }),
+      },
+    })
+
+    const charCells = wrapper.findAll('.display-buffer-char-cell')
+    expect(charCells[0]!.classes()).toContain('display-buffer-cell-highlighted')
+    expect(charCells[1]!.classes()).not.toContain('display-buffer-cell-highlighted')
+    // Row 1, col 0 -> index 28
+    expect(charCells[28]!.classes()).toContain('display-buffer-cell-highlighted')
+    wrapper.unmount()
+  })
+
+  it('highlights non-zero pattern cells with CSS class in pattern grid', () => {
+    const patterns = Array.from({ length: 24 }, () =>
+      Array.from({ length: 28 }, () => 0),
+    )
+    patterns[0]![0] = 1 // non-zero at (0, 0)
+    patterns[0]![1] = 0 // zero at (1, 0)
+
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor({ patterns }),
+      },
+    })
+
+    const patternCells = wrapper.findAll('.display-buffer-pattern-cell')
+    expect(patternCells[0]!.classes()).toContain('display-buffer-cell-highlighted')
+    expect(patternCells[1]!.classes()).not.toContain('display-buffer-cell-highlighted')
+    wrapper.unmount()
+  })
+
+  it('displays row index labels for character codes grid', () => {
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor(),
+      },
+    })
+
+    const rowLabels = wrapper.findAll('.display-buffer-char-row-label')
+    expect(rowLabels.length).toBe(24)
+    expect(rowLabels[0]!.text()).toBe('00')
+    expect(rowLabels[5]!.text()).toBe('05')
+    expect(rowLabels[23]!.text()).toBe('17')
+    wrapper.unmount()
+  })
+
+  it('displays row index labels for color patterns grid', () => {
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor(),
+      },
+    })
+
+    const rowLabels = wrapper.findAll('.display-buffer-pattern-row-label')
+    expect(rowLabels.length).toBe(24)
+    expect(rowLabels[0]!.text()).toBe('00')
+    expect(rowLabels[15]!.text()).toBe('0F')
+    expect(rowLabels[23]!.text()).toBe('17')
+    wrapper.unmount()
+  })
+
+  it('reads from accessor on initial render with mixed char data', () => {
+    const chars = Array.from({ length: 24 }, () =>
+      Array.from({ length: 28 }, () => 0x20),
+    )
+    // Set specific non-space values to test initial render
+    chars[0]![0] = 0x41 // 'A'
+    chars[0]![1] = 0x20 // space
+    chars[0]![2] = 0xFF // max value
+
+    const wrapper = mount(DisplayBufferSection, {
+      props: {
+        sharedDisplayBufferAccessor: makeMockAccessor({ chars }),
+      },
+    })
+
+    const charCells = wrapper.findAll('.display-buffer-char-cell')
+    expect(charCells[0]!.text()).toBe('41')
+    expect(charCells[1]!.text()).toBe('20')
+    expect(charCells[2]!.text()).toBe('FF')
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #605

## Changes
- Created `DisplayBufferSection.vue` with 28x24 color-coded grids for screen character codes and color pattern values
- Character codes displayed as 2-digit uppercase hex, patterns as decimal (0-3)
- Non-space cells and non-zero pattern cells highlighted with `display-buffer-cell-highlighted` CSS class
- Hex row index labels (00-17) for both grids
- Wired into `BufferInspector.vue` via `sharedDisplayBufferAccessor` prop, passed through from `IdeBottomArea.vue`
- Added i18n keys for grid section titles across all 4 locales

## Test plan
- [ ] 14 new DisplayBufferSection tests pass
- [ ] 2 new BufferInspector integration tests pass
- [ ] CI passes