### PR TITLE
test: resolve #683 - add strig button active class highlighting test in JoystickBufferSection

### DIFF
--- a/test/ide/JoystickBufferSection.test.ts
+++ b/test/ide/JoystickBufferSection.test.ts
@@ -290,6 +290,57 @@ describe('JoystickBufferSection', () => {
     })
   })
 
+  it('highlights buttons based on strig state', () => {
+    const buffer = createSharedJoystickBuffer()
+    const view = createViewsFromJoystickBuffer(buffer)
+    setStrigState(view, 0, 9) // A(8) + Start(1)
+
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const buttonContainers = wrapper.findAll('.joystick-dpad-buttons')
+    const buttons0 = buttonContainers[0]!.findAll('.dpad-button')
+    expect(buttons0.length).toBe(4)
+
+    // A and Start are active
+    expect(buttons0[0]!.classes()).toContain('dpad-active') // A
+    expect(buttons0[1]!.classes()).not.toContain('dpad-active') // B
+    expect(buttons0[2]!.classes()).not.toContain('dpad-active') // Sel
+    expect(buttons0[3]!.classes()).toContain('dpad-active') // Sta
+
+    // Joystick 1 should have no active buttons
+    const buttons1 = buttonContainers[1]!.findAll('.dpad-button')
+    expect(buttons1.length).toBe(4)
+    for (const btn of buttons1) {
+      expect(btn.classes()).not.toContain('dpad-active')
+    }
+    wrapper.unmount()
+  })
+
+  it('does not highlight any button when strig state is 0', () => {
+    const buffer = createSharedJoystickBuffer()
+
+    const wrapper = mount(JoystickBufferSection, {
+      props: {
+        sharedJoystickBuffer: buffer,
+        tick: 0,
+      },
+    })
+
+    const buttonContainers = wrapper.findAll('.joystick-dpad-buttons')
+    for (const container of buttonContainers) {
+      const buttons = container.findAll('.dpad-button')
+      for (const btn of buttons) {
+        expect(btn.classes()).not.toContain('dpad-active')
+      }
+    }
+    wrapper.unmount()
+  })
+
   it('reacts to buffer changes when tick increments', async () => {
     const buffer = createSharedJoystickBuffer()
     const view = createViewsFromJoystickBuffer(buffer)


### PR DESCRIPTION
## Summary
- Fixes #683

## Changes
- Added test "highlights buttons based on strig state" — sets strig to 9 (A+Start) on joystick 0, verifies `dpad-active` class on correct buttons and absence on others
- Added test "does not highlight any button when strig state is 0" — verifies no buttons highlighted with default zero state

## Test plan
- [x] 15/15 JoystickBufferSection tests pass (13 existing + 2 new)
- [ ] CI passes