### PR TITLE
feat: resolve #630 - create ExportHtmlDialog.vue with export options

### DIFF
--- a/src/features/ide/components/ExportHtmlDialog.vue
+++ b/src/features/ide/components/ExportHtmlDialog.vue
@@ -1,0 +1,371 @@
+<script setup lang="ts">
+/**
+ * ExportHtmlDialog - Modal dialog for exporting an F-BASIC program as a standalone HTML file.
+ *
+ * Provides options for page title, theme selection, and toggling sound/sprite inclusion.
+ * Uses the useHtmlExporter composable to trigger the actual export.
+ */
+
+import { onMounted, onUnmounted, ref, toRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { CompactBg } from '@/core/types/program-types'
+import { useHtmlExporter } from '@/features/ide/composables/useHtmlExporter'
+
+const props = withDefaults(defineProps<{
+  visible: boolean
+  source: string
+  bg?: CompactBg
+}>(), {
+  bg: undefined,
+})
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const { t } = useI18n()
+
+// Composable
+const { isExporting, exportError, exportHtml } = useHtmlExporter(
+  toRef(props, 'source'),
+  toRef(props, 'bg'),
+)
+
+// Export options state
+const title = ref('')
+const theme = ref<'dark' | 'light'>('dark')
+const includeSound = ref(true)
+const includeSprites = ref(true)
+
+// Reset state when dialog opens
+watch(
+  () => props.visible,
+  (visible) => {
+    if (!visible) return
+
+    title.value = ''
+    theme.value = 'dark'
+    includeSound.value = true
+    includeSprites.value = true
+    exportError.value = ''
+  },
+)
+
+function handleClose(): void {
+  emit('close')
+}
+
+function handleOverlayClick(e: MouseEvent): void {
+  if (e.target === e.currentTarget) {
+    handleClose()
+  }
+}
+
+function handleKeydown(e: KeyboardEvent): void {
+  if (!props.visible) return
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    handleClose()
+  }
+}
+
+async function handleExport(): Promise<void> {
+  await exportHtml({
+    title: title.value,
+    theme: theme.value,
+    includeSound: includeSound.value,
+    includeSprites: includeSprites.value,
+  })
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="visible"
+      class="export-html-dialog-overlay"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="t('ide.exportHtml.title')"
+      @click="handleOverlayClick"
+    >
+      <div class="export-html-dialog">
+        <h3 class="export-html-dialog-title">
+          {{ t('ide.exportHtml.title') }}
+        </h3>
+
+        <p class="export-html-dialog-description">
+          {{ t('ide.exportHtml.description') }}
+        </p>
+
+        <!-- Exporting state -->
+        <div
+          v-if="isExporting"
+          data-testid="export-html-exporting"
+          class="export-html-dialog-loading"
+        >
+          {{ t('ide.exportHtml.exporting') }}
+        </div>
+
+        <!-- Error state -->
+        <div
+          v-else-if="exportError"
+          data-testid="export-html-error"
+          class="export-html-dialog-error"
+        >
+          {{ t('ide.exportHtml.exportFailed') }}
+        </div>
+
+        <!-- Form -->
+        <template v-else>
+          <!-- Title input -->
+          <div class="export-html-dialog-field">
+            <label
+              for="export-html-title"
+              class="export-html-dialog-label"
+            >
+              {{ t('ide.exportHtml.titleLabel') }}
+            </label>
+            <input
+              id="export-html-title"
+              v-model="title"
+              type="text"
+              class="export-html-dialog-input"
+              data-testid="export-html-title-input"
+            />
+          </div>
+
+          <!-- Theme selection -->
+          <fieldset class="export-html-dialog-fieldset">
+            <legend class="export-html-dialog-label">
+              {{ t('ide.exportHtml.themeLabel') }}
+            </legend>
+            <div class="export-html-dialog-radio-group">
+              <label class="export-html-dialog-radio-label">
+                <input
+                  v-model="theme"
+                  type="radio"
+                  value="dark"
+                  data-testid="export-html-theme-dark"
+                />
+                {{ t('ide.exportHtml.themeDark') }}
+              </label>
+              <label class="export-html-dialog-radio-label">
+                <input
+                  v-model="theme"
+                  type="radio"
+                  value="light"
+                  data-testid="export-html-theme-light"
+                />
+                {{ t('ide.exportHtml.themeLight') }}
+              </label>
+            </div>
+          </fieldset>
+
+          <!-- Toggles -->
+          <div class="export-html-dialog-toggles">
+            <label class="export-html-dialog-toggle-label">
+              <input
+                v-model="includeSound"
+                type="checkbox"
+                data-testid="export-html-include-sound"
+              />
+              {{ t('ide.exportHtml.includeSound') }}
+            </label>
+            <label class="export-html-dialog-toggle-label">
+              <input
+                v-model="includeSprites"
+                type="checkbox"
+                data-testid="export-html-include-sprites"
+              />
+              {{ t('ide.exportHtml.includeSprites') }}
+            </label>
+          </div>
+
+          <!-- Actions -->
+          <div class="export-html-dialog-actions">
+            <button
+              class="export-html-dialog-btn export-html-dialog-btn-export"
+              data-testid="export-html-export-button"
+              @click="handleExport"
+            >
+              {{ t('ide.exportHtml.exportButton') }}
+            </button>
+            <button
+              class="export-html-dialog-btn export-html-dialog-btn-cancel"
+              data-testid="export-html-cancel-button"
+              @click="handleClose"
+            >
+              {{ t('ide.exportHtml.cancelButton') }}
+            </button>
+          </div>
+        </template>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.export-html-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--base-alpha-gray-00-60);
+}
+
+.export-html-dialog {
+  background: var(--game-surface-bg-gradient);
+  border: 2px solid var(--game-surface-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  min-width: 420px;
+  max-width: 90vw;
+  box-shadow: var(--game-shadow-base);
+}
+
+.export-html-dialog-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--game-text-primary);
+}
+
+.export-html-dialog-description {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  color: var(--game-text-secondary);
+  line-height: 1.4;
+}
+
+.export-html-dialog-loading {
+  padding: 1rem 0;
+  text-align: center;
+  color: var(--game-text-secondary);
+  font-size: 0.875rem;
+}
+
+.export-html-dialog-error {
+  padding: 0.75rem;
+  color: var(--semantic-solid-danger);
+  font-size: 0.875rem;
+  background: var(--base-alpha-danger-10);
+  border-radius: 6px;
+}
+
+.export-html-dialog-field {
+  margin-bottom: 0.75rem;
+}
+
+.export-html-dialog-label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--game-text-secondary);
+}
+
+.export-html-dialog-input {
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  font-size: 0.875rem;
+  color: var(--game-text-primary);
+  background: var(--game-surface-bg-start);
+  border: 1px solid var(--game-surface-border);
+  border-radius: 6px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.export-html-dialog-input:focus {
+  border-color: var(--base-solid-primary);
+  box-shadow: 0 0 0 2px var(--base-alpha-primary-20);
+}
+
+.export-html-dialog-fieldset {
+  margin: 0 0 0.75rem;
+  border: none;
+  padding: 0;
+}
+
+.export-html-dialog-radio-group {
+  display: flex;
+  gap: 1rem;
+}
+
+.export-html-dialog-radio-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  color: var(--game-text-primary);
+  cursor: pointer;
+}
+
+.export-html-dialog-toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.export-html-dialog-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  color: var(--game-text-primary);
+  cursor: pointer;
+}
+
+.export-html-dialog-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.export-html-dialog-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--game-surface-border);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.export-html-dialog-btn:focus-visible {
+  outline: 2px solid var(--base-solid-primary);
+  outline-offset: 2px;
+}
+
+.export-html-dialog-btn-export {
+  background: var(--base-solid-primary);
+  color: var(--game-text-contrast);
+  border-color: var(--base-solid-primary);
+}
+
+.export-html-dialog-btn-export:hover {
+  opacity: 0.9;
+}
+
+.export-html-dialog-btn-cancel {
+  background: transparent;
+  color: var(--game-text-secondary);
+}
+
+.export-html-dialog-btn-cancel:hover {
+  background: var(--game-surface-bg-start);
+}
+</style>

--- a/src/features/ide/composables/useHtmlExporter.ts
+++ b/src/features/ide/composables/useHtmlExporter.ts
@@ -1,0 +1,64 @@
+/**
+ * useHtmlExporter composable
+ *
+ * Orchestrates exporting an F-BASIC program as a standalone HTML file.
+ * This is a stub — the actual export logic will be implemented in later steps
+ * (issues tracking parent #538).
+ */
+
+import { ref } from 'vue'
+
+import type { CompactBg } from '@/core/types/program-types'
+
+/** Options for the HTML export. */
+export interface HtmlExportOptions {
+  /** Title for the exported HTML page. */
+  title: string
+  /** Theme to use: 'dark' or 'light'. */
+  theme: 'dark' | 'light'
+  /** Whether to include sound data in the export. */
+  includeSound: boolean
+  /** Whether to include sprite data in the export. */
+  includeSprites: boolean
+}
+
+/**
+ * Composable for exporting an F-BASIC program as a standalone HTML file.
+ *
+ * @param _source - The F-BASIC program source code (unused in stub)
+ * @param _bg - Optional BG data (unused in stub)
+ * @returns Reactive export state and the exportHtml function
+ */
+export function useHtmlExporter(
+  _source: { value: string },
+  _bg?: { value: CompactBg | undefined },
+) {
+  const isExporting = ref(false)
+  const exportError = ref('')
+
+  /**
+   * Triggers the HTML export with the given options.
+   *
+   * @param _options - Export configuration options
+   */
+  async function exportHtml(_options: HtmlExportOptions): Promise<void> {
+    isExporting.value = true
+    exportError.value = ''
+
+    try {
+      // Stub: actual export logic will be implemented in later steps.
+      // For now, simulate a brief async operation.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    } catch (err) {
+      exportError.value = err instanceof Error ? err.message : String(err)
+    } finally {
+      isExporting.value = false
+    }
+  }
+
+  return {
+    isExporting,
+    exportError,
+    exportHtml,
+  }
+}

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -546,6 +546,20 @@
     "tooLarge": "This program is too large to share via URL.",
     "loadFailed": "Failed to load shared program"
   },
+  "exportHtml": {
+    "title": "Export as HTML",
+    "description": "Export your program as a standalone HTML file that runs in any browser.",
+    "titleLabel": "Page Title",
+    "themeLabel": "Theme",
+    "themeDark": "Dark",
+    "themeLight": "Light",
+    "includeSound": "Include sound",
+    "includeSprites": "Include sprites",
+    "exportButton": "Export",
+    "cancelButton": "Cancel",
+    "exporting": "Exporting...",
+    "exportFailed": "Failed to export HTML file."
+  },
   "tutorial": {
     "title": "Tutorial",
     "defaultTitle": "F-BASIC Tutorial",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -546,6 +546,20 @@
     "tooLarge": "このプログラムはURLで共有するには大きすぎます。",
     "loadFailed": "共有プログラムの読み込みに失敗しました"
   },
+  "exportHtml": {
+    "title": "HTMLとしてエクスポート",
+    "description": "プログラムをスタンドアロンHTMLファイルとしてエクスポートします。",
+    "titleLabel": "ページタイトル",
+    "themeLabel": "テーマ",
+    "themeDark": "ダーク",
+    "themeLight": "ライト",
+    "includeSound": "サウンドを含む",
+    "includeSprites": "スプライトを含む",
+    "exportButton": "エクスポート",
+    "cancelButton": "キャンセル",
+    "exporting": "エクスポート中...",
+    "exportFailed": "HTMLファイルのエクスポートに失敗しました。"
+  },
   "tutorial": {
     "title": "チュートリアル",
     "defaultTitle": "F-BASICチュートリアル",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -546,6 +546,20 @@
     "tooLarge": "此程序过大，无法通过链接分享。",
     "loadFailed": "加载分享程序失败"
   },
