### PR TITLE
refactor: resolve #699 - use ACK_PENDING/ACK_RECEIVED constants instead of magic number 0 in AnimationSyncSection

### DIFF
--- a/src/features/ide/components/AnimationSyncSection.vue
+++ b/src/features/ide/components/AnimationSyncSection.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
+import { ACK_PENDING, SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
 import type { SyncCommand } from '@/core/animation/sharedDisplayBufferAccessor'
 
 defineOptions({
@@ -72,7 +72,7 @@ const rows = computed<SyncRow[]>(() => {
     },
     {
       field: t('ide.bufferInspector.animationSyncFieldAck'),
-      value: props.ackStatus === 0
+      value: props.ackStatus === ACK_PENDING
         ? t('ide.bufferInspector.animationSyncAckPending')
         : t('ide.bufferInspector.animationSyncAckReceived'),
     },

--- a/test/ide/AnimationSyncSection.test.ts
+++ b/test/ide/AnimationSyncSection.test.ts
@@ -2,7 +2,7 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 
-import { SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
+import { ACK_PENDING, ACK_RECEIVED, SyncCommandType } from '@/core/animation/sharedDisplayBuffer'
 import type { SyncCommand } from '@/core/animation/sharedDisplayBufferAccessor'
 import AnimationSyncSection from '@/features/ide/components/AnimationSyncSection.vue'
 
@@ -34,7 +34,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: null,
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 
@@ -46,7 +46,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: null,
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 
@@ -60,7 +60,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: null,
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 
@@ -74,7 +74,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: makeSyncCommand({ commandType: SyncCommandType.START_MOVEMENT }),
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 
@@ -87,7 +87,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: makeSyncCommand(),
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 
@@ -102,7 +102,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: makeSyncCommand({ commandType: SyncCommandType.START_MOVEMENT }),
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 
@@ -116,7 +116,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: makeSyncCommand({ actionNumber: 3 }),
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 
@@ -140,7 +140,7 @@ describe('AnimationSyncSection', () => {
             priority: 1,
           },
         }),
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 
@@ -172,7 +172,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: makeSyncCommand(),
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 
@@ -187,7 +187,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: makeSyncCommand(),
-        ackStatus: 1,
+        ackStatus: ACK_RECEIVED,
       },
     })
 
@@ -211,7 +211,7 @@ describe('AnimationSyncSection', () => {
       const wrapper = mount(AnimationSyncSection, {
         props: {
           syncCommand: makeSyncCommand({ commandType }),
-          ackStatus: 0,
+          ackStatus: ACK_PENDING,
         },
       })
 
@@ -226,7 +226,7 @@ describe('AnimationSyncSection', () => {
     const wrapper = mount(AnimationSyncSection, {
       props: {
         syncCommand: makeSyncCommand(),
-        ackStatus: 0,
+        ackStatus: ACK_PENDING,
       },
     })
 


### PR DESCRIPTION
## Summary
- Fixes #699

## Changes
- Import `ACK_PENDING` and `ACK_RECEIVED` from `sharedDisplayBuffer.ts` into `AnimationSyncSection.vue` and its test file
- Replace magic number `0` with `ACK_PENDING` (11 occurrences in tests, 1 in component)
- Replace magic number `1` with `ACK_RECEIVED` (1 occurrence in tests)

## Test plan
- [ ] Targeted tests pass (12/12)
- [ ] CI passes