### PR TITLE
fix: resolve #715 - add input validation to useComposer setOctave and getChannelOctave

### DIFF
--- a/src/features/ide/composables/useComposer.ts
+++ b/src/features/ide/composables/useComposer.ts
@@ -139,11 +139,14 @@ export function useComposer() {
    */
   function setOctave(value: number, channelIndex?: number): void {
     const index = channelIndex ?? activeChannel.value
+    if (Number.isNaN(index) || index < 0 || index >= CHANNEL_COUNT) return
     channelOctaves.value[index] = value
   }
 
   /** Gets the octave for a specific channel. */
   function getChannelOctave(channelIndex: number): number {
+    if (Number.isNaN(channelIndex) || channelIndex < 0 || channelIndex >= CHANNEL_COUNT)
+      return DEFAULT_OCTAVE
     return channelOctaves.value[channelIndex] ?? DEFAULT_OCTAVE
   }
 

--- a/test/features/ide/composables/useComposer.octave.test.ts
+++ b/test/features/ide/composables/useComposer.octave.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { DEFAULT_OCTAVE } from '@/features/ide/components/composerControlsConstants'
+import { useComposer } from '@/features/ide/composables/useComposer'
+
+describe('useComposer octave', () => {
+  beforeEach(() => {
+    // Reset singleton state between tests
+    const { reset } = useComposer()
+    reset()
+  })
+
+  // ---------------------------------------------------------------------------
+  // setOctave
+  // ---------------------------------------------------------------------------
+
+  describe('setOctave', () => {
+    it('sets octave for the active channel', () => {
+      const { setOctave, getChannelOctave } = useComposer()
+
+      setOctave(5)
+
+      expect(getChannelOctave(0)).toEqual(5)
+      // Other channels unchanged
+      expect(getChannelOctave(1)).toEqual(DEFAULT_OCTAVE)
+    })
+
+    it('sets octave for a specific channel', () => {
+      const { setOctave, getChannelOctave } = useComposer()
+
+      setOctave(3, 2)
+
+      expect(getChannelOctave(0)).toEqual(DEFAULT_OCTAVE)
+      expect(getChannelOctave(1)).toEqual(DEFAULT_OCTAVE)
+      expect(getChannelOctave(2)).toEqual(3)
+    })
+
+    it.each([
+      [NaN, 'NaN'],
+      [-1, 'negative index'],
+      [3, 'index equal to CHANNEL_COUNT (3)'],
+      [5, 'index greater than CHANNEL_COUNT (5)'],
+    ])('ignores %s for explicit channel index', (index) => {
+      const { setOctave, getChannelOctave } = useComposer()
+
+      setOctave(7, index)
+
+      // All valid channels should remain at DEFAULT_OCTAVE
+      expect(getChannelOctave(0)).toEqual(DEFAULT_OCTAVE)
+      expect(getChannelOctave(1)).toEqual(DEFAULT_OCTAVE)
+      expect(getChannelOctave(2)).toEqual(DEFAULT_OCTAVE)
+      // The invalid index itself should also return DEFAULT_OCTAVE
+      expect(getChannelOctave(index)).toEqual(DEFAULT_OCTAVE)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // getChannelOctave
+  // ---------------------------------------------------------------------------
+
+  describe('getChannelOctave', () => {
+    it.each([
+      [NaN, 'NaN'],
+      [-1, 'negative index'],
+      [3, 'index equal to CHANNEL_COUNT (3)'],
+      [5, 'index greater than CHANNEL_COUNT (5)'],
+    ])('returns DEFAULT_OCTAVE for %s', (index) => {
+      const { setOctave, getChannelOctave } = useComposer()
+
+      // Set a non-default octave on all valid channels first
+      setOctave(7, 0)
+      setOctave(7, 1)
+      setOctave(7, 2)
+
+      // Invalid indices should return DEFAULT_OCTAVE
+      expect(getChannelOctave(index)).toEqual(DEFAULT_OCTAVE)
+    })
+  })
+})

--- a/test/features/ide/composables/useComposer.test.ts
+++ b/test/features/ide/composables/useComposer.test.ts
@@ -353,28 +353,6 @@ describe('useComposer', () => {
     })
   })
 
-  describe('setOctave', () => {
-    it('sets octave for the active channel', () => {
-      const { setOctave, getChannelOctave } = useComposer()
-
-      setOctave(5)
-
-      expect(getChannelOctave(0)).toEqual(5)
-      // Other channels unchanged
-      expect(getChannelOctave(1)).toEqual(DEFAULT_OCTAVE)
-    })
-
-    it('sets octave for a specific channel', () => {
-      const { setOctave, getChannelOctave } = useComposer()
-
-      setOctave(3, 2)
-
-      expect(getChannelOctave(0)).toEqual(DEFAULT_OCTAVE)
-      expect(getChannelOctave(1)).toEqual(DEFAULT_OCTAVE)
-      expect(getChannelOctave(2)).toEqual(3)
-    })
-  })
-
   // ---------------------------------------------------------------------------
   // Reset
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #715

## Changes
- Added NaN + bounds validation guard to `setOctave()` matching the pattern used by `setActiveChannel()` and `clearChannel()`
- Added NaN + bounds validation guard to `getChannelOctave()` returning `DEFAULT_OCTAVE` for invalid indices
- Extracted octave-specific tests into dedicated `useComposer.octave.test.ts` file (main test file was at 496 lines)

## Test plan
- [x] 52 targeted tests pass (42 main + 10 octave)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes