### PR TITLE
test: resolve #685 - add click-guard test for disabled CRT filter toggle in ScreenTab

### DIFF
--- a/test/features/ide/components/ScreenTab.test.ts
+++ b/test/features/ide/components/ScreenTab.test.ts
@@ -146,13 +146,16 @@ describe('ScreenTab', () => {
     wrapper.unmount()
   })
 
-  it('disables filter toggle when prefers-reduced-motion is active', () => {
+  it('disables filter toggle when prefers-reduced-motion is active', async () => {
     mockPrefersReducedMotion.value = true
 
     const wrapper = mountScreenTab()
 
     const filterButton = wrapper.find('[data-testid="ide-filter-toggle"]')
     expect(filterButton.attributes('disabled')).toBeDefined()
+
+    await filterButton.trigger('click')
+    expect(mockToggleFilter).not.toHaveBeenCalled()
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #685

## Changes
- Extended existing "disables filter toggle when prefers-reduced-motion is active" test to also trigger a click on the disabled button and verify `toggleFilter` was NOT called

## Test plan
- [ ] 6/6 ScreenTab tests pass (5 existing + click guard added to existing test)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)