### PR TITLE
fix: resolve #675 - add input validation to useComposer setActiveChannel

### DIFF
--- a/src/features/ide/composables/useComposer.ts
+++ b/src/features/ide/composables/useComposer.ts
@@ -113,8 +113,12 @@ export function useComposer() {
     }
   }
 
-  /** Switches the active channel. */
+  /**
+   * Switches the active channel.
+   * Ignores out-of-range indices (must be 0 to CHANNEL_COUNT - 1).
+   */
   function setActiveChannel(index: number): void {
+    if (Number.isNaN(index) || index < 0 || index >= CHANNEL_COUNT) return
     activeChannel.value = index
   }
 

--- a/test/features/ide/composables/useComposer.test.ts
+++ b/test/features/ide/composables/useComposer.test.ts
@@ -103,6 +103,38 @@ describe('useComposer', () => {
       expect(activeChannel.value).toEqual(2)
     })
 
+    it('ignores negative index', () => {
+      const { activeChannel, setActiveChannel } = useComposer()
+
+      setActiveChannel(-1)
+
+      expect(activeChannel.value).toEqual(0)
+    })
+
+    it('ignores index equal to CHANNEL_COUNT (3)', () => {
+      const { activeChannel, setActiveChannel } = useComposer()
+
+      setActiveChannel(3)
+
+      expect(activeChannel.value).toEqual(0)
+    })
+
+    it('ignores index greater than CHANNEL_COUNT (5)', () => {
+      const { activeChannel, setActiveChannel } = useComposer()
+
+      setActiveChannel(5)
+
+      expect(activeChannel.value).toEqual(0)
+    })
+
+    it('ignores NaN', () => {
+      const { activeChannel, setActiveChannel } = useComposer()
+
+      setActiveChannel(NaN)
+
+      expect(activeChannel.value).toEqual(0)
+    })
+
     it('updates activeNotes to reflect new channel', () => {
       const { activeNotes, setActiveChannel, toggleNote } = useComposer()
 


### PR DESCRIPTION
## Summary
- Fixes #675

## Changes
- Added `Number.isNaN(index) || index < 0 || index >= CHANNEL_COUNT` guard to `setActiveChannel` in `useComposer.ts`
- Updated JSDoc to document the early return behavior
- Added 4 regression tests: negative index (-1), boundary (3), out-of-range (5), NaN

## Test plan
- [ ] Targeted tests pass (40/40)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)