### PR TITLE
fix: resolve #680 - track and clean up highlight setTimeout on unmount in KeyboardBufferSection

### DIFF
--- a/src/features/ide/components/KeyboardBufferSection.vue
+++ b/src/features/ide/components/KeyboardBufferSection.vue
@@ -17,6 +17,7 @@ const { t } = useI18n()
 const POLL_INTERVAL_MS = 100
 const HIGHLIGHT_DURATION_MS = 1000
 let pollTimer: ReturnType<typeof setInterval> | null = null
+let highlightTimer: ReturnType<typeof setTimeout> | null = null
 
 const keyCharCode = ref(0)
 const keyModifiers = ref(0)
@@ -32,8 +33,12 @@ function readKeyboardState(): void {
   // Detect keyAvailable transition
   if (newAvailable !== keyAvailable.value && newAvailable !== 0) {
     highlightKeyAvailable.value = true
-    setTimeout(() => {
+    if (highlightTimer !== null) {
+      clearTimeout(highlightTimer)
+    }
+    highlightTimer = setTimeout(() => {
       highlightKeyAvailable.value = false
+      highlightTimer = null
     }, HIGHLIGHT_DURATION_MS)
   }
 
@@ -52,6 +57,10 @@ onBeforeUnmount(() => {
   if (pollTimer !== null) {
     clearInterval(pollTimer)
     pollTimer = null
+  }
+  if (highlightTimer !== null) {
+    clearTimeout(highlightTimer)
+    highlightTimer = null
   }
 })
 </script>

--- a/test/ide/KeyboardBufferSection.test.ts
+++ b/test/ide/KeyboardBufferSection.test.ts
@@ -7,12 +7,12 @@ import { consumeKeyAvailable, setInkeyState } from '@/core/devices/sharedKeyboar
 import KeyboardBufferSection from '@/features/ide/components/KeyboardBufferSection.vue'
 
 import { createTestKeyboardBuffer } from './helpers/createTestKeyboardBuffer'
-
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (key: string) => key,
   }),
 }))
+
 
 /**
  * Mount the component with fake timers.
@@ -181,5 +181,33 @@ describe('KeyboardBufferSection', () => {
 
     expect(availableRow.classes()).not.toContain('keyboard-buffer-highlight')
     cleanup()
+  })
+
+  it('clears highlight timeout on unmount to prevent stale ref update', async () => {
+    const keyboardView = createTestKeyboardBuffer()
+    vi.useFakeTimers()
+
+    const wrapper = mount(KeyboardBufferSection, {
+      props: { keyboardView },
+    })
+
+    // Trigger a key press to start the highlight timeout
+    setInkeyState(keyboardView, 'A', 0)
+    vi.advanceTimersByTime(100)
+    await wrapper.vm.$nextTick()
+
+    // Confirm highlight is active (timeout was scheduled)
+    const availableRow = wrapper.findAll('.keyboard-buffer-row')[2]!
+    expect(availableRow.classes()).toContain('keyboard-buffer-highlight')
+
+    // Unmount before the highlight duration expires.
+    // The fix clears the highlight timer in onBeforeUnmount.
+    wrapper.unmount()
+
+    // After unmount, both the poll interval and the highlight timer
+    // should be cleared, leaving zero pending timers.
+    expect(vi.getTimerCount()).toBe(0)
+
+    vi.useRealTimers()
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #680

## Changes
- Added `highlightTimer` variable to track the highlight `setTimeout` reference
- Clear highlight timer in `onBeforeUnmount` to prevent stale ref updates when component unmounts during the 1s highlight window
- Added guard to clear previous highlight timer before setting a new one (handles rapid key transitions)
- Added regression test verifying zero pending timers after unmount during highlight window

## Test plan
- [x] Regression test: verifies highlight timeout is cleared on unmount (RED→GREEN cycle confirmed)
- [x] All 11 KeyboardBufferSection tests pass (10 existing + 1 new)
- [x] Type-check clean
- [x] ESLint clean

🤖 Generated by `/implement-issue`