### PR TITLE
refactor: resolve #724 - add Number.isInteger check to all channel index guards for consistency

### DIFF
--- a/src/features/ide/composables/useComposer.ts
+++ b/src/features/ide/composables/useComposer.ts
@@ -27,11 +27,6 @@ import { createNoteCellKey } from '@/features/ide/components/pianoRollConstants'
 /** Number of sound channels in F-BASIC. */
 const CHANNEL_COUNT = 3
 
-/** Returns true if the given index is a valid channel index (0 to CHANNEL_COUNT - 1). */
-function isValidChannelIndex(index: number): boolean {
-  return !Number.isNaN(index) && index >= 0 && index < CHANNEL_COUNT
-}
-
 // ---------------------------------------------------------------------------
 // Module-level singleton state
 // ---------------------------------------------------------------------------
@@ -108,7 +103,8 @@ export function useComposer() {
    */
   function clearChannel(channelIndex?: number): void {
     const index = channelIndex ?? activeChannel.value
-    if (!isValidChannelIndex(index)) return
+    if (!Number.isInteger(index) || index < 0 || index >= CHANNEL_COUNT)
+      return
     channelNotes.value[index] = new Set()
   }
 
@@ -124,7 +120,7 @@ export function useComposer() {
    * Ignores out-of-range indices (must be 0 to CHANNEL_COUNT - 1).
    */
   function setActiveChannel(index: number): void {
-    if (!isValidChannelIndex(index)) return
+    if (!Number.isInteger(index) || index < 0 || index >= CHANNEL_COUNT) return
     activeChannel.value = index
   }
 
@@ -144,13 +140,14 @@ export function useComposer() {
    */
   function setOctave(value: number, channelIndex?: number): void {
     const index = channelIndex ?? activeChannel.value
-    if (Number.isNaN(index) || index < 0 || index >= CHANNEL_COUNT) return
+    if (!Number.isInteger(index) || index < 0 || index >= CHANNEL_COUNT)
+      return
     channelOctaves.value[index] = value
   }
 
   /** Gets the octave for a specific channel. */
   function getChannelOctave(channelIndex: number): number {
-    if (Number.isNaN(channelIndex) || channelIndex < 0 || channelIndex >= CHANNEL_COUNT)
+    if (!Number.isInteger(channelIndex) || channelIndex < 0 || channelIndex >= CHANNEL_COUNT)
       return DEFAULT_OCTAVE
     return channelOctaves.value[channelIndex] ?? DEFAULT_OCTAVE
   }

--- a/test/features/ide/composables/useComposer.test.ts
+++ b/test/features/ide/composables/useComposer.test.ts
@@ -103,19 +103,6 @@ describe('useComposer', () => {
       expect(activeChannel.value).toEqual(2)
     })
 
-    it.each([
-      [-1, 'negative index'],
-      [3, 'index equal to CHANNEL_COUNT (3)'],
-      [5, 'index greater than CHANNEL_COUNT (5)'],
-      [NaN, 'NaN'],
-    ])('ignores %s', (index) => {
-      const { activeChannel, setActiveChannel } = useComposer()
-
-      setActiveChannel(index)
-
-      expect(activeChannel.value).toEqual(0)
-    })
-
     it('updates activeNotes to reflect new channel', () => {
       const { activeNotes, setActiveChannel, toggleNote } = useComposer()
 
@@ -249,22 +236,6 @@ describe('useComposer', () => {
       expect(channelNoteCount(1)).toEqual(1)
     })
 
-    it.each([
-      [-1, 'negative index'],
-      [3, 'index equal to CHANNEL_COUNT (3)'],
-      [5, 'index greater than CHANNEL_COUNT (5)'],
-      [NaN, 'NaN'],
-    ])('ignores %s', (index) => {
-      const { toggleNote, clearChannel, channelNoteCount, channelNotes } =
-        useComposer()
-
-      toggleNote(5, 3)
-      clearChannel(index)
-
-      expect(channelNoteCount(0)).toEqual(1)
-      expect(channelNotes.value.length).toEqual(3)
-      expect('NaN' in channelNotes.value).toEqual(false)
-    })
   })
 
   // ---------------------------------------------------------------------------
@@ -351,6 +322,29 @@ describe('useComposer', () => {
 
       expect(title.value).toEqual('My Song')
     })
+  })
+
+  describe('setOctave', () => {
+    it('sets octave for the active channel', () => {
+      const { setOctave, getChannelOctave } = useComposer()
+
+      setOctave(5)
+
+      expect(getChannelOctave(0)).toEqual(5)
+      // Other channels unchanged
+      expect(getChannelOctave(1)).toEqual(DEFAULT_OCTAVE)
+    })
+
+    it('sets octave for a specific channel', () => {
+      const { setOctave, getChannelOctave } = useComposer()
+
+      setOctave(3, 2)
+
+      expect(getChannelOctave(0)).toEqual(DEFAULT_OCTAVE)
+      expect(getChannelOctave(1)).toEqual(DEFAULT_OCTAVE)
+      expect(getChannelOctave(2)).toEqual(3)
+    })
+
   })
 
   // ---------------------------------------------------------------------------

--- a/test/features/ide/composables/useComposer.validation.test.ts
+++ b/test/features/ide/composables/useComposer.validation.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { DEFAULT_OCTAVE } from '@/features/ide/components/composerControlsConstants'
+import { useComposer } from '@/features/ide/composables/useComposer'
+
+describe('useComposer input validation', () => {
+  beforeEach(() => {
+    const { reset } = useComposer()
+    reset()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Shared invalid indices
+  // ---------------------------------------------------------------------------
+
+  const INVALID_INDICES = [
+    [-1, 'negative index'],
+    [3, 'index equal to CHANNEL_COUNT (3)'],
+    [5, 'index greater than CHANNEL_COUNT (5)'],
+    [1.5, 'non-integer float'],
+    [NaN, 'NaN'],
+  ] as const
+
+  // ---------------------------------------------------------------------------
+  // setActiveChannel
+  // ---------------------------------------------------------------------------
+
+  describe('setActiveChannel', () => {
+    it.each(INVALID_INDICES)('ignores %s', (index) => {
+      const { activeChannel, setActiveChannel } = useComposer()
+
+      setActiveChannel(index)
+
+      expect(activeChannel.value).toEqual(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // clearChannel
+  // ---------------------------------------------------------------------------
+
+  describe('clearChannel', () => {
+    it.each(INVALID_INDICES)('ignores %s', (index) => {
+      const { toggleNote, clearChannel, channelNoteCount, channelNotes } =
+        useComposer()
+
+      toggleNote(5, 3)
+      clearChannel(index)
+
+      expect(channelNoteCount(0)).toEqual(1)
+      expect(channelNotes.value.length).toEqual(3)
+      expect('NaN' in channelNotes.value).toEqual(false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // setOctave
+  // ---------------------------------------------------------------------------
+
+  describe('setOctave', () => {
+    it.each(INVALID_INDICES)('ignores invalid channel index %s', (index) => {
+      const { setOctave, getChannelOctave } = useComposer()
+
+      setOctave(7, index)
+
+      expect(getChannelOctave(0)).toEqual(DEFAULT_OCTAVE)
+      expect(getChannelOctave(1)).toEqual(DEFAULT_OCTAVE)
+      expect(getChannelOctave(2)).toEqual(DEFAULT_OCTAVE)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // getChannelOctave
+  // ---------------------------------------------------------------------------
+
+  describe('getChannelOctave', () => {
+    it.each(INVALID_INDICES)(
+      'returns DEFAULT_OCTAVE for invalid channel index %s',
+      (index) => {
+        const { setOctave, getChannelOctave } = useComposer()
+
+        setOctave(7, 0)
+
+        expect(getChannelOctave(index)).toEqual(DEFAULT_OCTAVE)
+      }
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Replace `Number.isNaN` with `!Number.isInteger` in `clearChannel` and `setActiveChannel` guards
- Add full `!Number.isInteger || bounds` guards to `setOctave` and `getChannelOctave`
- Extract validation tests to dedicated `useComposer.validation.test.ts` with shared `INVALID_INDICES` constant (20 tests)

Resolves #724

## Test plan
- [x] All 56 existing + new validation tests pass
- [x] TypeScript type-check clean
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)