### PR TITLE
refactor: resolve #759 - extract shared isValidChannelIndex and CHANNEL_COUNT to eliminate duplication

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -165,6 +165,19 @@ export const TIMING = {
   COPIED_FEEDBACK_MS: 2000, // Duration of "Copied!" feedback state in share dialog
 } as const
 
+// Sound constants
+/** Number of independent audio channels in F-BASIC. */
+export const CHANNEL_COUNT = 3
+
+/**
+ * Returns true if the given index is a valid channel index (0 to CHANNEL_COUNT - 1).
+ *
+ * Shared by the composer UI (useComposer) and the execution layer (SoundService).
+ */
+export function isValidChannelIndex(index: number): boolean {
+  return !Number.isNaN(index) && index >= 0 && index < CHANNEL_COUNT
+}
+
 // Screen dimensions and coordinate limits
 export const SCREEN_DIMENSIONS = {
   BACKGROUND: {

--- a/src/core/execution/sound/SoundService.ts
+++ b/src/core/execution/sound/SoundService.ts
@@ -9,12 +9,10 @@
  * This service compiles that symbolic data to audio using channel-specific state.
  */
 
+import { CHANNEL_COUNT } from '@/core/constants'
 import { compileToAudio, parseMusicToAst } from '@/core/sound/MusicDSLParser'
 import { SoundStateManager } from '@/core/sound/SoundStateManager'
 import type { CompiledAudio } from '@/core/sound/types'
-
-/** Number of independent audio channels (F-BASIC supports 3) */
-const CHANNEL_COUNT = 3
 
 /**
  * Service for managing sound state and compiling music.

--- a/src/features/ide/composables/useComposer.ts
+++ b/src/features/ide/composables/useComposer.ts
@@ -10,6 +10,7 @@
 
 import { computed, ref } from 'vue'
 
+import { CHANNEL_COUNT, isValidChannelIndex } from '@/core/constants'
 import {
   DEFAULT_DURATION,
   DEFAULT_ENVELOPE,
@@ -19,18 +20,6 @@ import {
 } from '@/features/ide/components/composerControlsConstants'
 import type { NoteCellKey } from '@/features/ide/components/pianoRollConstants'
 import { createNoteCellKey } from '@/features/ide/components/pianoRollConstants'
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** Number of sound channels in F-BASIC. */
-const CHANNEL_COUNT = 3
-
-/** Returns true if the given index is a valid channel index (0 to CHANNEL_COUNT - 1). */
-function isValidChannelIndex(index: number): boolean {
-  return !Number.isNaN(index) && index >= 0 && index < CHANNEL_COUNT
-}
 
 // ---------------------------------------------------------------------------
 // Module-level singleton state


### PR DESCRIPTION
## Summary
- Fixes #759 — eliminates duplicated `CHANNEL_COUNT = 3` and `isValidChannelIndex()` across `useComposer.ts` and `SoundService.ts`

## Changes
- Added `CHANNEL_COUNT` and `isValidChannelIndex()` exports to `src/core/constants.ts` (new "Sound constants" section)
- Updated `useComposer.ts` to import from shared constants, removed local definitions
- Updated `SoundService.ts` to import `CHANNEL_COUNT` from shared constants, removed local definition
- Net change: +15/-15 (pure extraction, no behavior change)

## Test plan
- [x] 42/42 useComposer tests pass (before and after refactor)
- [x] 10/10 octave validation tests pass
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes