### PR TITLE
feat: resolve #615 - add CRT filter toggle button and i18n keys

### DIFF
--- a/src/features/ide/components/ScreenTab.vue
+++ b/src/features/ide/components/ScreenTab.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { provideScreenDebug } from '@/features/ide/composables/useScreenDebug'
+import { useScreenFilter } from '@/features/ide/composables/useScreenFilter'
 import { provideScreenZoom } from '@/features/ide/composables/useScreenZoom'
 import { GameButton, GameButtonGroup, GameIcon, GameTabPane } from '@/shared/components/ui'
 
@@ -32,6 +33,10 @@ const { zoomLevel, setZoom } = provideScreenZoom()
 // Provide debug settings for child components
 const { showGrid, toggleGrid } = provideScreenDebug()
 
+// Screen filter state (shared singleton via module-level ref)
+const { filterEnabled, prefersReducedMotion, toggleFilter } =
+  useScreenFilter()
+
 // Zoom level options
 const zoomLevels: Array<{ value: 1 | 2 | 3 | 4; label: string }> = [
   { value: 1, label: '×1' },
@@ -43,6 +48,8 @@ const zoomLevels: Array<{ value: 1 | 2 | 3 | 4; label: string }> = [
 // Computed property for template binding (Vue templates auto-unwrap refs, but this helps TypeScript)
 const currentZoomLevel = computed(() => zoomLevel.value)
 const isGridShown = computed(() => showGrid.value)
+const isFilterEnabled = computed(() => filterEnabled.value)
+const isReducedMotion = computed(() => prefersReducedMotion.value)
 </script>
 
 <template>
@@ -74,6 +81,17 @@ const isGridShown = computed(() => showGrid.value)
         >
           <GameIcon icon="mdi:grid" size="small" />
           {{ t('ide.screenTab.grid') }}
+        </GameButton>
+        <GameButton
+          data-testid="ide-filter-toggle"
+          variant="toggle"
+          size="small"
+          :selected="isFilterEnabled"
+          :disabled="isReducedMotion"
+          @click="toggleFilter"
+        >
+          <GameIcon icon="mdi:monitor-shimmer" size="small" />
+          {{ t('ide.screenTab.filter') }}
         </GameButton>
       </div>
     </template>

--- a/src/features/ide/composables/useScreenFilter.ts
+++ b/src/features/ide/composables/useScreenFilter.ts
@@ -9,7 +9,7 @@
  * curvature, vignette layers).
  */
 
-import { useLocalStorage } from '@vueuse/core'
+import { useLocalStorage, usePreferredReducedMotion } from '@vueuse/core'
 import { computed } from 'vue'
 
 const FILTER_STORAGE_KEY = 'fbasic-screen-filter'
@@ -31,6 +31,11 @@ export function useScreenFilter() {
 
   const filterEnabled = computed(() => isEnabled.value)
 
+  const reducedMotionRaw = usePreferredReducedMotion()
+  const prefersReducedMotion = computed(
+    () => reducedMotionRaw.value === 'reduce'
+  )
+
   function toggleFilter(): void {
     isEnabled.value = !isEnabled.value
   }
@@ -41,6 +46,7 @@ export function useScreenFilter() {
 
   return {
     filterEnabled,
+    prefersReducedMotion,
     toggleFilter,
     setFilterEnabled,
   }

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -472,7 +472,8 @@
     }
   },
   "screenTab": {
-    "grid": "Grid"
+    "grid": "Grid",
+    "filter": "CRT"
   },
   "errors": {
     "executionTimeout": "Execution timed out after 5 minutes. Your program may contain an infinite loop."

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -472,7 +472,8 @@
     }
   },
   "screenTab": {
-    "grid": "グリッド"
+    "grid": "グリッド",
+    "filter": "CRT"
   },
   "errors": {
     "executionTimeout": "実行が5分でタイムアウトしました。プログラムに無限ループが含まれている可能性があります。"

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -472,7 +472,8 @@
     }
   },
   "screenTab": {
-    "grid": "网格"
+    "grid": "网格",
+    "filter": "CRT"
   },
   "errors": {
     "executionTimeout": "执行在5分钟后超时。您的程序可能包含无限循环。"

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -472,7 +472,8 @@
     }
   },
   "screenTab": {
-    "grid": "網格"
+    "grid": "網格",
+    "filter": "CRT"
   },
   "errors": {
     "executionTimeout": "執行在5分鐘後逾時。您的程式可能包含無限迴圈。"

--- a/test/features/ide/components/ScreenTab.test.ts
+++ b/test/features/ide/components/ScreenTab.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, ref } from 'vue'
+import { defineComponent } from 'vue'
+
+import ScreenTab from '@/features/ide/components/ScreenTab.vue'
+
+// Stub vue-i18n
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+// Mock useScreenFilter with controllable state
+const mockFilterEnabled = ref(false)
+const mockPrefersReducedMotion = ref(false)
+const mockToggleFilter = vi.fn(() => {
+  mockFilterEnabled.value = !mockFilterEnabled.value
+})
+const mockSetFilterEnabled = vi.fn()
+
+vi.mock('@/features/ide/composables/useScreenFilter', () => ({
+  useScreenFilter: () => ({
+    filterEnabled: computed(() => mockFilterEnabled.value),
+    prefersReducedMotion: computed(
+      () => mockPrefersReducedMotion.value
+    ),
+    toggleFilter: mockToggleFilter,
+    setFilterEnabled: mockSetFilterEnabled,
+  }),
+}))
+
+// Stub GameButton to capture click events and attributes
+const gameButtonStub = defineComponent({
+  props: ['variant', 'size', 'selected', 'disabled'],
+  template:
+    '<button :data-variant="variant" :data-selected="String(selected)" :disabled="disabled" :data-testid="$attrs[\'data-testid\']"><slot /></button>',
+})
+
+// Stub GameButtonGroup
+const gameButtonGroupStub = defineComponent({
+  template: '<div class="game-button-group-stub"><slot /></div>',
+})
+
+// Stub GameIcon
+const gameIconStub = defineComponent({
+  props: ['icon', 'size'],
+  template: '<span class="game-icon-stub" :data-icon="icon" />',
+})
+
+// Stub GameTabPane
+const gameTabPaneStub = defineComponent({
+  props: ['name'],
+  template:
+    '<div class="game-tab-pane-stub" :data-name="name"><slot name="label" /><slot name="tab-content-header" /><slot /></div>',
+})
+
+// Stub Screen
+const screenStub = defineComponent({
+  template: '<div class="screen-stub" data-testid="screen-stub" />',
+})
+
+// Stub ErrorPanel
+const errorPanelStub = defineComponent({
+  props: ['errors'],
+  template: '<div class="error-panel-stub" />',
+})
+
+describe('ScreenTab', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockFilterEnabled.value = false
+    mockPrefersReducedMotion.value = false
+    vi.clearAllMocks()
+  })
+
+  function mountScreenTab() {
+    return mount(ScreenTab, {
+      props: { errors: [] },
+      global: {
+        stubs: {
+          GameButton: gameButtonStub,
+          GameButtonGroup: gameButtonGroupStub,
+          GameIcon: gameIconStub,
+          GameTabPane: gameTabPaneStub,
+          Screen: screenStub,
+          ErrorPanel: errorPanelStub,
+        },
+      },
+    })
+  }
+
+  it('renders the filter toggle button', () => {
+    const wrapper = mountScreenTab()
+
+    const filterButton = wrapper.find('[data-testid="ide-filter-toggle"]')
+    expect(filterButton.exists()).toEqual(true)
+    wrapper.unmount()
+  })
+
+  it('shows filter toggle as not selected by default', () => {
+    const wrapper = mountScreenTab()
+
+    const filterButton = wrapper.find('[data-testid="ide-filter-toggle"]')
+    expect(filterButton.attributes('data-selected')).toEqual('false')
+    wrapper.unmount()
+  })
+
+  it('toggles filterEnabled when filter button is clicked', async () => {
+    const wrapper = mountScreenTab()
+
+    const filterButton = wrapper.find('[data-testid="ide-filter-toggle"]')
+    await filterButton.trigger('click')
+
+    expect(mockToggleFilter).toHaveBeenCalledOnce()
+
+    // After clicking, mock state should be toggled
+    expect(filterButton.attributes('data-selected')).toEqual('true')
+
+    // Click again to toggle back
+    await filterButton.trigger('click')
+    expect(filterButton.attributes('data-selected')).toEqual('false')
+    wrapper.unmount()
+  })
+
+  it('renders the filter toggle with i18n label', () => {
+    const wrapper = mountScreenTab()
+
+    const filterButton = wrapper.find('[data-testid="ide-filter-toggle"]')
+    expect(filterButton.text()).toEqual('ide.screenTab.filter')
+    wrapper.unmount()
+  })
+
+  it('renders the filter toggle icon', () => {
+    const wrapper = mountScreenTab()
+
+    const filterIcon = wrapper.find(
+      '[data-testid="ide-filter-toggle"] .game-icon-stub'
+    )
+    expect(filterIcon.exists()).toEqual(true)
+    expect(filterIcon.attributes('data-icon')).toEqual(
+      'mdi:monitor-shimmer'
+    )
+    wrapper.unmount()
+  })
+
+  it('disables filter toggle when prefers-reduced-motion is active', () => {
+    mockPrefersReducedMotion.value = true
+
+    const wrapper = mountScreenTab()
+
+    const filterButton = wrapper.find('[data-testid="ide-filter-toggle"]')
+    expect(filterButton.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+})

--- a/test/features/ide/composables/useScreenFilter.test.ts
+++ b/test/features/ide/composables/useScreenFilter.test.ts
@@ -113,4 +113,20 @@ describe('useScreenFilter', () => {
       expect(typeof result.setFilterEnabled).toEqual('function')
     })
   })
+
+  describe('prefersReducedMotion', () => {
+    it('returns prefersReducedMotion as a boolean ref', () => {
+      const { prefersReducedMotion } = useScreenFilter()
+
+      expect(prefersReducedMotion).toBeDefined()
+      expect(typeof prefersReducedMotion.value).toEqual('boolean')
+    })
+
+    it('returns false when prefers-reduced-motion is not set', () => {
+      // Default jsdom environment has no prefers-reduced-motion
+      const { prefersReducedMotion } = useScreenFilter()
+
+      expect(prefersReducedMotion.value).toEqual(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes #615 — adds CRT filter toggle button to ScreenTab with i18n support across all 4 locales
- Respects `prefers-reduced-motion` by disabling the toggle when user prefers reduced motion

## Changes
- Added `prefersReducedMotion` computed boolean to `useScreenFilter` composable via `usePreferredReducedMotion`
- Added filter toggle `GameButton` in `ScreenTab.vue` next to the grid toggle, wired to `useScreenFilter`
- Added `ide.screenTab.filter` i18n key ("CRT") across en, ja, zh-CN, zh-TW locales
- 8 new tests: 2 for composable `prefersReducedMotion`, 6 for ScreenTab filter toggle button

## Test plan
- [ ] Targeted tests pass (259 files, 3651 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)