### PR TITLE
feat: resolve #613 - add phosphor glow and color bleeding CSS effects

### DIFF
--- a/src/features/ide/components/Screen.vue
+++ b/src/features/ide/components/Screen.vue
@@ -449,6 +449,8 @@ onDeactivated(cleanupScreen)
   <div class="screen-display">
     <div class="crt-bezel">
       <div class="crt-screen">
+        <div v-if="filterEnabled" class="crt-phosphor-glow"></div>
+        <div v-if="filterEnabled" class="crt-color-bleed"></div>
         <div v-if="filterEnabled" class="crt-scanlines"></div>
         <div
           class="screen-stage-wrapper"
@@ -471,8 +473,7 @@ onDeactivated(cleanupScreen)
             }"
           >
           <v-layer>
-            <!-- Backdrop Screen (F-Basic layer 1: furthest back) -->
-            <!-- 32×30 characters = 256×240 pixels -->
+            <!-- Backdrop Screen (F-Basic layer 1: furthest back, 32×30 chars = 256×240 px) -->
             <v-rect
               :config="{
                 x: 0,
@@ -482,8 +483,7 @@ onDeactivated(cleanupScreen)
                 fill: backdropColorHex,
               }"
             />
-            <!-- Sprite layers (sprite back, sprite front) will be added programmatically -->
-            <!-- Background layer is now Canvas2D for performance (10-50x faster than Konva) -->
+            <!-- Sprite layers added programmatically; background layer uses Canvas2D for performance -->
           </v-layer>
           </v-stage>
           <!-- Debug Grid Overlay -->

--- a/src/shared/styles/screen-crt.css
+++ b/src/shared/styles/screen-crt.css
@@ -80,8 +80,29 @@
     inset: 0;
     background: repeating-linear-gradient( 0deg, transparent, transparent 2px, var(--crt-shadow-dark-10) 2px, var(--crt-shadow-dark-10) 4px);
     pointer-events: none;
-    z-index: 2;
+    z-index: 3;
     mix-blend-mode: multiply;
+}
+
+.screen-display .crt-phosphor-glow {
+    position: absolute;
+    inset: 0;
+    background: transparent;
+    pointer-events: none;
+    z-index: 2;
+    box-shadow: inset 0 0 60px 10px var(--crt-glow-light-10), inset 0 0 120px 20px var(--crt-glow-light-20);
+    mix-blend-mode: screen;
+}
+
+.screen-display .crt-color-bleed {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 1;
+    background: transparent;
+    filter: blur(0.3px);
+    mix-blend-mode: lighten;
+    opacity: 0.3;
 }
 
 .screen-display .crt-reflection {
@@ -89,7 +110,7 @@
     inset: 0;
     background: radial-gradient( ellipse 140% 100% at 85% 5%, var(--crt-glow-light-40) 0%, var(--crt-glow-light-20) 15%, var(--crt-glow-light-10) 30%, transparent 55%, var(--crt-shadow-dark-40) 100%);
     pointer-events: none;
-    z-index: 1;
+    z-index: 4;
     border-radius: 16px;
 }
 

--- a/test/ide/Screen.test.ts
+++ b/test/ide/Screen.test.ts
@@ -90,6 +90,88 @@ vi.mock('@/features/ide/components/DebugGridOverlay.vue', () => ({
   },
 }))
 
+describe('Screen - phosphor glow filter integration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('hides crt-phosphor-glow when filterEnabled is false (default)', () => {
+    const wrapper = mount(Screen, {
+      global: {
+        stubs: {
+          'v-stage': vStageStub,
+          'v-layer': vLayerStub,
+          'v-rect': vRectStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.screen-display').exists()).toEqual(true)
+    expect(wrapper.find('.crt-phosphor-glow').exists()).toEqual(false)
+    wrapper.unmount()
+  })
+
+  it('shows crt-phosphor-glow when filterEnabled is true', async () => {
+    localStorage.setItem('fbasic-screen-filter', 'true')
+
+    const wrapper = mount(Screen, {
+      global: {
+        stubs: {
+          'v-stage': vStageStub,
+          'v-layer': vLayerStub,
+          'v-rect': vRectStub,
+        },
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(wrapper.find('.crt-phosphor-glow').exists()).toEqual(true)
+    wrapper.unmount()
+  })
+})
+
+describe('Screen - color bleeding filter integration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('hides crt-color-bleed when filterEnabled is false (default)', () => {
+    const wrapper = mount(Screen, {
+      global: {
+        stubs: {
+          'v-stage': vStageStub,
+          'v-layer': vLayerStub,
+          'v-rect': vRectStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.screen-display').exists()).toEqual(true)
+    expect(wrapper.find('.crt-color-bleed').exists()).toEqual(false)
+    wrapper.unmount()
+  })
+
+  it('shows crt-color-bleed when filterEnabled is true', async () => {
+    localStorage.setItem('fbasic-screen-filter', 'true')
+
+    const wrapper = mount(Screen, {
+      global: {
+        stubs: {
+          'v-stage': vStageStub,
+          'v-layer': vLayerStub,
+          'v-rect': vRectStub,
+        },
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(wrapper.find('.crt-color-bleed').exists()).toEqual(true)
+    wrapper.unmount()
+  })
+})
+
 describe('Screen - scanline filter integration', () => {
   beforeEach(() => {
     localStorage.clear()


### PR DESCRIPTION
## Summary
- Fixes #613

## Changes
- Added `.crt-phosphor-glow` layer with bloom effect (CSS `box-shadow: inset` + `mix-blend-mode: screen`)
- Added `.crt-color-bleed` layer with NTSC color bleeding (CSS `filter: blur(0.3px)` + `mix-blend-mode: lighten`)
- Both effects gated by existing `filterEnabled` state from `useScreenFilter` composable
- Updated z-index layering: canvas(0) → color-bleed(1) → phosphor-glow(2) → scanlines(3) → reflection(4)
- 4 new tests in Screen.test.ts

## Test plan
- [ ] 6/6 Screen.test.ts tests pass
- [ ] CI passes