### PR TITLE
refactor: resolve #658 - use LOCAL_STORAGE_SYNC_DELAY_MS in Screen.test.ts setTimeout

### DIFF
--- a/test/ide/Screen.test.ts
+++ b/test/ide/Screen.test.ts
@@ -5,6 +5,8 @@ import { ref } from 'vue'
 
 import Screen from '@/features/ide/components/Screen.vue'
 
+const LOCAL_STORAGE_SYNC_DELAY_MS = 50
+
 // Mock useScreenContext to satisfy Screen.vue's provide/inject dependency
 vi.mock('@/features/ide/composables/useScreenContext', () => ({
   useScreenContext: () => ({
@@ -127,7 +129,7 @@ describe('Screen - scanline filter integration', () => {
     })
 
     // Allow VueUse useLocalStorage to read from localStorage
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await new Promise((resolve) => setTimeout(resolve, LOCAL_STORAGE_SYNC_DELAY_MS))
 
     expect(wrapper.find('.crt-scanlines').exists()).toEqual(true)
     wrapper.unmount()


### PR DESCRIPTION
## Summary
- Fixes #658

## Changes
- Replace hardcoded `50` with `LOCAL_STORAGE_SYNC_DELAY_MS` constant in `test/ide/Screen.test.ts`
- Follows the same pattern established in `useProgramStore.test.ts` (PR #651, issue #586)

## Test plan
- [ ] Targeted tests pass
- [ ] CI passes