### PR TITLE
feat: resolve #621 - add composer route and navigation entry

### DIFF
--- a/src/features/music-composer/MusicComposerPage.vue
+++ b/src/features/music-composer/MusicComposerPage.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { GameLayout } from '@/shared/components/ui'
+
+/**
+ * MusicComposerPage component - Placeholder page for the visual music composer.
+ *
+ * Will be fleshed out with PianoRoll, ComposerControls, and playback features
+ * in subsequent implementation steps (issues #616-#620).
+ */
+defineOptions({
+  name: 'MusicComposerPage',
+})
+</script>
+
+<template>
+  <GameLayout>
+    <div class="music-composer-page">
+      <h1>Music Composer</h1>
+    </div>
+  </GameLayout>
+</template>
+
+<style scoped>
+.music-composer-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -56,6 +56,17 @@ const routes: RouteRecordRaw[] = [
       group: 'tools',
     },
   },
+  {
+    path: '/composer',
+    name: 'Composer',
+    component: () => import('@/features/music-composer/MusicComposerPage.vue'),
+    meta: {
+      title: 'Composer',
+      showInNav: true,
+      icon: 'mdi:music-note',
+      group: 'tools',
+    },
+  },
   // ============================================
   // Testing & Diagnostics
   // ============================================

--- a/src/shared/components/composables/useNavigationRoutes.ts
+++ b/src/shared/components/composables/useNavigationRoutes.ts
@@ -25,6 +25,7 @@ const getItemKey = (routeName: string): string => {
     Home: 'home',
     Ide: 'ide',
     CharacterSpriteViewer: 'spriteViewer',
+    Composer: 'composer',
     PerformanceDiagnostics: 'performanceDiagnostics',
     KonvaSpriteTest: 'konvaSpriteTest',
     PositionSyncLoadTest: 'positionSyncLoadTest',

--- a/src/shared/i18n/locales/en/navigation.json
+++ b/src/shared/i18n/locales/en/navigation.json
@@ -21,6 +21,10 @@
       "name": "Sprite Viewer",
       "description": "View Character Sprites"
     },
+    "composer": {
+      "name": "Composer",
+      "description": "Music Composer"
+    },
     "performanceDiagnostics": {
       "name": "Performance",
       "description": "Performance Diagnostics"

--- a/src/shared/i18n/locales/ja/navigation.json
+++ b/src/shared/i18n/locales/ja/navigation.json
@@ -21,6 +21,10 @@
       "name": "スプライトビューア",
       "description": "キャラクタースプライトを表示"
     },
+    "composer": {
+      "name": "コンポーザー",
+      "description": "ミュージックコンポーザー"
+    },
     "performanceDiagnostics": {
       "name": "パフォーマンス",
       "description": "パフォーマンス診断"

--- a/src/shared/i18n/locales/zh-CN/navigation.json
+++ b/src/shared/i18n/locales/zh-CN/navigation.json
@@ -21,6 +21,10 @@
       "name": "精灵查看器",
       "description": "查看角色精灵"
     },
+    "composer": {
+      "name": "作曲器",
+      "description": "音乐作曲器"
+    },
     "performanceDiagnostics": {
       "name": "性能诊断",
       "description": "性能诊断工具"

--- a/src/shared/i18n/locales/zh-TW/navigation.json
+++ b/src/shared/i18n/locales/zh-TW/navigation.json
@@ -21,6 +21,10 @@
       "name": "精靈檢視器",
       "description": "檢視角色精靈"
     },
+    "composer": {
+      "name": "作曲器",
+      "description": "音樂作曲器"
+    },
     "performanceDiagnostics": {
       "name": "效能診斷",
       "description": "效能診斷工具"

--- a/test/features/music-composer/MusicComposerPage.test.ts
+++ b/test/features/music-composer/MusicComposerPage.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { type Component,defineComponent } from 'vue'
+
+// Stub GameLayout to avoid pulling in GameNavigation and its heavy deps
+const gameLayoutStub = defineComponent({
+  name: 'GameLayout',
+  template: '<div class="game-layout-stub"><slot /></div>',
+})
+
+vi.mock('@/shared/components/ui', () => ({
+  GameLayout: gameLayoutStub,
+}))
+
+// Stub vue-i18n
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: ref('en'),
+  }),
+}))
+
+// Stub vue-router
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ path: '/composer' }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+describe('MusicComposerPage', () => {
+  it('mounts with component name MusicComposerPage', async () => {
+    const { default: pageComponent } = (await import(
+      '@/features/music-composer/MusicComposerPage.vue'
+    )) as { default: Component }
+
+    const wrapper = mount(pageComponent, {
+      global: {
+        stubs: {
+          GameLayout: gameLayoutStub,
+          RouterView: true,
+        },
+      },
+    })
+
+    const vm = wrapper.vm as { $options: { name: string } }
+    expect(vm.$options.name).toEqual('MusicComposerPage')
+    wrapper.unmount()
+  })
+
+  it('renders a placeholder heading with "Music Composer"', async () => {
+    const { default: pageComponent } = (await import(
+      '@/features/music-composer/MusicComposerPage.vue'
+    )) as { default: Component }
+
+    const wrapper = mount(pageComponent, {
+      global: {
+        stubs: {
+          GameLayout: gameLayoutStub,
+          RouterView: true,
+        },
+      },
+    })
+
+    const heading = wrapper.find('h1')
+    expect(heading.exists()).toBe(true)
+    expect(heading.text()).toEqual('Music Composer')
+    wrapper.unmount()
+  })
+
+  it('uses GameLayout as root container', async () => {
+    const { default: pageComponent } = (await import(
+      '@/features/music-composer/MusicComposerPage.vue'
+    )) as { default: Component }
+
+    const wrapper = mount(pageComponent, {
+      global: {
+        stubs: {
+          GameLayout: gameLayoutStub,
+          RouterView: true,
+        },
+      },
+    })
+
+    expect(wrapper.find('.game-layout-stub').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})

--- a/test/router/composerRoute.test.ts
+++ b/test/router/composerRoute.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { RouteRecordNormalized } from 'vue-router'
+
+// Stub vue-i18n for router (needed by i18n module)
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: ref('en'),
+  }),
+  createI18n: vi.fn(() => ({})),
+}))
+
+describe('Router composer route', () => {
+  it('has a /composer route with name Composer', async () => {
+    const router = await import('@/router/index')
+    const routes = router.default.getRoutes()
+
+    const composerRoute = routes.find(
+      (r: RouteRecordNormalized) => r.name === 'Composer',
+    )
+
+    expect(composerRoute).toBeDefined()
+    expect(composerRoute!.path).toEqual('/composer')
+  })
+
+  it('has correct meta for the composer route', async () => {
+    const router = await import('@/router/index')
+    const routes = router.default.getRoutes()
+
+    const composerRoute = routes.find(
+      (r: RouteRecordNormalized) => r.name === 'Composer',
+    )
+
+    expect(composerRoute).toBeDefined()
+    expect(composerRoute!.meta).toEqual({
+      title: 'Composer',
+      showInNav: true,
+      icon: 'mdi:music-note',
+      group: 'tools',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #621 — Step 6 of 7 for #536 (visual music composer / sequencer)

## Changes
- Added `/composer` route to router with meta (title, showInNav, icon, group)
- Added `Composer` entry to `useNavigationRoutes` nameMap
- Created `MusicComposerPage.vue` placeholder page with GameLayout and heading
- Added composer navigation i18n strings to all 4 locale files (en, ja, zh-CN, zh-TW)
- Added 5 unit tests (3 component + 2 router configuration)

## Test plan
- [x] 5/5 new tests pass (3 MusicComposerPage + 2 composerRoute)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes