### PR TITLE
refactor: resolve #702 - use field name as :key instead of index in AnimationSyncSection v-for

### DIFF
--- a/src/features/ide/components/AnimationSyncSection.vue
+++ b/src/features/ide/components/AnimationSyncSection.vue
@@ -94,7 +94,7 @@ const rows = computed<SyncRow[]>(() => {
         </tr>
       </thead>
       <tbody>
-        <tr v-for="(row, index) in rows" :key="index" class="sync-row">
+        <tr v-for="row in rows" :key="row.field" class="sync-row">
           <td class="sync-cell">{{ row.field }}</td>
           <td class="sync-cell">{{ row.value }}</td>
         </tr>


### PR DESCRIPTION
## Summary
- Fixes #702

## Changes
- Changed `:key="index"` to `:key="row.field"` on the `v-for` loop for table rows, using the parameter label field as a semantically correct key
- Removed unused `index` from v-for destructuring

## Test plan
- [x] 12/12 AnimationSyncSection tests pass (before and after)
- [ ] CI passes