### PR TITLE
refactor: resolve #696 - extract LOCAL_STORAGE_SYNC_DELAY_MS to shared test utility

### DIFF
--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared Test Constants
+ *
+ * Single source of truth for constants used across multiple test files.
+ * This prevents local copies from drifting when the underlying value changes.
+ */
+
+/** Delay for VueUse's useLocalStorage async sync to flush */
+export const LOCAL_STORAGE_SYNC_DELAY_MS = 50

--- a/test/ide/Screen.test.ts
+++ b/test/ide/Screen.test.ts
@@ -5,7 +5,7 @@ import { ref } from 'vue'
 
 import Screen from '@/features/ide/components/Screen.vue'
 
-const LOCAL_STORAGE_SYNC_DELAY_MS = 50
+import { LOCAL_STORAGE_SYNC_DELAY_MS } from '../helpers/constants'
 
 // Mock useScreenContext to satisfy Screen.vue's provide/inject dependency
 vi.mock('@/features/ide/composables/useScreenContext', () => ({

--- a/test/ide/useProgramStore.test.ts
+++ b/test/ide/useProgramStore.test.ts
@@ -10,8 +10,7 @@ import { ref } from 'vue'
 import type { ProgramData } from '@/core/types/program-types'
 import { createEmptyGrid } from '@/features/bg-editor/composables/useBgGrid'
 
-/** Delay for VueUse's useLocalStorage async sync to flush */
-const LOCAL_STORAGE_SYNC_DELAY_MS = 50
+import { LOCAL_STORAGE_SYNC_DELAY_MS } from '../helpers/constants'
 
 // Mock fileIO module
 vi.mock('@/shared/utils/fileIO', () => ({


### PR DESCRIPTION
## Summary
- Fixes #696

## Changes
- Created `test/helpers/constants.ts` with single source of truth for `LOCAL_STORAGE_SYNC_DELAY_MS = 50`
- Updated `Screen.test.ts` and `useProgramStore.test.ts` to import from shared constant

## Test plan
- [x] 31 tests pass (12 Screen + 19 useProgramStore, before and after)
- [ ] CI passes