### PR TITLE
feat: resolve #606 - implement animation sync section in BufferInspector

### DIFF
--- a/src/features/ide/components/AnimationSyncSection.vue
+++ b/src/features/ide/components/AnimationSyncSection.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
+import type { SyncCommand } from '@/core/animation/sharedDisplayBufferAccessor'
+
+defineOptions({
+  name: 'AnimationSyncSection',
+})
+
+const props = defineProps<{
+  syncCommand: SyncCommand | null
+  ackStatus: number
+}>()
+
+const { t } = useI18n()
+
+const COMMAND_TYPE_NAMES: Record<SyncCommandType, string> = {
+  [SyncCommandType.NONE]: 'NONE',
+  [SyncCommandType.START_MOVEMENT]: 'START',
+  [SyncCommandType.STOP_MOVEMENT]: 'STOP',
+  [SyncCommandType.ERASE_MOVEMENT]: 'ERASE',
+  [SyncCommandType.SET_POSITION]: 'SET',
+  [SyncCommandType.CLEAR_ALL_MOVEMENTS]: 'CLEAR_ALL',
+}
+
+function commandTypeName(type: SyncCommandType): string {
+  return COMMAND_TYPE_NAMES[type]
+}
+
+interface SyncRow {
+  field: string
+  value: string
+}
+
+const rows = computed<SyncRow[]>(() => {
+  if (!props.syncCommand) return []
+  const cmd = props.syncCommand
+  return [
+    {
+      field: t('ide.bufferInspector.animationSyncFieldType'),
+      value: commandTypeName(cmd.commandType),
+    },
+    {
+      field: t('ide.bufferInspector.animationSyncFieldAction'),
+      value: String(cmd.actionNumber),
+    },
+    {
+      field: t('ide.bufferInspector.animationSyncFieldStartX'),
+      value: String(cmd.params.startX),
+    },
+    {
+      field: t('ide.bufferInspector.animationSyncFieldStartY'),
+      value: String(cmd.params.startY),
+    },
+    {
+      field: t('ide.bufferInspector.animationSyncFieldDirection'),
+      value: String(cmd.params.direction),
+    },
+    {
+      field: t('ide.bufferInspector.animationSyncFieldSpeed'),
+      value: String(cmd.params.speed),
+    },
+    {
+      field: t('ide.bufferInspector.animationSyncFieldDistance'),
+      value: String(cmd.params.distance),
+    },
+    {
+      field: t('ide.bufferInspector.animationSyncFieldPriority'),
+      value: String(cmd.params.priority),
+    },
+    {
+      field: t('ide.bufferInspector.animationSyncFieldAck'),
+      value: props.ackStatus === 0
+        ? t('ide.bufferInspector.animationSyncAckPending')
+        : t('ide.bufferInspector.animationSyncAckReceived'),
+    },
+  ]
+})
+</script>
+
+<template>
+  <div class="animation-sync-section">
+    <div class="animation-sync-title">{{ t('ide.bufferInspector.animationSyncTitle') }}</div>
+    <div v-if="!syncCommand" class="animation-sync-idle">
+      {{ t('ide.bufferInspector.animationSyncIdle') }}
+    </div>
+    <table v-else class="animation-sync-table">
+      <thead>
+        <tr>
+          <th class="sync-hdr">{{ t('ide.bufferInspector.animationSyncColField') }}</th>
+          <th class="sync-hdr">{{ t('ide.bufferInspector.animationSyncColValue') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(row, index) in rows" :key="index" class="sync-row">
+          <td class="sync-cell">{{ row.field }}</td>
+          <td class="sync-cell">{{ row.value }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<style scoped>
+.animation-sync-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.animation-sync-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--game-text-secondary);
+}
+
+.animation-sync-idle {
+  font-size: 0.75rem;
+  color: var(--game-text-tertiary);
+  font-style: italic;
+}
+
+.animation-sync-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.sync-hdr {
+  text-align: left;
+  padding: 0.15rem 0.35rem;
+  color: var(--game-text-secondary);
+  font-weight: 600;
+  border-bottom: 1px solid var(--game-surface-border);
+}
+
+.sync-cell {
+  padding: 0.1rem 0.35rem;
+  white-space: nowrap;
+}
+
+.sync-row:nth-child(odd) {
+  background: var(--game-surface-bg-start);
+}
+</style>

--- a/src/features/ide/components/BufferInspector.vue
+++ b/src/features/ide/components/BufferInspector.vue
@@ -1,27 +1,32 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import type { SpriteState } from '@/core/sprite/types'
 import { GameBlock } from '@/shared/components/ui'
 
+import AnimationSyncSection from './AnimationSyncSection.vue'
 import DisplayBufferSection from './DisplayBufferSection.vue'
 import JoystickBufferSection from './JoystickBufferSection.vue'
 import SpriteSlotsSection from './SpriteSlotsSection.vue'
-import type { ScreenBufferReader } from './types'
 
 defineOptions({
   name: 'BufferInspector',
 })
 
-defineProps<{
+const props = defineProps<{
   spriteStates: SpriteState[]
   spriteEnabled: boolean
-  sharedDisplayBufferAccessor: ScreenBufferReader
+  sharedDisplayBufferAccessor: SharedDisplayBufferAccessor
   sharedJoystickBuffer?: SharedArrayBuffer
   tick?: number
 }>()
 
 const { t } = useI18n()
+
+const syncCommand = computed(() => props.sharedDisplayBufferAccessor.readSyncCommand())
+const ackStatus = computed(() => props.sharedDisplayBufferAccessor.readAck())
 </script>
 
 <template>
@@ -38,6 +43,7 @@ const { t } = useI18n()
         :tick="tick"
       />
       <SpriteSlotsSection :sprite-states="spriteStates" :sprite-enabled="spriteEnabled" />
+      <AnimationSyncSection :sync-command="syncCommand" :ack-status="ackStatus" />
     </div>
   </GameBlock>
 </template>
@@ -64,6 +70,7 @@ const { t } = useI18n()
   min-height: 100px;
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
   overflow: hidden;
 }
 </style>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -423,7 +423,22 @@
     "joystick0": "Joy 0",
     "joystick1": "Joy 1",
     "joystickStick": "STICK",
-    "joystickStrig": "STRIG"
+    "joystickStrig": "STRIG",
+    "animationSyncTitle": "Animation Sync",
+    "animationSyncIdle": "(idle)",
+    "animationSyncAckPending": "Pending",
+    "animationSyncAckReceived": "Received",
+    "animationSyncColField": "Field",
+    "animationSyncColValue": "Value",
+    "animationSyncFieldType": "Command Type",
+    "animationSyncFieldAction": "Action #",
+    "animationSyncFieldStartX": "startX",
+    "animationSyncFieldStartY": "startY",
+    "animationSyncFieldDirection": "Direction",
+    "animationSyncFieldSpeed": "Speed",
+    "animationSyncFieldDistance": "Distance",
+    "animationSyncFieldPriority": "Priority",
+    "animationSyncFieldAck": "ACK"
   },
   "composer": {
     "title": "Controls",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -423,7 +423,22 @@
     "joystick0": "Joy 0",
     "joystick1": "Joy 1",
     "joystickStick": "STICK",
-    "joystickStrig": "STRIG"
+    "joystickStrig": "STRIG",
+    "animationSyncTitle": "アニメーション同期",
+    "animationSyncIdle": "(アイドル)",
+    "animationSyncAckPending": "保留中",
+    "animationSyncAckReceived": "受信済み",
+    "animationSyncColField": "フィールド",
+    "animationSyncColValue": "値",
+    "animationSyncFieldType": "コマンド種別",
+    "animationSyncFieldAction": "アクション #",
+    "animationSyncFieldStartX": "startX",
+    "animationSyncFieldStartY": "startY",
+    "animationSyncFieldDirection": "方向",
+    "animationSyncFieldSpeed": "速度",
+    "animationSyncFieldDistance": "距離",
+    "animationSyncFieldPriority": "優先度",
+    "animationSyncFieldAck": "ACK"
   },
   "composer": {
     "title": "コントロール",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -423,7 +423,22 @@
     "joystick0": "Joy 0",
     "joystick1": "Joy 1",
     "joystickStick": "STICK",
-    "joystickStrig": "STRIG"
+    "joystickStrig": "STRIG",
+    "animationSyncTitle": "动画同步",
+    "animationSyncIdle": "(空闲)",
+    "animationSyncAckPending": "等待中",
+    "animationSyncAckReceived": "已接收",
+    "animationSyncColField": "字段",
+    "animationSyncColValue": "值",
+    "animationSyncFieldType": "命令类型",
+    "animationSyncFieldAction": "动作 #",
+    "animationSyncFieldStartX": "startX",
+    "animationSyncFieldStartY": "startY",
+    "animationSyncFieldDirection": "方向",
+    "animationSyncFieldSpeed": "速度",
+    "animationSyncFieldDistance": "距离",
+    "animationSyncFieldPriority": "优先级",
+    "animationSyncFieldAck": "ACK"
   },
   "composer": {
     "title": "控制",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -423,7 +423,22 @@
     "joystick0": "Joy 0",
     "joystick1": "Joy 1",
     "joystickStick": "STICK",
-    "joystickStrig": "STRIG"
+    "joystickStrig": "STRIG",
+    "animationSyncTitle": "動畫同步",
+    "animationSyncIdle": "(閒置)",
+    "animationSyncAckPending": "等待中",
+    "animationSyncAckReceived": "已接收",
+    "animationSyncColField": "欄位",
+    "animationSyncColValue": "值",
+    "animationSyncFieldType": "命令類型",
+    "animationSyncFieldAction": "動作 #",
+    "animationSyncFieldStartX": "startX",
+    "animationSyncFieldStartY": "startY",
+    "animationSyncFieldDirection": "方向",
+    "animationSyncFieldSpeed": "速度",
+    "animationSyncFieldDistance": "距離",
+    "animationSyncFieldPriority": "優先順序",
+    "animationSyncFieldAck": "ACK"
   },
   "composer": {
     "title": "控制",

--- a/test/ide/AnimationSyncSection.test.ts
+++ b/test/ide/AnimationSyncSection.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
+import type { SyncCommand } from '@/core/animation/sharedDisplayBufferAccessor'
+import AnimationSyncSection from '@/features/ide/components/AnimationSyncSection.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+/** Factory for a SyncCommand with defaults */
+function makeSyncCommand(overrides: Partial<SyncCommand> = {}): SyncCommand {
+  return {
+    commandType: SyncCommandType.NONE,
+    actionNumber: 0,
+    params: {
+      startX: 0,
+      startY: 0,
+      direction: 0,
+      speed: 0,
+      distance: 0,
+      priority: 0,
+    },
+    ...overrides,
+  }
+}
+
+describe('AnimationSyncSection', () => {
+  it('has the correct component name', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: null,
+        ackStatus: 0,
+      },
+    })
+
+    expect(wrapper.vm.$options.name).toBe('AnimationSyncSection')
+    wrapper.unmount()
+  })
+
+  it('renders section title', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: null,
+        ackStatus: 0,
+      },
+    })
+
+    const title = wrapper.find('.animation-sync-title')
+    expect(title.exists()).toBe(true)
+    expect(title.text()).toBe('ide.bufferInspector.animationSyncTitle')
+    wrapper.unmount()
+  })
+
+  it('shows idle state when syncCommand is null', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: null,
+        ackStatus: 0,
+      },
+    })
+
+    expect(wrapper.find('.animation-sync-idle').exists()).toBe(true)
+    expect(wrapper.find('.animation-sync-idle').text()).toBe('ide.bufferInspector.animationSyncIdle')
+    expect(wrapper.find('.animation-sync-table').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders table when syncCommand is provided', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: makeSyncCommand({ commandType: SyncCommandType.START_MOVEMENT }),
+        ackStatus: 0,
+      },
+    })
+
+    expect(wrapper.find('.animation-sync-idle').exists()).toBe(false)
+    expect(wrapper.find('.animation-sync-table').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders table with correct headers', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: makeSyncCommand(),
+        ackStatus: 0,
+      },
+    })
+
+    const headers = wrapper.findAll('.sync-hdr')
+    expect(headers.length).toBe(2)
+    expect(headers[0]!.text()).toBe('ide.bufferInspector.animationSyncColField')
+    expect(headers[1]!.text()).toBe('ide.bufferInspector.animationSyncColValue')
+    wrapper.unmount()
+  })
+
+  it('shows command type as display name', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: makeSyncCommand({ commandType: SyncCommandType.START_MOVEMENT }),
+        ackStatus: 0,
+      },
+    })
+
+    const cells = wrapper.findAll('.sync-cell')
+    expect(cells[0]!.text()).toBe('ide.bufferInspector.animationSyncFieldType')
+    expect(cells[1]!.text()).toBe('START')
+    wrapper.unmount()
+  })
+
+  it('shows action number', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: makeSyncCommand({ actionNumber: 3 }),
+        ackStatus: 0,
+      },
+    })
+
+    const cells = wrapper.findAll('.sync-cell')
+    // Action row is the 2nd row: field at index 2, value at index 3
+    expect(cells[2]!.text()).toBe('ide.bufferInspector.animationSyncFieldAction')
+    expect(cells[3]!.text()).toBe('3')
+    wrapper.unmount()
+  })
+
+  it('shows all params correctly', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: makeSyncCommand({
+          params: {
+            startX: 10,
+            startY: 20,
+            direction: 3,
+            speed: 5,
+            distance: 100,
+            priority: 1,
+          },
+        }),
+        ackStatus: 0,
+      },
+    })
+
+    const cells = wrapper.findAll('.sync-cell')
+    // Row 0: type (indices 0,1)
+    // Row 1: action (indices 2,3)
+    // Row 2: startX (indices 4,5)
+    // Row 3: startY (indices 6,7)
+    // Row 4: direction (indices 8,9)
+    // Row 5: speed (indices 10,11)
+    // Row 6: distance (indices 12,13)
+    // Row 7: priority (indices 14,15)
+    expect(cells[4]!.text()).toBe('ide.bufferInspector.animationSyncFieldStartX')
+    expect(cells[5]!.text()).toBe('10')
+    expect(cells[6]!.text()).toBe('ide.bufferInspector.animationSyncFieldStartY')
+    expect(cells[7]!.text()).toBe('20')
+    expect(cells[8]!.text()).toBe('ide.bufferInspector.animationSyncFieldDirection')
+    expect(cells[9]!.text()).toBe('3')
+    expect(cells[10]!.text()).toBe('ide.bufferInspector.animationSyncFieldSpeed')
+    expect(cells[11]!.text()).toBe('5')
+    expect(cells[12]!.text()).toBe('ide.bufferInspector.animationSyncFieldDistance')
+    expect(cells[13]!.text()).toBe('100')
+    expect(cells[14]!.text()).toBe('ide.bufferInspector.animationSyncFieldPriority')
+    expect(cells[15]!.text()).toBe('1')
+    wrapper.unmount()
+  })
+
+  it('shows ACK status as Pending when ackStatus is 0', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: makeSyncCommand(),
+        ackStatus: 0,
+      },
+    })
+
+    const cells = wrapper.findAll('.sync-cell')
+    // ACK is the last row: field at 16, value at 17
+    expect(cells[16]!.text()).toBe('ide.bufferInspector.animationSyncFieldAck')
+    expect(cells[17]!.text()).toBe('ide.bufferInspector.animationSyncAckPending')
+    wrapper.unmount()
+  })
+
+  it('shows ACK status as Received when ackStatus is 1', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: makeSyncCommand(),
+        ackStatus: 1,
+      },
+    })
+
+    const cells = wrapper.findAll('.sync-cell')
+    expect(cells[16]!.text()).toBe('ide.bufferInspector.animationSyncFieldAck')
+    expect(cells[17]!.text()).toBe('ide.bufferInspector.animationSyncAckReceived')
+    wrapper.unmount()
+  })
+
+  it('maps all SyncCommandType values to display names', () => {
+    const cases: [SyncCommandType, string][] = [
+      [SyncCommandType.NONE, 'NONE'],
+      [SyncCommandType.START_MOVEMENT, 'START'],
+      [SyncCommandType.STOP_MOVEMENT, 'STOP'],
+      [SyncCommandType.ERASE_MOVEMENT, 'ERASE'],
+      [SyncCommandType.SET_POSITION, 'SET'],
+      [SyncCommandType.CLEAR_ALL_MOVEMENTS, 'CLEAR_ALL'],
+    ]
+
+    for (const [commandType, expectedName] of cases) {
+      const wrapper = mount(AnimationSyncSection, {
+        props: {
+          syncCommand: makeSyncCommand({ commandType }),
+          ackStatus: 0,
+        },
+      })
+
+      const cells = wrapper.findAll('.sync-cell')
+      expect(cells[0]!.text()).toBe('ide.bufferInspector.animationSyncFieldType')
+      expect(cells[1]!.text()).toBe(expectedName)
+      wrapper.unmount()
+    }
+  })
+
+  it('renders expected number of rows in the table', () => {
+    const wrapper = mount(AnimationSyncSection, {
+      props: {
+        syncCommand: makeSyncCommand(),
+        ackStatus: 0,
+      },
+    })
+
+    const rows = wrapper.findAll('.sync-row')
+    expect(rows.length).toBe(9) // command type + action number + 6 params + ACK
+    wrapper.unmount()
+  })
+})

--- a/test/ide/BufferInspector.test.ts
+++ b/test/ide/BufferInspector.test.ts
@@ -5,6 +5,8 @@ import { defineComponent } from 'vue'
 
 import { SHARED_DISPLAY_BUFFER_BYTES } from '@/core/animation/sharedDisplayBuffer'
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
+import { SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
+import type { SyncCommand } from '@/core/animation/sharedDisplayBufferAccessor'
 import BufferInspector from '@/features/ide/components/BufferInspector.vue'
 import type { ScreenBufferReader } from '@/features/ide/components/types'
 
@@ -24,13 +26,26 @@ const MOCK_ACCESSOR: ScreenBufferReader = {
 const testBuffer = new SharedArrayBuffer(SHARED_DISPLAY_BUFFER_BYTES)
 const MOCK_FULL_ACCESSOR = new SharedDisplayBufferAccessor(testBuffer)
 
+/** Mock accessor with readSyncCommand/readAck for testing */
+function createMockAccessor(overrides: Partial<SharedDisplayBufferAccessor> = {}): SharedDisplayBufferAccessor {
+  return {
+    readScreenChar: () => 0x20,
+    readScreenPattern: () => 0,
+    readSyncCommand: (): SyncCommand | null => null,
+    readAck: (): number => 0,
+    ...overrides,
+  } as SharedDisplayBufferAccessor
+}
+
 describe('BufferInspector', () => {
+  const mockAccessor = createMockAccessor()
+
   it('renders without errors', () => {
     const wrapper = mount(BufferInspector, {
       props: {
         spriteStates: [],
         spriteEnabled: false,
-        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedDisplayBufferAccessor: mockAccessor,
       },
       global: {
         stubs: {
@@ -48,7 +63,7 @@ describe('BufferInspector', () => {
       props: {
         spriteStates: [],
         spriteEnabled: false,
-        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedDisplayBufferAccessor: mockAccessor,
       },
       global: {
         stubs: {
@@ -66,7 +81,7 @@ describe('BufferInspector', () => {
       props: {
         spriteStates: [],
         spriteEnabled: false,
-        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedDisplayBufferAccessor: mockAccessor,
       },
       global: {
         stubs: {
@@ -84,12 +99,12 @@ describe('BufferInspector', () => {
     wrapper.unmount()
   })
 
-  it('renders content area with DisplayBufferSection, JoystickBufferSection and SpriteSlotsSection', () => {
+  it('renders content area with DisplayBufferSection, JoystickBufferSection, SpriteSlotsSection and AnimationSyncSection', () => {
     const wrapper = mount(BufferInspector, {
       props: {
         spriteStates: [],
         spriteEnabled: false,
-        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedDisplayBufferAccessor: mockAccessor,
       },
       global: {
         stubs: {
@@ -102,6 +117,7 @@ describe('BufferInspector', () => {
     expect(wrapper.find('.display-buffer-section').exists()).toBe(true)
     expect(wrapper.find('.joystick-buffer-section').exists()).toBe(true)
     expect(wrapper.find('.sprite-slots-section').exists()).toBe(true)
+    expect(wrapper.find('.animation-sync-section').exists()).toBe(true)
     wrapper.unmount()
   })
 
@@ -110,7 +126,7 @@ describe('BufferInspector', () => {
       props: {
         spriteStates: [],
         spriteEnabled: false,
-        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedDisplayBufferAccessor: mockAccessor,
       },
       global: {
         stubs: {
@@ -121,7 +137,7 @@ describe('BufferInspector', () => {
 
     const section = wrapper.findComponent({ name: 'DisplayBufferSection' })
     expect(section.exists()).toBe(true)
-    expect(section.props('sharedDisplayBufferAccessor')).toEqual(MOCK_ACCESSOR)
+    expect(section.props('sharedDisplayBufferAccessor')).toEqual(mockAccessor)
     wrapper.unmount()
   })
 
@@ -131,7 +147,7 @@ describe('BufferInspector', () => {
       props: {
         spriteStates: [],
         spriteEnabled: false,
-        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedDisplayBufferAccessor: mockAccessor,
         sharedJoystickBuffer: buffer,
       },
       global: {
@@ -154,7 +170,7 @@ describe('BufferInspector', () => {
           { spriteNumber: 0, x: 10, y: 20, visible: true, priority: 0, definition: null },
         ],
         spriteEnabled: true,
-        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedDisplayBufferAccessor: mockAccessor,
       },
       global: {
         stubs: {
@@ -169,6 +185,37 @@ describe('BufferInspector', () => {
       { spriteNumber: 0, x: 10, y: 20, visible: true, priority: 0, definition: null },
     ])
     expect(section.props('spriteEnabled')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('passes sync command and ack status to AnimationSyncSection', () => {
+    const syncCommand: SyncCommand = {
+      commandType: SyncCommandType.START_MOVEMENT,
+      actionNumber: 2,
+      params: { startX: 10, startY: 20, direction: 1, speed: 3, distance: 50, priority: 0 },
+    }
+    const accessor = createMockAccessor({
+      readSyncCommand: () => syncCommand,
+      readAck: () => 1,
+    })
+
+    const wrapper = mount(BufferInspector, {
+      props: {
+        spriteStates: [],
+        spriteEnabled: false,
+        sharedDisplayBufferAccessor: accessor,
+      },
+      global: {
+        stubs: {
+          GameBlock: defineComponent({ template: '<div><slot /></div>' }),
+        },
+      },
+    })
+
+    const section = wrapper.findComponent({ name: 'AnimationSyncSection' })
+    expect(section.exists()).toBe(true)
+    expect(section.props('syncCommand')).toEqual(syncCommand)
+    expect(section.props('ackStatus')).toBe(1)
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #606 — implements animation sync section in BufferInspector showing command type, action number, params, and ACK status from the display buffer

## Changes
- New `AnimationSyncSection.vue` component (148 lines) with props for `SyncCommand` data and ACK status
- Updated `BufferInspector.vue` to accept `sharedDisplayBufferAccessor` prop and wire sync data
- Updated `IdeBottomArea.vue` to pass accessor to BufferInspector
- Added 15 i18n keys across all 4 locales (en, ja, zh-CN, zh-TW)
- 12 new unit tests for AnimationSyncSection, 2 new integration tests for BufferInspector sync

## Test plan
- [x] 20/20 tests pass (12 AnimationSyncSection + 8 BufferInspector)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes