### PR TITLE
refactor: resolve #716 - consistent it.each parameter ordering in useComposer validation tests

### DIFF
--- a/test/features/ide/composables/useComposer.test.ts
+++ b/test/features/ide/composables/useComposer.test.ts
@@ -250,10 +250,10 @@ describe('useComposer', () => {
     })
 
     it.each([
-      [NaN, 'NaN'],
       [-1, 'negative index'],
       [3, 'index equal to CHANNEL_COUNT (3)'],
       [5, 'index greater than CHANNEL_COUNT (5)'],
+      [NaN, 'NaN'],
     ])('ignores %s', (index) => {
       const { toggleNote, clearChannel, channelNoteCount, channelNotes } =
         useComposer()


### PR DESCRIPTION
## Summary
- Fixes #716

## Changes
- Reorder `clearChannel` validation `it.each` parameters from `[NaN, -1, 3, 5]` to `[-1, 3, 5, NaN]` to match `setActiveChannel` ordering for consistency

## Test plan
- [ ] Targeted tests pass (44/44)
- [ ] CI passes