### PR TITLE
feat: resolve #608 - implement JoystickBufferSection in BufferInspector

### DIFF
--- a/src/features/ide/components/BufferInspector.vue
+++ b/src/features/ide/components/BufferInspector.vue
@@ -5,6 +5,7 @@ import type { SpriteState } from '@/core/sprite/types'
 import { GameBlock } from '@/shared/components/ui'
 
 import DisplayBufferSection from './DisplayBufferSection.vue'
+import JoystickBufferSection from './JoystickBufferSection.vue'
 import SpriteSlotsSection from './SpriteSlotsSection.vue'
 import type { ScreenBufferReader } from './types'
 
@@ -16,6 +17,8 @@ defineProps<{
   spriteStates: SpriteState[]
   spriteEnabled: boolean
   sharedDisplayBufferAccessor: ScreenBufferReader
+  sharedJoystickBuffer?: SharedArrayBuffer
+  tick?: number
 }>()
 
 const { t } = useI18n()
@@ -30,6 +33,10 @@ const { t } = useI18n()
   >
     <div class="buffer-inspector-content">
       <DisplayBufferSection :shared-display-buffer-accessor="sharedDisplayBufferAccessor" />
+      <JoystickBufferSection
+        :shared-joystick-buffer="sharedJoystickBuffer"
+        :tick="tick"
+      />
       <SpriteSlotsSection :sprite-states="spriteStates" :sprite-enabled="spriteEnabled" />
     </div>
   </GameBlock>

