### PR TITLE
fix: resolve #708 - use LOCAL_STORAGE_SYNC_DELAY_MS consistently in Screen.test.ts vignette test

### DIFF
--- a/test/ide/Screen.test.ts
+++ b/test/ide/Screen.test.ts
@@ -165,7 +165,7 @@ describe.each([
       },
     })
 
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await new Promise((resolve) => setTimeout(resolve, LOCAL_STORAGE_SYNC_DELAY_MS))
 
     expect(wrapper.find('.crt-vignette').exists()).toEqual(true)
     wrapper.unmount()


### PR DESCRIPTION
## Summary
- Fixes #708

## Changes
- Replace hardcoded `50` with `LOCAL_STORAGE_SYNC_DELAY_MS` constant in the vignette filter test's `setTimeout` call in `Screen.test.ts`

## Test plan
- [x] All 12 Screen.test.ts tests pass
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes