### PR TITLE
refactor: resolve #686 - declare data-testid as prop in gameButtonStub instead of using attrs fallthrough

### DIFF
--- a/test/features/ide/components/ScreenTab.test.ts
+++ b/test/features/ide/components/ScreenTab.test.ts
@@ -34,9 +34,9 @@ vi.mock('@/features/ide/composables/useScreenFilter', () => ({
 
 // Stub GameButton to capture click events and attributes
 const gameButtonStub = defineComponent({
-  props: ['variant', 'size', 'selected', 'disabled'],
+  props: ['variant', 'size', 'selected', 'disabled', 'dataTestid'],
   template:
-    '<button :data-variant="variant" :data-selected="String(selected)" :disabled="disabled" :data-testid="$attrs[\'data-testid\']"><slot /></button>',
+    '<button :data-variant="variant" :data-selected="String(selected)" :disabled="disabled" :data-testid="dataTestid"><slot /></button>',
 })
 
 // Stub GameButtonGroup


### PR DESCRIPTION
## Summary
- Fixes #686

## Changes
- Added `dataTestid` to `gameButtonStub` props declaration in ScreenTab.test.ts
- Changed template binding from `$attrs['data-testid']` to explicit `dataTestid` prop, matching the real GameButton component pattern

## Test plan
- [x] 6/6 ScreenTab tests pass (before and after refactor)
- [ ] CI passes