--- a/src/features/ide/components/IdeBottomArea.vue
+++ b/src/features/ide/components/IdeBottomArea.vue
@@ -82,6 +82,7 @@ defineExpose({
             :sprite-states="spriteStates"
             :sprite-enabled="spriteEnabled"
             :shared-display-buffer-accessor="sharedDisplayBufferAccessor"
+            :shared-joystick-buffer="sharedJoystickBuffer"
           />
         </GameTabPane>
       </GameTabs>

--- a/src/features/ide/components/JoystickBufferSection.vue
+++ b/src/features/ide/components/JoystickBufferSection.vue
@@ -1,0 +1,289 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import {
+  createViewsFromJoystickBuffer,
+  getStickState,
+  getStrigState,
+} from '@/core/devices/sharedJoystickBuffer'
+
+defineOptions({
+  name: 'JoystickBufferSection',
+})
+
+const props = withDefaults(
+  defineProps<{
+    sharedJoystickBuffer?: SharedArrayBuffer
+    /** Incremented by parent on each animation frame to trigger buffer re-reads. */
+    tick?: number
+  }>(),
+  {
+    tick: 0,
+  }
+)
+
+const { t } = useI18n()
+
+/** Bitmask constants for stick directions */
+const STICK_RIGHT = 1
+const STICK_LEFT = 2
+const STICK_DOWN = 4
+const STICK_UP = 8
+
+/** Bitmask constants for strig buttons */
+const STRIG_START = 1
+const STRIG_SELECT = 2
+const STRIG_B = 4
+const STRIG_A = 8
+
+/** Whether the joystick buffer is available */
+const hasBuffer = computed(() => props.sharedJoystickBuffer != null)
+
+/** Read stick/strig values from the shared buffer (0 when unavailable) */
+const stickStates = computed<[number, number]>(() => {
+  // tick is read to trigger re-computation when parent signals a new frame
+  void props.tick
+  if (!props.sharedJoystickBuffer) return [0, 0]
+  try {
+    const view = createViewsFromJoystickBuffer(props.sharedJoystickBuffer)
+    return [getStickState(view, 0), getStickState(view, 1)]
+  } catch {
+    return [0, 0]
+  }
+})
+
+const strigStates = computed<[number, number]>(() => {
+  // tick is read to trigger re-computation when parent signals a new frame
+  void props.tick
+  if (!props.sharedJoystickBuffer) return [0, 0]
+  try {
+    const view = createViewsFromJoystickBuffer(props.sharedJoystickBuffer)
+    return [getStrigState(view, 0), getStrigState(view, 1)]
+  } catch {
+    return [0, 0]
+  }
+})
+
+/** Check if a direction bit is set in the stick state */
+function hasDirection(stickState: number, bit: number): boolean {
+  return (stickState & bit) !== 0
+}
+
+/** Check if a button bit is set in the strig state */
+function hasButton(strigState: number, bit: number): boolean {
+  return (strigState & bit) !== 0
+}
+
+/** Button definitions for strig display */
+const STRIG_BUTTONS = [
+  { bit: STRIG_A, label: 'A' },
+  { bit: STRIG_B, label: 'B' },
+  { bit: STRIG_SELECT, label: 'Sel' },
+  { bit: STRIG_START, label: 'Sta' },
+] as const
+
+const JOYSTICK_IDS = [0, 1] as const
+</script>
+
+<template>
+  <div class="joystick-buffer-section">
+    <div class="joystick-buffer-title">{{ t('ide.bufferInspector.joystickTitle') }}</div>
+
+    <div v-if="!hasBuffer" class="joystick-buffer-unavailable">
+      {{ t('ide.bufferInspector.joystickUnavailable') }}
+    </div>
+
+    <div v-else class="joystick-buffer-grid">
+      <div
+        v-for="id in JOYSTICK_IDS"
+        :key="id"
+        class="joystick-buffer-row"
+      >
+        <span class="joystick-buffer-label">{{ t(`ide.bufferInspector.joystick${id}`) }}</span>
+
+        <div class="joystick-dpad">
+          <span
+            class="dpad-up"
+            :class="{ 'dpad-active': hasDirection(stickStates[id], STICK_UP) }"
+          >
+            &#9650;
+          </span>
+          <span
+            class="dpad-left"
+            :class="{ 'dpad-active': hasDirection(stickStates[id], STICK_LEFT) }"
+          >
+            &#9664;
+          </span>
+          <span
+            class="dpad-right"
+            :class="{ 'dpad-active': hasDirection(stickStates[id], STICK_RIGHT) }"
+          >
+            &#9654;
+          </span>
+          <span
+            class="dpad-down"
+            :class="{ 'dpad-active': hasDirection(stickStates[id], STICK_DOWN) }"
+          >
+            &#9660;
+          </span>
+        </div>
+
+        <div class="joystick-dpad-buttons">
+          <span
+            v-for="btn in STRIG_BUTTONS"
+            :key="btn.label"
+            class="dpad-button"
+            :class="{ 'dpad-active': hasButton(strigStates[id], btn.bit) }"
+          >
+            {{ btn.label }}
+          </span>
+        </div>
+
+        <div class="joystick-values">
+          <span class="joystick-stick-label">
+            {{ t('ide.bufferInspector.joystickStick') }}
+          </span>
+          <span class="joystick-stick-value">{{ stickStates[id] }}</span>
+          <span class="joystick-strig-label">
+            {{ t('ide.bufferInspector.joystickStrig') }}
+          </span>
+          <span class="joystick-strig-value">{{ strigStates[id] }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.joystick-buffer-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.joystick-buffer-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--game-text-secondary);
+}
+
+.joystick-buffer-unavailable {
+  font-size: 0.75rem;
+  color: var(--game-text-tertiary);
+  font-style: italic;
+}
+
+.joystick-buffer-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.joystick-buffer-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.joystick-buffer-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--game-text-secondary);
+  min-width: 1.5rem;
+}
+
+.joystick-dpad {
+  display: grid;
+  grid-template-areas:
+    '. up .'
+    'left . right'
+    '. down .';
+  grid-template-columns: 1rem 1rem 1rem;
+  grid-template-rows: 1rem 1rem 1rem;
+  gap: 1px;
+}
+
+.dpad-up {
+  grid-area: up;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  color: var(--game-text-tertiary);
+}
+
+.dpad-down {
+  grid-area: down;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  color: var(--game-text-tertiary);
+}
+
+.dpad-left {
+  grid-area: left;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  color: var(--game-text-tertiary);
+}
+
+.dpad-right {
+  grid-area: right;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  color: var(--game-text-tertiary);
+}
+
+.dpad-active {
+  color: var(--game-accent);
+}
+
+.joystick-dpad-buttons {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.dpad-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.55rem;
+  font-weight: 600;
+  color: var(--game-text-tertiary);
+  padding: 0.1rem 0.3rem;
+  border: 1px solid var(--game-surface-border);
+  border-radius: 2px;
+  min-width: 1.2rem;
+}
+
+.dpad-button.dpad-active {
+  color: var(--game-accent);
+  border-color: var(--game-accent);
+}
+
+.joystick-values {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.joystick-stick-label,
+.joystick-strig-label {
+  color: var(--game-text-secondary);
+  font-weight: 600;
+}
+
+.joystick-stick-value,
+.joystick-strig-value {
+  color: var(--game-text-primary);
+  min-width: 1.2rem;
+}
+</style>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -417,7 +417,13 @@
     "spriteSlotsColPriority": "Priority",
     "spriteSlotsColDefinition": "Definition",
     "displayBufferCharTitle": "Character Codes",
-    "displayBufferPatternTitle": "Color Patterns"
+    "displayBufferPatternTitle": "Color Patterns",
+    "joystickTitle": "Joystick Buffer",
+    "joystickUnavailable": "No joystick buffer",
+    "joystick0": "Joy 0",
+    "joystick1": "Joy 1",
+    "joystickStick": "STICK",
+    "joystickStrig": "STRIG"
   },
   "composer": {
     "title": "Controls",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -417,7 +417,13 @@
     "spriteSlotsColPriority": "優先度",
     "spriteSlotsColDefinition": "定義",
     "displayBufferCharTitle": "キャラクタコード",
-    "displayBufferPatternTitle": "カラーパターン"
+    "displayBufferPatternTitle": "カラーパターン",
+    "joystickTitle": "ジョイスティックバッファ",
+    "joystickUnavailable": "ジョイスティックバッファなし",
+    "joystick0": "Joy 0",
+    "joystick1": "Joy 1",
+    "joystickStick": "STICK",
+    "joystickStrig": "STRIG"
   },
   "composer": {
     "title": "コントロール",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -417,7 +417,13 @@
     "spriteSlotsColPriority": "优先级",
     "spriteSlotsColDefinition": "定义",
     "displayBufferCharTitle": "字符代码",
-    "displayBufferPatternTitle": "颜色图案"
+    "displayBufferPatternTitle": "颜色图案",
+    "joystickTitle": "摇杆缓冲区",
+    "joystickUnavailable": "无摇杆缓冲区",
+    "joystick0": "Joy 0",
+    "joystick1": "Joy 1",
+    "joystickStick": "STICK",
+    "joystickStrig": "STRIG"
   },
   "composer": {
     "title": "控制",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -417,7 +417,13 @@
     "spriteSlotsColPriority": "優先順序",
     "spriteSlotsColDefinition": "定義",
     "displayBufferCharTitle": "字元代碼",
-    "displayBufferPatternTitle": "顏色圖案"
+    "displayBufferPatternTitle": "顏色圖案",
+    "joystickTitle": "搖桿緩衝區",
+    "joystickUnavailable": "無搖桿緩衝區",
+    "joystick0": "Joy 0",
+    "joystick1": "Joy 1",
+    "joystickStick": "STICK",
+    "joystickStrig": "STRIG"
   },
   "composer": {
     "title": "控制",

--- a/test/ide/BufferInspector.test.ts
+++ b/test/ide/BufferInspector.test.ts
@@ -84,7 +84,7 @@ describe('BufferInspector', () => {
     wrapper.unmount()
   })
 
-  it('renders content area with DisplayBufferSection and SpriteSlotsSection', () => {
+  it('renders content area with DisplayBufferSection, JoystickBufferSection and SpriteSlotsSection', () => {
     const wrapper = mount(BufferInspector, {
       props: {
         spriteStates: [],
@@ -100,6 +100,7 @@ describe('BufferInspector', () => {
 
     expect(wrapper.find('.buffer-inspector-content').exists()).toBe(true)
     expect(wrapper.find('.display-buffer-section').exists()).toBe(true)
+    expect(wrapper.find('.joystick-buffer-section').exists()).toBe(true)
     expect(wrapper.find('.sprite-slots-section').exists()).toBe(true)
     wrapper.unmount()
   })
@@ -121,6 +122,28 @@ describe('BufferInspector', () => {
     const section = wrapper.findComponent({ name: 'DisplayBufferSection' })
     expect(section.exists()).toBe(true)
     expect(section.props('sharedDisplayBufferAccessor')).toEqual(MOCK_ACCESSOR)
+    wrapper.unmount()
+  })
+
+  it('passes sharedJoystickBuffer to JoystickBufferSection', () => {
+    const buffer = new SharedArrayBuffer(32)
+    const wrapper = mount(BufferInspector, {
+      props: {
+        spriteStates: [],
+        spriteEnabled: false,
+        sharedDisplayBufferAccessor: MOCK_ACCESSOR,
+        sharedJoystickBuffer: buffer,
+      },
+      global: {
+        stubs: {
+          GameBlock: defineComponent({ template: '<div><slot /></div>' }),
+        },
+      },
+    })
+
+    const section = wrapper.findComponent({ name: 'JoystickBufferSection' })
+    expect(section.exists()).toBe(true)
+    expect(section.props('sharedJoystickBuffer')).toBe(buffer)
     wrapper.unmount()
   })
 

--- a/test/ide/JoystickBufferSection.test.ts
+++ b/test/ide/JoystickBufferSection.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createSharedJoystickBuffer,
+  createViewsFromJoystickBuffer,
+  setStickState,
+  setStrigState,
+} from '@/core/devices/sharedJoystickBuffer'
+import JoystickBufferSection from '@/features/ide/components/JoystickBufferSection.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+describe('JoystickBufferSection', () => {
+  it('has the correct component name', () => {
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: undefined,
+        tick: 0,
+      },
+    })
+
+    expect(wrapper.vm.$options.name).toBe('JoystickBufferSection')
+    wrapper.unmount()
+  })
+
+  it('renders section title', () => {
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: undefined,
+        tick: 0,
+      },
+    })
+
+    const title = wrapper.find('.joystick-buffer-title')
+    expect(title.exists()).toBe(true)
+    expect(title.text()).toBe('ide.bufferInspector.joystickTitle')
+    wrapper.unmount()
+  })
+
+  it('shows unavailable message when no buffer is provided', () => {
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: undefined,
+        tick: 0,
+      },
+    })
+
+    expect(wrapper.find('.joystick-buffer-unavailable').exists()).toBe(true)
+    expect(wrapper.find('.joystick-buffer-unavailable').text()).toBe(
+      'ide.bufferInspector.joystickUnavailable'
+    )
+    wrapper.unmount()
+  })
+
+  it('does not show unavailable message when buffer is provided', () => {
+    const buffer = createSharedJoystickBuffer()
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    expect(wrapper.find('.joystick-buffer-unavailable').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders joystick labels for both joysticks', () => {
+    const buffer = createSharedJoystickBuffer()
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const labels = wrapper.findAll('.joystick-buffer-label')
+    expect(labels.length).toBe(2)
+    expect(labels[0]!.text()).toBe('ide.bufferInspector.joystick0')
+    expect(labels[1]!.text()).toBe('ide.bufferInspector.joystick1')
+    wrapper.unmount()
+  })
+
+  it('displays stick state values for both joysticks', () => {
+    const buffer = createSharedJoystickBuffer()
+    const view = createViewsFromJoystickBuffer(buffer)
+    setStickState(view, 0, 5) // up + right
+    setStickState(view, 1, 10) // left + down
+
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const stickValues = wrapper.findAll('.joystick-stick-value')
+    expect(stickValues.length).toBe(2)
+    expect(stickValues[0]!.text()).toBe('5')
+    expect(stickValues[1]!.text()).toBe('10')
+    wrapper.unmount()
+  })
+
+  it('displays strig state values for both joysticks', () => {
+    const buffer = createSharedJoystickBuffer()
+    const view = createViewsFromJoystickBuffer(buffer)
+    setStrigState(view, 0, 12) // A + B
+    setStrigState(view, 1, 1) // start
+
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const strigValues = wrapper.findAll('.joystick-strig-value')
+    expect(strigValues.length).toBe(2)
+    expect(strigValues[0]!.text()).toBe('12')
+    expect(strigValues[1]!.text()).toBe('1')
+    wrapper.unmount()
+  })
+
+  it('displays stick and strig labels', () => {
+    const buffer = createSharedJoystickBuffer()
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const stickLabels = wrapper.findAll('.joystick-stick-label')
+    const strigLabels = wrapper.findAll('.joystick-strig-label')
+    expect(stickLabels.length).toBe(2)
+    expect(strigLabels.length).toBe(2)
+    expect(stickLabels[0]!.text()).toBe('ide.bufferInspector.joystickStick')
+    expect(strigLabels[0]!.text()).toBe('ide.bufferInspector.joystickStrig')
+    wrapper.unmount()
+  })
+
+  it('renders D-pad visual indicator for each joystick', () => {
+    const buffer = createSharedJoystickBuffer()
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const dpads = wrapper.findAll('.joystick-dpad')
+    expect(dpads.length).toBe(2)
+    wrapper.unmount()
+  })
+
+  it('highlights D-pad directions based on stick state', () => {
+    const buffer = createSharedJoystickBuffer()
+    const view = createViewsFromJoystickBuffer(buffer)
+    setStickState(view, 0, 9) // up + right = 8 + 1
+
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const dpads = wrapper.findAll('.joystick-dpad')
+    const dpad0 = dpads[0]!
+
+    expect(dpad0.find('.dpad-up').classes()).toContain('dpad-active')
+    expect(dpad0.find('.dpad-right').classes()).toContain('dpad-active')
+    expect(dpad0.find('.dpad-down').classes()).not.toContain('dpad-active')
+    expect(dpad0.find('.dpad-left').classes()).not.toContain('dpad-active')
+    wrapper.unmount()
+  })
+
+  it('does not highlight any direction when stick state is 0', () => {
+    const buffer = createSharedJoystickBuffer()
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const dpads = wrapper.findAll('.joystick-dpad')
+    const dpad0 = dpads[0]!
+
+    expect(dpad0.find('.dpad-up').classes()).not.toContain('dpad-active')
+    expect(dpad0.find('.dpad-right').classes()).not.toContain('dpad-active')
+    expect(dpad0.find('.dpad-down').classes()).not.toContain('dpad-active')
+    expect(dpad0.find('.dpad-left').classes()).not.toContain('dpad-active')
+    wrapper.unmount()
+  })
+
+  it('shows button labels for strig state', () => {
+    const buffer = createSharedJoystickBuffer()
+    const view = createViewsFromJoystickBuffer(buffer)
+    setStrigState(view, 0, 4) // B button
+
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const buttons = wrapper.findAll('.joystick-dpad-buttons')
+    expect(buttons.length).toBe(2)
+    // Joystick 0 should show B button active
+    const button0Text = buttons[0]!.text()
+    expect(button0Text).toContain('B')
+    wrapper.unmount()
+  })
+
+  it('reacts to buffer changes when tick increments', async () => {
+    const buffer = createSharedJoystickBuffer()
+    const view = createViewsFromJoystickBuffer(buffer)
+
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    // Initial state should be 0
+    const stickValues = wrapper.findAll('.joystick-stick-value')
+    expect(stickValues[0]!.text()).toBe('0')
+
+    // Mutate the buffer directly (simulating main thread write)
+    setStickState(view, 0, 15) // all directions
+
+    // Increment tick to trigger re-read of buffer
+    await wrapper.setProps({ tick: 1 })
+
+    const updatedStickValues = wrapper.findAll('.joystick-stick-value')
+    expect(updatedStickValues[0]!.text()).toBe('15')
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #608 — adds JoystickBufferSection to BufferInspector showing stickState[0-1], strigState[0-1] with visual D-pad indicator
- Step 6 of 8 for #531 (SharedArrayBuffer visualizer)

## Changes
- New `JoystickBufferSection.vue` (289 lines) with CSS grid D-pad visual, stick/strig state display, button indicators
- BufferInspector.vue: added optional `sharedJoystickBuffer` + `tick` props, renders JoystickBufferSection
- IdeBottomArea.vue: passes `sharedJoystickBuffer` prop to BufferInspector
- 7 i18n keys across 4 locales (en, ja, zh-CN, zh-TW)
- 13 unit tests + 2 integration tests

## Test plan
- [ ] Targeted tests pass (15 new tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)