### PR TITLE
refactor: resolve #676 - extract hardcoded polling interval as named constant in KeyboardBufferSection

### DIFF
--- a/src/features/ide/components/KeyboardBufferSection.vue
+++ b/src/features/ide/components/KeyboardBufferSection.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
 const { t } = useI18n()
 
 const HIGHLIGHT_DURATION_MS = 1000
+const POLL_INTERVAL_MS = 100
 let pollTimer: ReturnType<typeof setInterval> | null = null
 
 const keyCharCode = ref(0)
@@ -44,7 +45,7 @@ function readKeyboardState(): void {
 
 onMounted(() => {
   readKeyboardState()
-  pollTimer = setInterval(readKeyboardState, 100)
+  pollTimer = setInterval(readKeyboardState, POLL_INTERVAL_MS)
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- Fixes #676

## Changes
- Added `const POLL_INTERVAL_MS = 100` alongside `HIGHLIGHT_DURATION_MS` in `KeyboardBufferSection.vue`
- Replaced hardcoded `100` in `setInterval(readKeyboardState, 100)` with `POLL_INTERVAL_MS`

## Test plan
- [x] All 10 KeyboardBufferSection tests pass
- [x] TypeScript type-check clean
- [x] ESLint clean
- [x] Full test suite (263 files, 3736 tests) passes

## Note
This PR is based on `feat/issue-607-implement-keyboard-buffer-section-in-buffer-inspector` (#673) since `KeyboardBufferSection.vue` was introduced in that PR. It should be merged after #673.