### PR TITLE
refactor: resolve #707 - add fade-out transition for keyboard buffer highlight

### DIFF
--- a/src/features/ide/components/KeyboardBufferSection.vue
+++ b/src/features/ide/components/KeyboardBufferSection.vue
@@ -125,13 +125,13 @@ onBeforeUnmount(() => {
   padding: 0.1rem 0.35rem;
   font-size: 0.7rem;
   font-variant-numeric: tabular-nums;
+  transition: background 0.3s ease-out;
 }
 
 .keyboard-buffer-highlight {
   background: var(--game-accent);
   color: var(--game-text-primary);
   border-radius: 2px;
-  transition: background 0.3s ease-out;
 }
 
 .keyboard-buffer-label {


### PR DESCRIPTION
## Summary
- Fixes #707

## Changes
- Move `transition: background 0.3s ease-out` from `.keyboard-buffer-highlight` to `.keyboard-buffer-row` so fade-out is smooth when highlight class is removed

## Test plan
- [ ] Targeted tests pass (11/11)
- [ ] CI passes