### PR TITLE
feat: resolve #620 - create codeGenerator for PLAY statement generation

### DIFF
--- a/src/features/ide/composables/codeGenerator.ts
+++ b/src/features/ide/composables/codeGenerator.ts
@@ -1,0 +1,296 @@
+/**
+ * Code generator for the Visual Music Composer.
+ *
+ * Converts composer state (note data, channel configuration, metadata)
+ * into F-BASIC PLAY statement lines.
+ *
+ * Step 5 of 7 for #536 (Visual Music Composer).
+ */
+
+import type { NoteCellKey } from '@/features/ide/components/pianoRollConstants'
+import {
+  NOTE_NAMES,
+  parseNoteCellKey,
+} from '@/features/ide/components/pianoRollConstants'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Plain data snapshot of composer state for code generation. */
+export interface ComposerState {
+  tempo: number
+  steps: number
+  duration: string
+  envelope: string
+  title: string
+  channelNotes: NoteCellKey[][]
+  channelOctaves: number[]
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum length of a PLAY string before splitting into a variable. */
+const MAX_PLAY_STRING_LENGTH = 32
+
+/** Mapping from duration preset to F-BASIC note length value (1-9). */
+const DURATION_TO_LENGTH: Record<string, number> = {
+  '1/16': 1,
+  '1/8': 3,
+  '1/4': 5,
+  '1/2': 7,
+  '1': 9,
+}
+
+/** Mapping from envelope preset to F-BASIC envelope string. */
+const ENVELOPE_TO_STRING: Record<string, string> = {
+  none: 'M0V15',
+  short: 'M1V3',
+  medium: 'M1V7',
+  long: 'M1V15',
+}
+
+/** Note names by semitone index (0=C, 1=C#, ... 11=B). */
+const NOTE_BY_SEMITONE = [
+  'C', '#C', 'D', '#D', 'E', 'F', '#F', 'G', '#G', 'A', '#A', 'B',
+] as const
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a tempo BPM value (40-240) to F-BASIC T parameter (1-8).
+ *
+ * T1 = fastest (240 BPM), T8 = slowest (40 BPM).
+ * Linear interpolation across the range.
+ */
+function mapTempoToT(tempo: number): number {
+  const clamped = Math.max(40, Math.min(240, tempo))
+  const t = 8 - ((clamped - 40) / 200) * 7
+  return Math.round(t)
+}
+
+/**
+ * Maps a duration preset string to the F-BASIC note length value.
+ */
+function mapDurationToLength(duration: string): number {
+  return DURATION_TO_LENGTH[duration] ?? 5
+}
+
+/**
+ * Maps an envelope preset string to the F-BASIC envelope string.
+ */
+function mapEnvelopeToString(envelope: string): string {
+  return ENVELOPE_TO_STRING[envelope] ?? 'M0V15'
+}
+
+// ---------------------------------------------------------------------------
+// Note parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the semitone index (0-11) and octave from a note name.
+ *
+ * Handles natural notes (C4 -> semitone 0, octave 4) and
+ * sharp notes (F#4 -> semitone 6, octave 4).
+ */
+function parseNoteName(
+  noteName: string
+): { semitone: number; octave: number } | null {
+  if (noteName.length === 0) return null
+
+  const sharpIndex = noteName.indexOf('#')
+  const firstChar = noteName[0] ?? ''
+
+  let notePart: string
+  let octaveStr: string
+
+  if (sharpIndex !== -1) {
+    // Sharp note: "F#4" -> notePart="#F" (F-BASIC format), octaveStr="4"
+    notePart = `#${firstChar}`
+    octaveStr = noteName.slice(sharpIndex + 1)
+  } else {
+    // Natural note: "C4" -> notePart="C", octaveStr="4"
+    notePart = firstChar
+    octaveStr = noteName.slice(1)
+  }
+
+  const semitone = NOTE_BY_SEMITONE.indexOf(
+    notePart as (typeof NOTE_BY_SEMITONE)[number]
+  )
+  if (semitone === -1) return null
+
+  const octave = Number.parseInt(octaveStr, 10)
+  if (Number.isNaN(octave)) return null
+
+  return { semitone, octave }
+}
+
+// ---------------------------------------------------------------------------
+// Channel string builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the PLAY string data for a single channel.
+ *
+ * Converts note cell keys into a sequential string of F-BASIC note
+ * commands. Inserts octave changes when the octave differs from the
+ * current octave, and rests for empty steps.
+ *
+ * Notes are generated from step 0 through the last step that contains
+ * a note. Trailing empty steps after the last note are omitted.
+ *
+ * @param notes - Note cell keys for this channel
+ * @param noteLength - F-BASIC note length value (1-9)
+ */
+function buildChannelString(
+  notes: NoteCellKey[],
+  noteLength: number
+): string {
+  if (notes.length === 0) return ''
+
+  // Group notes by step index
+  const notesByStep = new Map<number, string[]>()
+  let maxStep = 0
+
+  for (const key of notes) {
+    const { noteIndex, stepIndex } = parseNoteCellKey(key)
+    const noteName = NOTE_NAMES[noteIndex]
+    if (!noteName) continue
+
+    if (!notesByStep.has(stepIndex)) {
+      notesByStep.set(stepIndex, [])
+    }
+    notesByStep.get(stepIndex)!.push(noteName)
+
+    if (stepIndex > maxStep) {
+      maxStep = stepIndex
+    }
+  }
+
+  const parts: string[] = []
+  let currentOctave = 4 // F-BASIC PLAY default octave
+
+  for (let step = 0; step <= maxStep; step++) {
+    const noteNames = notesByStep.get(step)
+
+    if (noteNames === undefined) {
+      parts.push(`R${noteLength}`)
+      continue
+    }
+
+    for (const noteName of noteNames) {
+      const parsed = parseNoteName(noteName)
+      if (!parsed) continue
+
+      if (parsed.octave !== currentOctave) {
+        parts.push(`O${parsed.octave}`)
+        currentOctave = parsed.octave
+      }
+
+      parts.push(`${NOTE_BY_SEMITONE[parsed.semitone]}${noteLength}`)
+    }
+  }
+
+  return parts.join('')
+}
+
+// ---------------------------------------------------------------------------
+// Long string splitting
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps a PLAY string into a string variable assignment if it exceeds
+ * the maximum length.
+ *
+ * Short: `10 PLAY "..."`
+ * Long:  `10 A$="...":PLAY A$`
+ */
+function formatPlayLine(
+  lineNumber: number,
+  playString: string
+): string[] {
+  if (playString.length <= MAX_PLAY_STRING_LENGTH) {
+    return [`${lineNumber} PLAY "${playString}"`]
+  }
+
+  const lines: string[] = []
+  const varNames: string[] = []
+  let varIndex = 0
+
+  for (let offset = 0; offset < playString.length;) {
+    const remaining = playString.length - offset
+    const chunkSize = Math.min(remaining, MAX_PLAY_STRING_LENGTH)
+    const chunk = playString.slice(offset, offset + chunkSize)
+    offset += chunkSize
+
+    const varName = String.fromCharCode(65 + varIndex)
+    varNames.push(varName)
+    lines.push(`${lineNumber} ${varName}$="${chunk}"`)
+    lineNumber += 10
+    varIndex++
+  }
+
+  // Play all chunks concatenated with + to preserve all notes
+  lines.push(`${lineNumber} PLAY ${varNames.map((v) => `${v}$`).join('+')}`)
+
+  return lines
+}
+
+// ---------------------------------------------------------------------------
+// Main generator
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates F-BASIC code lines from composer state.
+ *
+ * Produces an array of BASIC program lines (with line numbers)
+ * that play back the composed music using PLAY statements.
+ *
+ * @param state - Composer state snapshot
+ * @returns Array of BASIC line strings
+ */
+export function generatePlayCode(state: ComposerState): string[] {
+  const lines: string[] = []
+  let lineNumber = 10
+
+  // Title as REM comment
+  if (state.title.trim()) {
+    lines.push(`${lineNumber} REM ${state.title.trim()}`)
+    lineNumber += 10
+  }
+
+  // Build per-channel strings
+  const channelStrings: string[] = []
+  for (let ch = 0; ch < 3; ch++) {
+    const chNotes = state.channelNotes[ch] ?? []
+    const chString = buildChannelString(
+      chNotes,
+      mapDurationToLength(state.duration)
+    )
+    if (chString) {
+      channelStrings.push(chString)
+    }
+  }
+
+  // No notes at all
+  if (channelStrings.length === 0) {
+    return lines
+  }
+
+  // Build the prefix: tempo + envelope
+  const tempoStr = `T${mapTempoToT(state.tempo)}`
+  const envelopeStr = mapEnvelopeToString(state.envelope)
+
+  // Join channels with colon
+  const combinedString = `${tempoStr}${envelopeStr}${channelStrings.join(':')}`
+
+  // Format the PLAY line(s)
+  const playLines = formatPlayLine(lineNumber, combinedString)
+  lines.push(...playLines)
+
+  return lines
+}

--- a/test/features/ide/composables/codeGenerator.integration.test.ts
+++ b/test/features/ide/composables/codeGenerator.integration.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import type { NoteCellKey } from '@/features/ide/components/pianoRollConstants'
+import { createNoteCellKey } from '@/features/ide/components/pianoRollConstants'
+import type { ComposerState } from '@/features/ide/composables/codeGenerator'
+import { generatePlayCode } from '@/features/ide/composables/codeGenerator'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeState(
+  overrides: Partial<ComposerState> = {}
+): ComposerState {
+  return {
+    tempo: 120,
+    steps: 16,
+    duration: '1/4',
+    envelope: 'none',
+    title: '',
+    channelNotes: [[], [], []],
+    channelOctaves: [4, 4, 4],
+    ...overrides,
+  }
+}
+
+// NOTE_NAMES index reference (reversed order, 0=B5 highest, 35=C3 lowest):
+//   0: B5   1: A#5  2: A5   3: G#5  4: G5   5: F#5  6: F5   7: E5
+//   8: D#5  9: D5  10: C#5 11: C5  12: B4  13: A#4 14: A4  15: G#4
+//  16: G4  17: F#4 18: F4  19: E4  20: D#4 21: D4  22: C#4 23: C4
+//  24: B3  25: A#3 26: A3  27: G#3 28: G3  29: F#3 30: F3  31: E3
+//  32: D#3 33: D3  34: C#3 35: C3
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('generatePlayCode integration', () => {
+  // -------------------------------------------------------------------------
+  // Multi-channel output
+  // -------------------------------------------------------------------------
+
+  describe('multi-channel', () => {
+    it('joins channel strings with colon separator', () => {
+      const ch0Notes: NoteCellKey[] = [createNoteCellKey(23, 0)] // C4
+      const ch1Notes: NoteCellKey[] = [createNoteCellKey(16, 0)] // G4
+      const state = makeState({
+        channelNotes: [ch0Notes, ch1Notes, []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15C5:G5"',
+      ])
+    })
+
+    it('handles all 3 channels', () => {
+      const ch0Notes: NoteCellKey[] = [createNoteCellKey(23, 0)] // C4
+      const ch1Notes: NoteCellKey[] = [createNoteCellKey(16, 0)] // G4
+      const ch2Notes: NoteCellKey[] = [createNoteCellKey(19, 0)] // E4
+      const state = makeState({
+        channelNotes: [ch0Notes, ch1Notes, ch2Notes],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15C5:G5:E5"',
+      ])
+    })
+
+    it('only includes channels with notes', () => {
+      const ch2Notes: NoteCellKey[] = [createNoteCellKey(19, 0)] // E4
+      const state = makeState({
+        channelNotes: [[], [], ch2Notes],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15E5"',
+      ])
+    })
+
+    it('uses note octave from note name, not channel octave', () => {
+      const ch0Notes: NoteCellKey[] = [createNoteCellKey(23, 0)] // C4 (octave 4)
+      const ch1Notes: NoteCellKey[] = [createNoteCellKey(11, 0)] // C5 (octave 5)
+      const state = makeState({
+        channelNotes: [ch0Notes, ch1Notes, []],
+        channelOctaves: [3, 5, 4],
+      })
+
+      const lines = generatePlayCode(state)
+
+      // Note octave comes from the note name, not the channel setting
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15C5:O5C5"',
+      ])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Title / REM
+  // -------------------------------------------------------------------------
+
+  describe('title handling', () => {
+    it('includes REM line with title when title is set', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        title: 'Mary Had a Little Lamb',
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 REM Mary Had a Little Lamb',
+        '20 PLAY "T5M0V15C5"',
+      ])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Line numbering
+  // -------------------------------------------------------------------------
+
+  describe('line numbering', () => {
+    it('numbers lines starting at 10 with step 10', () => {
+      const ch0Notes: NoteCellKey[] = [
+        createNoteCellKey(23, 0),
+        createNoteCellKey(19, 1),
+      ]
+      const state = makeState({
+        title: 'Test',
+        channelNotes: [ch0Notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toMatch(/^10 /)
+      expect(lines[1]).toMatch(/^20 /)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Long PLAY string splitting
+  // -------------------------------------------------------------------------
+
+  describe('long string handling', () => {
+    it('splits long PLAY string and concatenates all chunks', () => {
+      const notes: NoteCellKey[] = []
+      for (let step = 0; step < 16; step++) {
+        notes.push(createNoteCellKey(23, step))
+      }
+      const state = makeState({
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines.length).toBeGreaterThanOrEqual(3)
+      const lastLine = lines[lines.length - 1]
+      expect(lastLine).toMatch(/PLAY [A-Z]\$\+[A-Z]\$/)
+
+      // Verify all notes are present across variable assignments (no data loss)
+      const varAssignments = lines.filter((l) => l.includes('$="'))
+      const totalNoteChars = varAssignments.reduce((sum, line) => {
+        const match = line.match(/\$="([^"]*)"/)
+        return sum + (match?.[1] ? match[1].replace(/^T\dM\dV\d+/, '').length : 0)
+      }, 0)
+      // 16 notes × 2 chars each (C5) = 32 note characters
+      expect(totalNoteChars).toEqual(32)
+    })
+
+    it('uses inline PLAY for short strings', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15C5"',
+      ])
+    })
+  })
+})

--- a/test/features/ide/composables/codeGenerator.test.ts
+++ b/test/features/ide/composables/codeGenerator.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from 'vitest'
+
+import type { NoteCellKey } from '@/features/ide/components/pianoRollConstants'
+import { createNoteCellKey } from '@/features/ide/components/pianoRollConstants'
+import type { ComposerState } from '@/features/ide/composables/codeGenerator'
+import { generatePlayCode } from '@/features/ide/composables/codeGenerator'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeState(
+  overrides: Partial<ComposerState> = {}
+): ComposerState {
+  return {
+    tempo: 120,
+    steps: 16,
+    duration: '1/4',
+    envelope: 'none',
+    title: '',
+    channelNotes: [[], [], []],
+    channelOctaves: [4, 4, 4],
+    ...overrides,
+  }
+}
+
+// NOTE_NAMES index reference (reversed order, 0=B5 highest, 35=C3 lowest):
+//   0: B5   1: A#5  2: A5   3: G#5  4: G5   5: F#5  6: F5   7: E5
+//   8: D#5  9: D5  10: C#5 11: C5  12: B4  13: A#4 14: A4  15: G#4
+//  16: G4  17: F#4 18: F4  19: E4  20: D#4 21: D4  22: C#4 23: C4
+//  24: B3  25: A#3 26: A3  27: G#3 28: G3  29: F#3 30: F3  31: E3
+//  32: D#3 33: D3  34: C#3 35: C3
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('generatePlayCode', () => {
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  describe('empty state', () => {
+    it('returns no lines when all channels are empty', () => {
+      const state = makeState()
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([])
+    })
+
+    it('returns only REM title when channels are empty', () => {
+      const state = makeState({ title: 'My Song' })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual(['10 REM My Song'])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Single note generation
+  // -------------------------------------------------------------------------
+
+  describe('single note', () => {
+    it('generates PLAY statement with tempo, envelope, octave, and note', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(11, 0)] // C5
+      const state = makeState({
+        channelNotes: [notes, [], []],
+        channelOctaves: [4, 4, 4],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15O5C5"',
+      ])
+    })
+
+    it('generates correct note for D4 (index 21)', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(21, 0)]
+      const state = makeState({
+        channelNotes: [notes, [], []],
+        channelOctaves: [4, 4, 4],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15D5"',
+      ])
+    })
+
+    it('generates correct note for sharp F#4 (index 17)', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(17, 0)]
+      const state = makeState({
+        channelNotes: [notes, [], []],
+        channelOctaves: [4, 4, 4],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15#F5"',
+      ])
+    })
+
+    it('generates correct note for C3 (index 35)', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(35, 0)]
+      const state = makeState({
+        channelNotes: [notes, [], []],
+        channelOctaves: [3, 4, 4],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15O3C5"',
+      ])
+    })
+
+    it('generates correct note for B5 (index 0)', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(0, 0)]
+      const state = makeState({
+        channelNotes: [notes, [], []],
+        channelOctaves: [5, 4, 4],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15O5B5"',
+      ])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Multiple notes and rests
+  // -------------------------------------------------------------------------
+
+  describe('multiple notes', () => {
+    it('generates sequential notes sorted by step index', () => {
+      const notes: NoteCellKey[] = [
+        createNoteCellKey(23, 0), // C4
+        createNoteCellKey(19, 1), // E4
+        createNoteCellKey(16, 2), // G4
+      ]
+      const state = makeState({
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15C5E5G5"',
+      ])
+    })
+
+    it('inserts rests for gaps between notes', () => {
+      const notes: NoteCellKey[] = [
+        createNoteCellKey(23, 0), // C4
+        createNoteCellKey(16, 2), // G4
+      ]
+      const state = makeState({
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15C5R5G5"',
+      ])
+    })
+
+    it('inserts rests from the beginning when first note is not at step 0', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(19, 2)] // E4
+      const state = makeState({
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15R5R5E5"',
+      ])
+    })
+
+    it('does not add trailing rests after the last note', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)] // C4
+      const state = makeState({
+        channelNotes: [notes, [], []],
+        steps: 16,
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15C5"',
+      ])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Octave changes
+  // -------------------------------------------------------------------------
+
+  describe('octave changes', () => {
+    it('inserts octave prefix when note crosses octave boundary up', () => {
+      const notes: NoteCellKey[] = [
+        createNoteCellKey(12, 0), // B4
+        createNoteCellKey(11, 1), // C5
+      ]
+      const state = makeState({
+        channelNotes: [notes, [], []],
+        channelOctaves: [4, 4, 4],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15B5O5C5"',
+      ])
+    })
+
+    it('inserts octave prefix when note crosses octave boundary down', () => {
+      const notes: NoteCellKey[] = [
+        createNoteCellKey(11, 0), // C5
+        createNoteCellKey(12, 1), // B4
+      ]
+      const state = makeState({
+        channelNotes: [notes, [], []],
+        channelOctaves: [5, 4, 4],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines).toEqual([
+        '10 PLAY "T5M0V15O5C5O4B5"',
+      ])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Duration mapping
+  // -------------------------------------------------------------------------
+
+  describe('duration mapping', () => {
+    it.each([
+      ['1/16', '1'],
+      ['1/8', '3'],
+      ['1/4', '5'],
+      ['1/2', '7'],
+      ['1', '9'],
+    ] as const)('maps duration %s to length %s', (duration, expectedLength) => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        duration,
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain(`C${expectedLength}"`)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Envelope mapping
+  // -------------------------------------------------------------------------
+
+  describe('envelope mapping', () => {
+    it('maps "none" to M0V15', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        envelope: 'none',
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain('M0V15')
+    })
+
+    it('maps "short" to M1V3', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        envelope: 'short',
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain('M1V3')
+    })
+
+    it('maps "medium" to M1V7', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        envelope: 'medium',
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain('M1V7')
+    })
+
+    it('maps "long" to M1V15', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        envelope: 'long',
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain('M1V15')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Tempo mapping
+  // -------------------------------------------------------------------------
+
+  describe('tempo mapping', () => {
+    it('maps tempo 120 to T5', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        tempo: 120,
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain('T5')
+    })
+
+    it('maps tempo 40 to T8', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        tempo: 40,
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain('T8')
+    })
+
+    it('maps tempo 240 to T1', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        tempo: 240,
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain('T1')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #620 — Step 5 of 7 for #536 (Visual Music Composer)

## Changes
- Created `codeGenerator.ts` composable that converts note data from useComposer to F-BASIC PLAY statements
- Tempo mapping: linear BPM(40-240) → T(1-8), 120 BPM = T5
- Note octave emitted from note name (F-BASIC notation: `#F4` not `F#4`)
- Duration mapping: `1/16`→1, `1/8`→3, `1/4`→5, `1/2`→7, `1`→9
- Long PLAY strings split at 32 chars into string variable assignments
- Rests only between/before notes, never trailing
- 33 tests (25 unit + 8 integration) covering all edge cases

## Test plan
- [ ] Targeted tests pass (33/33)
- [ ] CI passes