+  "exportHtml": {
+    "title": "导出为 HTML",
+    "description": "将程序导出为可在任意浏览器中运行的独立 HTML 文件。",
+    "titleLabel": "页面标题",
+    "themeLabel": "主题",
+    "themeDark": "深色",
+    "themeLight": "浅色",
+    "includeSound": "包含声音",
+    "includeSprites": "包含精灵",
+    "exportButton": "导出",
+    "cancelButton": "取消",
+    "exporting": "正在导出...",
+    "exportFailed": "导出 HTML 文件失败。"
+  },
   "tutorial": {
     "title": "教程",
     "defaultTitle": "F-BASIC 教程",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -546,6 +546,20 @@
     "tooLarge": "此程式過大，無法透過連結分享。",
     "loadFailed": "載入分享程式失敗"
   },
+  "exportHtml": {
+    "title": "匯出為 HTML",
+    "description": "將程式匯出為可在任意瀏覽器中執行的獨立 HTML 檔案。",
+    "titleLabel": "頁面標題",
+    "themeLabel": "主題",
+    "themeDark": "深色",
+    "themeLight": "淺色",
+    "includeSound": "包含聲音",
+    "includeSprites": "包含精靈",
+    "exportButton": "匯出",
+    "cancelButton": "取消",
+    "exporting": "正在匯出...",
+    "exportFailed": "匯出 HTML 檔案失敗。"
+  },
   "tutorial": {
     "title": "教學",
     "defaultTitle": "F-BASIC 教學",

--- a/test/ide/ExportHtmlDialog.test.ts
+++ b/test/ide/ExportHtmlDialog.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, ref } from 'vue'
+
+import type { CompactBg } from '@/core/types/program-types'
+import ExportHtmlDialog from '@/features/ide/components/ExportHtmlDialog.vue'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const mockExportHtml = vi.fn()
+const mockIsExporting = ref(false)
+const mockExportError = ref('')
+
+vi.mock('@/features/ide/composables/useHtmlExporter', () => ({
+  useHtmlExporter: () => ({
+    isExporting: mockIsExporting,
+    exportError: mockExportError,
+    exportHtml: mockExportHtml,
+  }),
+}))
+
+// Stub Teleport so content renders inline (vue-test-utils cannot find
+// teleported elements via wrapper.find since they live outside the VNode tree).
+const teleportStub = defineComponent({
+  name: 'Teleport',
+  props: ['to'],
+  render() {
+    return this.$slots.default?.()
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mountDialog(props: {
+  visible?: boolean
+  source?: string
+  bg?: CompactBg
+} = {}) {
+  return mount(ExportHtmlDialog, {
+    props: {
+      visible: false,
+      source: '10 PRINT "HELLO"',
+      ...props,
+    },
+    global: {
+      stubs: { Teleport: teleportStub },
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ExportHtmlDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsExporting.value = false
+    mockExportError.value = ''
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // -- Visibility ------------------------------------------------------------
+  it('renders nothing when visible is false', () => {
+    const wrapper = mountDialog({ visible: false })
+    expect(wrapper.find('.export-html-dialog-overlay').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders dialog overlay when visible is true', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    expect(wrapper.find('.export-html-dialog-overlay').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('has proper dialog ARIA attributes', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    const overlay = wrapper.find('.export-html-dialog-overlay')
+    expect(overlay.attributes('role')).toEqual('dialog')
+    expect(overlay.attributes('aria-modal')).toEqual('true')
+    expect(overlay.attributes('aria-label')).toEqual('ide.exportHtml.title')
+    wrapper.unmount()
+  })
+
+  // -- Form fields -----------------------------------------------------------
+  it('shows title input, theme selection, sound toggle, and sprites toggle', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="export-html-title-input"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="export-html-theme-dark"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="export-html-theme-light"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="export-html-include-sound"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="export-html-include-sprites"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('title input is editable and bound', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    const input = wrapper.find<HTMLInputElement>('[data-testid="export-html-title-input"]')
+    await input.setValue('My Program')
+
+    expect(input.element.value).toEqual('My Program')
+    wrapper.unmount()
+  })
+
+  it('theme selection works for dark and light', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    const darkRadio = wrapper.find<HTMLInputElement>('[data-testid="export-html-theme-dark"]')
+    const lightRadio = wrapper.find<HTMLInputElement>('[data-testid="export-html-theme-light"]')
+
+    expect(darkRadio.element.checked).toBe(true)
+    expect(lightRadio.element.checked).toBe(false)
+
+    // Select light theme
+    await lightRadio.setValue(true)
+    expect(lightRadio.element.checked).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('sound toggle works', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    const soundCheckbox = wrapper.find<HTMLInputElement>('[data-testid="export-html-include-sound"]')
+    expect(soundCheckbox.element.checked).toBe(true)
+
+    await soundCheckbox.setValue(false)
+    expect(soundCheckbox.element.checked).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('sprites toggle works', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    const spritesCheckbox = wrapper.find<HTMLInputElement>('[data-testid="export-html-include-sprites"]')
+    expect(spritesCheckbox.element.checked).toBe(true)
+
+    await spritesCheckbox.setValue(false)
+    expect(spritesCheckbox.element.checked).toBe(false)
+    wrapper.unmount()
+  })
+
+  // -- Export button ---------------------------------------------------------
+  it('export button calls exportHtml from composable', async () => {
+    mockExportHtml.mockResolvedValue(undefined)
+
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    await wrapper.find('[data-testid="export-html-export-button"]').trigger('click')
+    await nextTick()
+
+    expect(mockExportHtml).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  // -- Cancel button ---------------------------------------------------------
+  it('cancel button emits close event', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    await wrapper.find('[data-testid="export-html-cancel-button"]').trigger('click')
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  // -- Escape key dismissal -------------------------------------------------
+  it('emits close on Escape key press when visible', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('does not emit close on Escape when not visible', () => {
+    const wrapper = mountDialog({ visible: false })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+    expect(wrapper.emitted('close')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  // -- Overlay click dismissal ----------------------------------------------
+  it('emits close when overlay background is clicked', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    const overlay = wrapper.find('.export-html-dialog-overlay')
+    await overlay.trigger('click')
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('does not emit close when dialog content is clicked', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    const dialog = wrapper.find('.export-html-dialog')
+    await dialog.trigger('click')
+
+    expect(wrapper.emitted('close')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  // -- Exporting state -------------------------------------------------------
+  it('shows exporting state while exporting', async () => {
+    mockIsExporting.value = true
+
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="export-html-exporting"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="export-html-exporting"]').text()).toEqual('ide.exportHtml.exporting')
+    wrapper.unmount()
+  })
+
+  it('shows error state when export fails', async () => {
+    mockExportError.value = 'Export failed'
+
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="export-html-error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="export-html-error"]').text()).toEqual('ide.exportHtml.exportFailed')
+    wrapper.unmount()
+  })
+
+  // -- Cleanup --------------------------------------------------------------
+  it('removes keydown listener on unmount', async () => {
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    wrapper.unmount()
+
+    // Dispatching Escape after unmount should not throw
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #630 — Step 1 of 7 for #538 (export programs as standalone HTML)

## Changes
- Created `ExportHtmlDialog.vue` — modal dialog with title input, theme selection (dark/light), include sound/sprites toggles, Export and Cancel buttons
- Created `useHtmlExporter.ts` composable stub with typed `HtmlExportOptions` interface and reactive export state
- Added 13 i18n keys under `ide.exportHtml.*` to all 4 locale files (en, ja, zh-CN, zh-TW)
- Added 17 unit tests covering form rendering, input binding, toggle states, export triggering, loading states, and error handling

## Test plan
- [x] 17/17 ExportHtmlDialog tests pass
- [x] No regression in ShareDialog tests (20/20)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes