### PR TITLE
refactor: resolve #733 - use CSS custom properties for CRT layer z-index values in screen-crt.css

### DIFF
--- a/src/shared/styles/screen-crt.css
+++ b/src/shared/styles/screen-crt.css
@@ -10,6 +10,14 @@
 /* CRT Color Variables - Dark Theme (default) */
 
 .screen-display {
+    /* CRT layer stacking order — lower values render behind higher values */
+    --crt-layer-stage: 0;
+    --crt-layer-color-bleed: 1;
+    --crt-layer-phosphor-glow: 2;
+    --crt-layer-scanlines: 3;
+    --crt-layer-vignette: 4;
+    --crt-layer-reflection: 5;
+
     --crt-glow-light-10: rgb(from var(--base-solid-gray-100) r g b / 10%);
     --crt-glow-light-20: rgb(from var(--base-solid-gray-100) r g b / 20%);
     --crt-glow-light-40: rgb(from var(--base-solid-gray-100) r g b / 40%);
@@ -80,7 +88,7 @@
     inset: 0;
     background: repeating-linear-gradient( 0deg, transparent, transparent 2px, var(--crt-shadow-dark-10) 2px, var(--crt-shadow-dark-10) 4px);
     pointer-events: none;
-    z-index: 3;
+    z-index: var(--crt-layer-scanlines);
     mix-blend-mode: multiply;
 }
 
@@ -89,7 +97,7 @@
     inset: 0;
     background: transparent;
     pointer-events: none;
-    z-index: 2;
+    z-index: var(--crt-layer-phosphor-glow);
     box-shadow: inset 0 0 60px 10px var(--crt-glow-light-10), inset 0 0 120px 20px var(--crt-glow-light-20);
     mix-blend-mode: screen;
 }
@@ -98,7 +106,7 @@
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 1;
+    z-index: var(--crt-layer-color-bleed);
     background: transparent;
     filter: blur(0.3px);
     mix-blend-mode: lighten;
@@ -110,7 +118,7 @@
     inset: 0;
     background: radial-gradient( ellipse 140% 100% at 85% 5%, var(--crt-glow-light-40) 0%, var(--crt-glow-light-20) 15%, var(--crt-glow-light-10) 30%, transparent 55%, var(--crt-shadow-dark-40) 100%);
     pointer-events: none;
-    z-index: 5;
+    z-index: var(--crt-layer-reflection);
     border-radius: 16px;
 }
 
@@ -120,7 +128,7 @@
 
 .screen-display .screen-stage-wrapper {
     position: relative;
-    z-index: 0;
+    z-index: var(--crt-layer-stage);
     overflow: hidden;
 }
 
@@ -141,7 +149,7 @@
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 4;
+    z-index: var(--crt-layer-vignette);
     border-radius: 24px;
     background: radial-gradient(
         ellipse 100% 100% at 50% 50%,


### PR DESCRIPTION
## Summary
- Introduces 6 CSS custom properties for CRT layer z-index values on `.screen-display`
- Replaces 6 numeric z-index values with `var(--crt-layer-*)` references
- Pure readability/maintainability improvement — no behavioral change

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)