### PR TITLE
refactor: resolve #723 - use isValidChannelIndex in setOctave and getChannelOctave

### DIFF
--- a/src/features/ide/composables/useComposer.ts
+++ b/src/features/ide/composables/useComposer.ts
@@ -144,14 +144,13 @@ export function useComposer() {
    */
   function setOctave(value: number, channelIndex?: number): void {
     const index = channelIndex ?? activeChannel.value
-    if (Number.isNaN(index) || index < 0 || index >= CHANNEL_COUNT) return
+    if (!isValidChannelIndex(index)) return
     channelOctaves.value[index] = value
   }
 
   /** Gets the octave for a specific channel. */
   function getChannelOctave(channelIndex: number): number {
-    if (Number.isNaN(channelIndex) || channelIndex < 0 || channelIndex >= CHANNEL_COUNT)
-      return DEFAULT_OCTAVE
+    if (!isValidChannelIndex(channelIndex)) return DEFAULT_OCTAVE
     return channelOctaves.value[channelIndex] ?? DEFAULT_OCTAVE
   }
 


### PR DESCRIPTION
## Summary
- Fixes #723

## Changes
- Replaced inline validation guards in `setOctave` and `getChannelOctave` with the shared `isValidChannelIndex()` helper
- Now all 4 channel-index-accepting functions (`clearChannel`, `setActiveChannel`, `setOctave`, `getChannelOctave`) use the same validation consistently

## Test plan
- [x] 42/42 useComposer tests pass (before and after refactor)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)