### PR TITLE
fix: resolve #704 - add input validation to useComposer clearChannel

### DIFF
--- a/src/features/ide/composables/useComposer.ts
+++ b/src/features/ide/composables/useComposer.ts
@@ -103,6 +103,7 @@ export function useComposer() {
    */
   function clearChannel(channelIndex?: number): void {
     const index = channelIndex ?? activeChannel.value
+    if (Number.isNaN(index) || index < 0 || index >= CHANNEL_COUNT) return
     channelNotes.value[index] = new Set()
   }
 
@@ -190,6 +191,7 @@ export function useComposer() {
     title,
     activeChannel,
     activeNotes,
+    channelNotes,
 
     // Operations
     toggleNote,

--- a/test/features/ide/composables/useComposer.test.ts
+++ b/test/features/ide/composables/useComposer.test.ts
@@ -103,34 +103,15 @@ describe('useComposer', () => {
       expect(activeChannel.value).toEqual(2)
     })
 
-    it('ignores negative index', () => {
+    it.each([
+      [-1, 'negative index'],
+      [3, 'index equal to CHANNEL_COUNT (3)'],
+      [5, 'index greater than CHANNEL_COUNT (5)'],
+      [NaN, 'NaN'],
+    ])('ignores %s', (index) => {
       const { activeChannel, setActiveChannel } = useComposer()
 
-      setActiveChannel(-1)
-
-      expect(activeChannel.value).toEqual(0)
-    })
-
-    it('ignores index equal to CHANNEL_COUNT (3)', () => {
-      const { activeChannel, setActiveChannel } = useComposer()
-
-      setActiveChannel(3)
-
-      expect(activeChannel.value).toEqual(0)
-    })
-
-    it('ignores index greater than CHANNEL_COUNT (5)', () => {
-      const { activeChannel, setActiveChannel } = useComposer()
-
-      setActiveChannel(5)
-
-      expect(activeChannel.value).toEqual(0)
-    })
-
-    it('ignores NaN', () => {
-      const { activeChannel, setActiveChannel } = useComposer()
-
-      setActiveChannel(NaN)
+      setActiveChannel(index)
 
       expect(activeChannel.value).toEqual(0)
     })
@@ -266,6 +247,23 @@ describe('useComposer', () => {
 
       expect(channelNoteCount(0)).toEqual(0)
       expect(channelNoteCount(1)).toEqual(1)
+    })
+
+    it.each([
+      [NaN, 'NaN'],
+      [-1, 'negative index'],
+      [3, 'index equal to CHANNEL_COUNT (3)'],
+      [5, 'index greater than CHANNEL_COUNT (5)'],
+    ])('ignores %s', (index) => {
+      const { toggleNote, clearChannel, channelNoteCount, channelNotes } =
+        useComposer()
+
+      toggleNote(5, 3)
+      clearChannel(index)
+
+      expect(channelNoteCount(0)).toEqual(1)
+      expect(channelNotes.value.length).toEqual(3)
+      expect('NaN' in channelNotes.value).toEqual(false)
     })
   })
 
@@ -479,6 +477,7 @@ describe('useComposer', () => {
       expect(result).toHaveProperty('title')
       expect(result).toHaveProperty('activeChannel')
       expect(result).toHaveProperty('activeNotes')
+      expect(result).toHaveProperty('channelNotes')
       expect(typeof result.toggleNote).toEqual('function')
       expect(typeof result.clearChannel).toEqual('function')
       expect(typeof result.clearAll).toEqual('function')


### PR DESCRIPTION
## Summary
- Fixes #704

## Changes
- Added NaN + bounds guard (`Number.isNaN(index) || index < 0 || index >= CHANNEL_COUNT`) to `clearChannel()` in `useComposer.ts`, same pattern as `setActiveChannel` fix (#675)
- Exposed `channelNotes` in composable return for test access
- Added 4 parameterized regression tests for `clearChannel` invalid inputs (NaN, -1, 3, 5)
- Consolidated existing `setActiveChannel` validation tests into `it.each` format

## Test plan
- [ ] Targeted tests pass (3760 tests)
- [ ] CI passes

🤖 Generated with Claude Code