### PR TITLE
feat: resolve #614 - add screen curvature and vignette CSS effects

### DIFF
--- a/src/features/ide/components/Screen.vue
+++ b/src/features/ide/components/Screen.vue
@@ -383,21 +383,16 @@ watch(
 // Backdrop is managed by vue-konva template via backdropColorHex computed property
 
 // Initialize Animation Worker (single writer to shared buffer)
-const animationWorkerResult = useAnimationWorker({
-  sharedAnimationBuffer: computed(() => ctx.sharedAnimationBuffer.value ?? null),
-  onReady: () => {
-    logScreen.debug('[Screen] Animation Worker ready')
-    // Animation Worker is now ready - it polls the shared buffer for commands
-  },
-  onError: (error) => {
-    logScreen.error('[Screen] Animation Worker error:', error)
-  },
-})
-
-const {
-  initialize: initializeAnimationWorker,
-  terminate: terminateAnimationWorker,
-} = animationWorkerResult
+const { initialize: initializeAnimationWorker, terminate: terminateAnimationWorker } =
+  useAnimationWorker({
+    sharedAnimationBuffer: computed(() => ctx.sharedAnimationBuffer.value ?? null),
+    onReady: () => {
+      logScreen.debug('[Screen] Animation Worker ready')
+    },
+    onError: (error) => {
+      logScreen.error('[Screen] Animation Worker error:', error)
+    },
+  })
 
 // Initial render when stage becomes available
 watch(
@@ -448,10 +443,11 @@ onDeactivated(cleanupScreen)
 <template>
   <div class="screen-display">
     <div class="crt-bezel">
-      <div class="crt-screen">
+      <div :class="['crt-screen', { 'crt-filter-active': filterEnabled }]">
         <div v-if="filterEnabled" class="crt-phosphor-glow"></div>
         <div v-if="filterEnabled" class="crt-color-bleed"></div>
         <div v-if="filterEnabled" class="crt-scanlines"></div>
+        <div v-if="filterEnabled" class="crt-vignette"></div>
         <div
           class="screen-stage-wrapper"
           data-testid="ide-screen-stage"

--- a/src/shared/styles/screen-crt.css
+++ b/src/shared/styles/screen-crt.css
@@ -130,3 +130,23 @@
     image-rendering: crisp-edges;
     filter: brightness(1.05) contrast(1.1);
 }
+
+/* Curvature effect — rounded screen edges when CRT filter is active */
+.screen-display .crt-screen.crt-filter-active {
+    border-radius: 24px;
+}
+
+/* Vignette overlay — darkened corners simulating CRT tube edge falloff */
+.screen-display .crt-vignette {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 3;
+    border-radius: 24px;
+    background: radial-gradient(
+        ellipse 100% 100% at 50% 50%,
+        transparent 60%,
+        var(--crt-shadow-dark-30) 80%,
+        var(--crt-shadow-dark-60) 100%
+    );
+}

--- a/test/ide/Screen.test.ts
+++ b/test/ide/Screen.test.ts
@@ -216,4 +216,39 @@ describe('Screen - scanline filter integration', () => {
     expect(wrapper.find('.crt-scanlines').exists()).toEqual(true)
     wrapper.unmount()
   })
+
+  it('hides crt-vignette when filterEnabled is false (default)', () => {
+    const wrapper = mount(Screen, {
+      global: {
+        stubs: {
+          'v-stage': vStageStub,
+          'v-layer': vLayerStub,
+          'v-rect': vRectStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.screen-display').exists()).toEqual(true)
+    expect(wrapper.find('.crt-vignette').exists()).toEqual(false)
+    wrapper.unmount()
+  })
+
+  it('shows crt-vignette when filterEnabled is true', async () => {
+    localStorage.setItem('fbasic-screen-filter', 'true')
+
+    const wrapper = mount(Screen, {
+      global: {
+        stubs: {
+          'v-stage': vStageStub,
+          'v-layer': vLayerStub,
+          'v-rect': vRectStub,
+        },
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(wrapper.find('.crt-vignette').exists()).toEqual(true)
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes #614 — Step 4 of 5 for #534 (CRT filter effects)

## Changes
- Add CRT vignette overlay (`crt-vignette`) with radial-gradient darkened corners, gated by `filterEnabled`
- Add barrel distortion curvature via `border-radius: 24px` on `.crt-screen.crt-filter-active`
- Inline `useAnimationWorker` destructuring (remove unnecessary intermediate variable)
- Z-index layering: canvas(0) → reflection(1) → scanlines(2) → vignette(3)

## Test plan
- [ ] Targeted tests pass (2 new: vignette hidden by default, shown when enabled)
- [ ] CI passes