### PR TITLE
refactor: resolve #698 - differentiate z-index for scanlines and vignette layers

### DIFF
--- a/src/shared/styles/screen-crt.css
+++ b/src/shared/styles/screen-crt.css
@@ -110,7 +110,7 @@
     inset: 0;
     background: radial-gradient( ellipse 140% 100% at 85% 5%, var(--crt-glow-light-40) 0%, var(--crt-glow-light-20) 15%, var(--crt-glow-light-10) 30%, transparent 55%, var(--crt-shadow-dark-40) 100%);
     pointer-events: none;
-    z-index: 4;
+    z-index: 5;
     border-radius: 16px;
 }
 
@@ -141,7 +141,7 @@
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 3;
+    z-index: 4;
     border-radius: 24px;
     background: radial-gradient(
         ellipse 100% 100% at 50% 50%,


### PR DESCRIPTION
## Summary
- Fixes #698

## Changes
- Bump `.crt-vignette` z-index from 3 to 4
- Bump `.crt-reflection` z-index from 4 to 5
- All 6 CRT layers now have distinct z-index values (0-5), eliminating implicit DOM-order dependency

## Test plan
- [ ] Targeted tests pass (12/12)
- [ ] CI passes