### PR TITLE
fix: resolve #705 - add integer validation to useComposer setActiveChannel guard

### DIFF
--- a/src/features/ide/composables/useComposer.ts
+++ b/src/features/ide/composables/useComposer.ts
@@ -119,7 +119,7 @@ export function useComposer() {
    * Ignores out-of-range indices (must be 0 to CHANNEL_COUNT - 1).
    */
   function setActiveChannel(index: number): void {
-    if (Number.isNaN(index) || index < 0 || index >= CHANNEL_COUNT) return
+    if (Number.isNaN(index) || !Number.isInteger(index) || index < 0 || index >= CHANNEL_COUNT) return
     activeChannel.value = index
   }
 

--- a/test/features/ide/composables/useComposer.test.ts
+++ b/test/features/ide/composables/useComposer.test.ts
@@ -108,6 +108,7 @@ describe('useComposer', () => {
       [3, 'index equal to CHANNEL_COUNT (3)'],
       [5, 'index greater than CHANNEL_COUNT (5)'],
       [NaN, 'NaN'],
+      [1.5, 'non-integer float'],
     ])('ignores %s', (index) => {
       const { activeChannel, setActiveChannel } = useComposer()
 


### PR DESCRIPTION
## Summary
- Fixes #705

## Changes
- Added `!Number.isInteger(index)` check to `setActiveChannel` guard to reject non-integer float values (e.g., `1.5`)
- Added regression test case `[1.5, 'non-integer float']` to existing `it.each` validation tests

## Test plan
- [x] Targeted tests pass (45/45 useComposer tests)
- [ ] CI passes