### PR TITLE
refactor: resolve #756 - extract shared extractCodeBlocks test helper from tutorial lesson tests

### DIFF
--- a/src/features/ide/tutorial/index.ts
+++ b/src/features/ide/tutorial/index.ts
@@ -1,8 +1,8 @@
 /**
- * Barrel export for basics tutorial lessons (1-5).
+ * Barrel export for tutorial lesson data files.
  *
  * Imports all individual lesson modules and exports them
- * as a single ordered array for consumption by TutorialPanel.vue.
+ * as ordered arrays for consumption by TutorialPanel.vue.
  */
 
 import { lesson1Print } from './lessons/lesson1Print'
@@ -10,6 +10,9 @@ import { lesson2Variables } from './lessons/lesson2Variables'
 import { lesson3Input } from './lessons/lesson3Input'
 import { lesson4IfThen } from './lessons/lesson4IfThen'
 import { lesson5ForNext } from './lessons/lesson5ForNext'
+import { lesson6Cls } from './lessons/lesson6Cls'
+import { lesson7Color } from './lessons/lesson7Color'
+import { lesson8Locate } from './lessons/lesson8Locate'
 import type { Lesson } from './types'
 
 /**
@@ -28,4 +31,18 @@ export const basicsLessons: Lesson[] = [
   lesson3Input,
   lesson4IfThen,
   lesson5ForNext,
+]
+
+/**
+ * Ordered array of screen tutorial lessons.
+ *
+ * Lesson order:
+ * 6. CLS — clearing the screen
+ * 7. COLOR — setting text and background colors
+ * 8. LOCATE — cursor positioning and screen functions
+ */
+export const screenLessons: Lesson[] = [
+  lesson6Cls,
+  lesson7Color,
+  lesson8Locate,
 ]

--- a/src/features/ide/tutorial/index.ts
+++ b/src/features/ide/tutorial/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Barrel export for basics tutorial lessons (1-5).
+ *
+ * Imports all individual lesson modules and exports them
+ * as a single ordered array for consumption by TutorialPanel.vue.
+ */
+
+import { lesson1Print } from './lessons/lesson1Print'
+import { lesson2Variables } from './lessons/lesson2Variables'
+import { lesson3Input } from './lessons/lesson3Input'
+import { lesson4IfThen } from './lessons/lesson4IfThen'
+import { lesson5ForNext } from './lessons/lesson5ForNext'
+import type { Lesson } from './types'
+
+/**
+ * Ordered array of basics tutorial lessons.
+ *
+ * Lesson order:
+ * 1. PRINT — output text and values to screen
+ * 2. Variables — numeric and string variables, assignment
+ * 3. INPUT — getting user input
+ * 4. IF/THEN — conditional execution
+ * 5. FOR/NEXT — loops
+ */
+export const basicsLessons: Lesson[] = [
+  lesson1Print,
+  lesson2Variables,
+  lesson3Input,
+  lesson4IfThen,
+  lesson5ForNext,
+]

--- a/src/features/ide/tutorial/lessons/lesson1Print.ts
+++ b/src/features/ide/tutorial/lessons/lesson1Print.ts
@@ -1,0 +1,74 @@
+/**
+ * Lesson 1: PRINT — Output text and values to screen.
+ *
+ * Covers the PRINT statement, its `?` abbreviation,
+ * and the `;` and `,` separators for controlling output format.
+ */
+
+import type { Lesson } from '../types'
+
+export const lesson1Print: Lesson = {
+  title: 'PRINT',
+
+  content: [
+    '# Lesson 1: PRINT',
+
+    'The `PRINT` command displays text and values on the screen.',
+    'It is one of the most useful commands in BASIC.',
+    'You can also write `?` as a shorthand for `PRINT`.',
+
+    '## Printing Text',
+
+    'To display a message, put it inside double quotes:',
+
+    '```basic',
+    '10 PRINT "HELLO WORLD"',
+    '```',
+
+    'You can use `?` as an abbreviation:',
+
+    '```basic',
+    '10 ? "HELLO WORLD"',
+    '```',
+
+    '## Printing Numbers',
+
+    '`PRINT` can also display numbers and the results of calculations:',
+
+    '```basic',
+    '10 PRINT 100',
+    '20 PRINT 3+5',
+    '```',
+
+    '## Combining Text and Numbers',
+
+    'Use `;` to join multiple items on the same line.',
+    'A space is automatically added before positive numbers:',
+
+    '```basic',
+    '10 A=42',
+    '20 PRINT "ANSWER=";A',
+    '```',
+
+    '## Controlling Newlines',
+
+    'Normally `PRINT` adds a newline at the end.',
+    'Add `;` at the end to continue on the same line:',
+
+    '```basic',
+    '10 PRINT "A";',
+    '20 PRINT "B";',
+    '30 PRINT "C"',
+    '```',
+
+    '## Try It',
+
+    'Try these examples to see what `PRINT` can do:',
+
+    '```basic',
+    '10 PRINT "HELLO!"',
+    '20 PRINT 7*8',
+    '30 PRINT "SCORE:";100',
+    '```',
+  ].join('\n\n'),
+}

--- a/src/features/ide/tutorial/lessons/lesson2Variables.ts
+++ b/src/features/ide/tutorial/lessons/lesson2Variables.ts
@@ -1,0 +1,84 @@
+/**
+ * Lesson 2: Variables — Numeric and string variables, assignment.
+ *
+ * Covers numeric variables, string variables (ending with $),
+ * the 2-character name distinction rule, and default values.
+ */
+
+import type { Lesson } from '../types'
+
+export const lesson2Variables: Lesson = {
+  title: 'Variables',
+
+  content: [
+    '# Lesson 2: Variables',
+
+    'A **variable** is a named box that stores a value.',
+    'You assign values with `=` and use the variable name',
+    'to recall the value later.',
+
+    '## Numeric Variables',
+
+    'Numeric variables hold numbers. Assign them like this:',
+
+    '```basic',
+    '10 A=10',
+    '20 B=25',
+    '30 PRINT A+B',
+    '```',
+
+    'Variable names start with a letter.',
+    'The computer uses only the **first 2 characters** to',
+    'tell variables apart, so `SCORE` and `SC` are the same:',
+
+    '```basic',
+    '10 SC=100',
+    '20 SCORE=200',
+    '30 PRINT SC',
+    '```',
+
+    '## String Variables',
+
+    'String variables hold text. Their names end with `$`:',
+
+    '```basic',
+    '10 A$="MARIO"',
+    '20 B$="LUIGI"',
+    '30 PRINT A$',
+    '40 PRINT B$',
+    '```',
+
+    'Just like numeric variables, only the first 2 characters',
+    'of the name matter. `NA$` and `NAME$` refer to the same variable.',
+
+    '## Combining Strings',
+
+    'Use `+` to join two string variables:',
+
+    '```basic',
+    '10 A$="FAMILY"',
+    '20 B$=" BASIC"',
+    '30 PRINT A$+B$',
+    '```',
+
+    '## Default Values',
+
+    'A numeric variable you have not assigned yet equals **0**.',
+    'A string variable you have not assigned yet equals **""** (empty):',
+
+    '```basic',
+    '10 PRINT X',
+    '20 PRINT Z$',
+    '```',
+
+    '## Try It',
+
+    '```basic',
+    '10 A=7',
+    '20 B=3',
+    '30 PRINT "A+B=";A+B',
+    '40 N$="RESULT"',
+    '50 PRINT N$;"=";A*B',
+    '```',
+  ].join('\n\n'),
+}

--- a/src/features/ide/tutorial/lessons/lesson3Input.ts
+++ b/src/features/ide/tutorial/lessons/lesson3Input.ts
@@ -1,0 +1,69 @@
+/**
+ * Lesson 3: INPUT — Getting user input from the keyboard.
+ *
+ * Covers the INPUT statement with prompt strings,
+ * numeric and string variable input, and basic usage patterns.
+ */
+
+import type { Lesson } from '../types'
+
+export const lesson3Input: Lesson = {
+  title: 'INPUT',
+
+  content: [
+    '# Lesson 3: INPUT',
+
+    'The `INPUT` command waits for the user to type something',
+    'on the keyboard and stores it in a variable.',
+
+    '## Basic Input',
+
+    'When `INPUT` runs, a `?` appears on screen.',
+    'Type a value and press RETURN:',
+
+    '```basic',
+    '10 INPUT A',
+    '20 PRINT "YOU TYPED:";A',
+    '```',
+
+    '## Adding a Prompt',
+
+    'You can display a message before the `?` by placing',
+    'a text string followed by `;`:',
+
+    '```basic',
+    '10 INPUT "YOUR NAME";N$',
+    '20 PRINT "HELLO,";N$;"!"',
+    '```',
+
+    '## Numeric Input',
+
+    '`INPUT` works with numeric variables too.',
+    'The computer converts the typed text into a number:',
+
+    '```basic',
+    '10 INPUT "A=";A',
+    '20 INPUT "B=";B',
+    '30 PRINT "A+B=";A+B',
+    '```',
+
+    '## String Input',
+
+    'For string variables, whatever you type is stored as text.',
+
+    '```basic',
+    '10 INPUT "TYPE SOMETHING";W$',
+    '20 PRINT "YOU SAID:";W$',
+    '```',
+
+    '## Try It',
+
+    'Try this small program that asks for your name and age:',
+
+    '```basic',
+    '10 INPUT "NAME";N$',
+    '20 INPUT "AGE";A',
+    '30 PRINT N$;" IS ";A;" YEARS OLD"',
+    '```',
+  ].join('\n\n'),
+}

--- a/src/features/ide/tutorial/lessons/lesson4IfThen.ts
+++ b/src/features/ide/tutorial/lessons/lesson4IfThen.ts
@@ -1,0 +1,80 @@
+/**
+ * Lesson 4: IF/THEN — Conditional execution.
+ *
+ * Covers the IF...THEN statement for branching logic,
+ * comparison operators, and jumping to line numbers.
+ */
+
+import type { Lesson } from '../types'
+
+export const lesson4IfThen: Lesson = {
+  title: 'IF / THEN',
+
+  content: [
+    '# Lesson 4: IF / THEN',
+
+    'The `IF...THEN` statement lets your program make decisions.',
+    'It checks a condition and runs a command only when',
+    'the condition is true.',
+
+    '## Basic Syntax',
+
+    '```basic',
+    'IF condition THEN command',
+    '```',
+
+    'If the condition is **true**, the command after `THEN` runs.',
+    'If the condition is **false**, the program skips to the next line.',
+
+    '## Comparison Operators',
+
+    'You can compare values using these operators:',
+
+    '- `=` — equal to',
+    '- `<>` — not equal to',
+    '- `>` — greater than',
+    '- `<` — less than',
+    '- `>=` — greater than or equal to',
+    '- `<=` — less than or equal to',
+
+    '## Simple Example',
+
+    '```basic',
+    '10 A=10',
+    '20 IF A=10 THEN PRINT "A IS 10"',
+    '30 IF A>5 THEN PRINT "A IS BIG"',
+    '40 IF A<5 THEN PRINT "A IS SMALL"',
+    '```',
+
+    '## Jumping to a Line Number',
+
+    'Instead of a command, you can put a line number after `THEN`',
+    'to jump to that line:',
+
+    '```basic',
+    '10 A=0',
+    '20 IF A=0 THEN 50',
+    '30 PRINT "THIS LINE IS SKIPPED"',
+    '40 END',
+    '50 PRINT "JUMPED TO LINE 50"',
+    '```',
+
+    '## Comparing Strings',
+
+    'You can also compare string variables:',
+
+    '```basic',
+    '10 A$="YES"',
+    '20 IF A$="YES" THEN PRINT "OK!"',
+    '30 IF A$<>"NO" THEN PRINT "NOT NO"',
+    '```',
+
+    '## Try It',
+
+    '```basic',
+    '10 INPUT "SCORE";S',
+    '20 IF S>=100 THEN PRINT "GREAT!"',
+    '30 IF S<100 THEN PRINT "KEEP TRYING"',
+    '```',
+  ].join('\n\n'),
+}

--- a/src/features/ide/tutorial/lessons/lesson5ForNext.ts
+++ b/src/features/ide/tutorial/lessons/lesson5ForNext.ts
@@ -1,0 +1,74 @@
+/**
+ * Lesson 5: FOR/NEXT — Loops for repeating actions.
+ *
+ * Covers the FOR...TO...NEXT loop, optional STEP,
+ * counting up and down, and basic nested loops.
+ */
+
+import type { Lesson } from '../types'
+
+export const lesson5ForNext: Lesson = {
+  title: 'FOR / NEXT',
+
+  content: [
+    '# Lesson 5: FOR / NEXT',
+
+    'The `FOR...NEXT` loop repeats a block of code a set',
+    'number of times. It is one of the most powerful tools',
+    'in BASIC programming.',
+
+    '## Basic Loop',
+
+    'A loop needs a **variable**, a **start value**, and an **end value**:',
+
+    '```basic',
+    '10 FOR I=1 TO 5',
+    '20 PRINT I',
+    '30 NEXT',
+    '```',
+
+    'This prints the numbers 1 through 5.',
+    'The loop variable `I` starts at 1 and increases by 1',
+    'each time `NEXT` is reached, stopping after 5.',
+
+    '## Using STEP',
+
+    'You can change how much the variable increases',
+    'with the `STEP` keyword:',
+
+    '```basic',
+    '10 FOR I=0 TO 10 STEP 2',
+    '20 PRINT I;',
+    '30 NEXT',
+    '```',
+
+    'Use a negative step to count down:',
+
+    '```basic',
+    '10 FOR I=5 TO 1 STEP -1',
+    '20 PRINT I;',
+    '30 NEXT',
+    '```',
+
+    '## Loops with PRINT',
+
+    'Loops are great for drawing patterns with text:',
+
+    '```basic',
+    '10 FOR I=1 TO 10',
+    '20 PRINT "*";',
+    '30 NEXT',
+    '40 PRINT',
+    '```',
+
+    '## Try It',
+
+    'Try combining loops with what you have learned so far:',
+
+    '```basic',
+    '10 FOR I=1 TO 3',
+    '20 PRINT "HELLO #";I',
+    '30 NEXT',
+    '```',
+  ].join('\n\n'),
+}

--- a/src/features/ide/tutorial/lessons/lesson6Cls.ts
+++ b/src/features/ide/tutorial/lessons/lesson6Cls.ts
@@ -1,0 +1,92 @@
+/**
+ * Lesson 6: CLS — Clearing the screen.
+ *
+ * Covers the CLS command for clearing the background screen,
+ * its use in programs, and combining it with other commands.
+ */
+
+import type { Lesson } from '../types'
+
+export const lesson6Cls: Lesson = {
+  title: 'CLS',
+
+  content: [
+    '# Lesson 6: CLS',
+
+    'The `CLS` command clears the background screen.',
+    'It removes all text and graphics that were displayed.',
+    'This is useful when you want a fresh screen',
+
+    '## Basic Usage',
+
+    'Use `CLS` on its own to clear the screen:',
+
+    '```basic',
+    '10 CLS',
+    '```',
+
+    'After clearing, the cursor moves to the top-left',
+    'corner of the screen.',
+
+    '## Clearing Before Output',
+
+    'It is common to use `CLS` at the beginning of a',
+    'program so the screen starts clean:',
+
+    '```basic',
+    '10 CLS',
+    '20 PRINT "WELCOME TO MY PROGRAM"',
+    '30 PRINT "===================="',
+    '40 PRINT',
+    '50 PRINT "HELLO!"',
+    '```',
+
+    '## Clearing Between Sections',
+
+    'You can use `CLS` to separate different parts',
+    'of your program. Combined with `PAUSE`, you can',
+    'show one screen, wait, then show another:',
+
+    '```basic',
+    '10 CLS',
+    '20 PRINT "PAGE 1"',
+    '30 PAUSE 100',
+    '40 CLS',
+    '50 PRINT "PAGE 2"',
+    '```',
+
+    '## Combining CLS with Other Commands',
+
+    'You can put `CLS` on the same line as other commands',
+    'using the colon `:` separator:',
+
+    '```basic',
+    '10 CLS:PRINT "FRESH START"',
+    '20 FOR I=1 TO 5',
+    '30 PRINT I;" ";',
+    '40 NEXT',
+    '```',
+
+    '## Important Note',
+
+    '`CLS` clears the **background screen**.',
+    'If you have used `VIEW` to copy BG GRAPHIC',
+    'to the background screen, `CLS` will remove it.',
+    'Use `VIEW` again to restore the graphics.',
+
+    '## Try It',
+
+    'Try this program to see `CLS` in action:',
+
+    '```basic',
+    '10 CLS',
+    '20 FOR I=1 TO 10',
+    '30 PRINT "*";',
+    '40 NEXT',
+    '50 PRINT',
+    '60 PAUSE 100',
+    '70 CLS',
+    '80 PRINT "SCREEN CLEARED!"',
+    '```',
+  ].join('\n\n'),
+}

--- a/src/features/ide/tutorial/lessons/lesson7Color.ts
+++ b/src/features/ide/tutorial/lessons/lesson7Color.ts
@@ -1,0 +1,104 @@
+/**
+ * Lesson 7: COLOR — Setting text and background colors.
+ *
+ * Covers the COLOR statement for specifying color patterns
+ * per screen area, color pattern numbers, and combining
+ * COLOR with CGSET for full color control.
+ */
+
+import type { Lesson } from '../types'
+
+export const lesson7Color: Lesson = {
+  title: 'COLOR',
+
+  content: [
+    '# Lesson 7: COLOR',
+
+    'The `COLOR` command sets the color pattern for',
+    'characters on the background screen.',
+    'It lets you add color to your programs.',
+
+    '## Basic Syntax',
+
+    '`COLOR` takes three arguments:',
+
+    '```basic',
+    'COLOR X, Y, n',
+    '```',
+
+    '- `X` — Horizontal column (0 to 27)',
+    '- `Y` — Vertical line (0 to 23)',
+    '- `n` — Color pattern number (0 to 3)',
+
+    '## How It Works',
+
+    'The screen is divided into small areas.',
+    'Each area covers a 2-column by 2-line block.',
+    '`COLOR` sets the color pattern for the area',
+    'that contains the position (X, Y).',
+
+    'The color pattern number `n` (0 to 3) selects',
+    'one of four color combinations from the current',
+    'palette. Use `CGSET` to choose which palette',
+    'to use.',
+
+    '## Example: Coloring Text Areas',
+
+    'This program fills the screen with characters',
+    'and applies different colors to different areas:',
+
+    '```basic',
+    '10 CLS',
+    '20 FOR I=0 TO 200',
+    '30 PRINT CHR$(225);',
+    '40 NEXT',
+    '50 COLOR 0, 0, 1',
+    '60 COLOR 10, 0, 2',
+    '70 COLOR 20, 0, 3',
+    '80 LOCATE 0, 20',
+    '```',
+
+    '## Using Loops with COLOR',
+
+    'You can use `FOR...NEXT` to apply colors',
+    'to multiple areas:',
+
+    '```basic',
+    '10 CLS',
+    '20 FOR I=0 TO 100',
+    '30 PRINT "*";',
+    '40 NEXT',
+    '50 FOR C=0 TO 3',
+    '60 COLOR C*4, 2, C',
+    '70 NEXT',
+    '80 LOCATE 0, 20',
+    '```',
+
+    '## Color Pattern Numbers',
+
+    'The color pattern number `n` selects from',
+    'the current palette:',
+    '- `0` — Color combination 0',
+    '- `1` — Color combination 1',
+    '- `2` — Color combination 2',
+    '- `3` — Color combination 3',
+
+    'See the color chart for the actual colors',
+    'in each palette.',
+
+    '## Try It',
+
+    'Try this program to see colors in action:',
+
+    '```basic',
+    '10 CLS',
+    '20 FOR I=0 TO 50',
+    '30 PRINT "##";',
+    '40 NEXT',
+    '50 COLOR 0, 0, 3',
+    '60 COLOR 8, 0, 2',
+    '70 COLOR 16, 0, 1',
+    '80 LOCATE 0, 22',
+    '```',
+  ].join('\n\n'),
+}

--- a/src/features/ide/tutorial/lessons/lesson8Locate.ts
+++ b/src/features/ide/tutorial/lessons/lesson8Locate.ts
@@ -1,0 +1,103 @@
+/**
+ * Lesson 8: LOCATE — Cursor positioning and screen functions.
+ *
+ * Covers the LOCATE statement for moving the cursor,
+ * screen coordinates, POS and CSRLIN functions,
+ * and combining LOCATE with loops for patterns.
+ */
+
+import type { Lesson } from '../types'
+
+export const lesson8Locate: Lesson = {
+  title: 'LOCATE',
+
+  content: [
+    '# Lesson 8: LOCATE',
+
+    'The `LOCATE` command moves the cursor to a',
+    'specific position on the screen.',
+    'This lets you place text exactly where you want it.',
+
+    '## Basic Syntax',
+
+    '```basic',
+    'LOCATE X, Y',
+    '```',
+
+    '- `X` — Horizontal column (0 to 27)',
+    '- `Y` — Vertical line (0 to 23)',
+
+    '## Screen Coordinates',
+
+    'The screen has 28 columns and 24 lines:',
+    '- Top-left corner: `(0, 0)`',
+    '- Top-right corner: `(27, 0)`',
+    '- Bottom-left corner: `(0, 23)`',
+    '- Bottom-right corner: `(27, 23)`',
+
+    '## Basic Example',
+
+    'Place text at a specific position:',
+
+    '```basic',
+    '10 CLS',
+    '20 LOCATE 10, 10',
+    '30 PRINT "HELLO"',
+    '```',
+
+    'The text "HELLO" appears at column 10, line 10.',
+
+    '## Drawing with LOCATE and Loops',
+
+    'Combine `LOCATE` with `FOR...NEXT` to draw',
+    'patterns on the screen:',
+
+    '```basic',
+    '10 CLS',
+    '20 FOR I=0 TO 20',
+    '30 LOCATE I, I',
+    '40 PRINT "*";',
+    '50 NEXT',
+    '60 LOCATE 0, 22',
+    '```',
+
+    '## POS and CSRLIN Functions',
+
+    'You can check the current cursor position:',
+    '- `POS(0)` — Returns the horizontal column (0-27)',
+    '- `CSRLIN` — Returns the vertical line (0-23)',
+
+    '```basic',
+    '10 CLS',
+    '20 LOCATE 5, 10',
+    '30 PRINT "POSITION: ";POS(0);", ";CSRLIN',
+    '```',
+
+    '## Creating a Title Screen',
+
+    'Use `LOCATE` to center text on the screen:',
+
+    '```basic',
+    '10 CLS',
+    '20 LOCATE 8, 5',
+    '30 PRINT "MY GAME"',
+    '40 LOCATE 6, 8',
+    '50 PRINT "PRESS ANY KEY"',
+    '60 LOCATE 0, 20',
+    '```',
+
+    '## Try It',
+
+    'Try making your own screen layout:',
+
+    '```basic',
+    '10 CLS',
+    '20 LOCATE 0, 0',
+    '30 PRINT "SCORE: 100"',
+    '40 LOCATE 20, 0',
+    '50 PRINT "LIVES: 3"',
+    '60 LOCATE 10, 12',
+    '70 PRINT "GAME OVER"',
+    '```',
+  ].join('\n\n'),
+}

--- a/src/features/ide/tutorial/types.ts
+++ b/src/features/ide/tutorial/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Tutorial lesson data types.
+ *
+ * Defines the structure for lesson content consumed by
+ * LessonContent.vue and indexed by useTutorial.ts.
+ */
+
+/**
+ * Represents a single tutorial lesson.
+ *
+ * Each lesson contains a title for navigation display and
+ * markdown content that may include headings, paragraphs,
+ * inline formatting, and fenced code blocks.
+ */
+export interface Lesson {
+  /** Display title shown in the lesson navigation. */
+  title: string
+
+  /**
+   * Markdown content for the lesson body.
+   *
+   * Supported syntax:
+   * - Headings: `#` `##` `###`
+   * - Paragraphs (separated by blank lines)
+   * - Bold: `**text**`
+   * - Italic: `*text*`
+   * - Inline code: `` `code` ``
+   * - Fenced code blocks: ` ```basic ... ``` `
+   *
+   * Code blocks render with a "Try It" button that
+   * allows users to load the code into the editor.
+   */
+  content: string
+}

--- a/test/helpers/extractCodeBlocks.ts
+++ b/test/helpers/extractCodeBlocks.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared Test Helper: extractCodeBlocks
+ *
+ * Extracts all fenced code block contents from a markdown string.
+ * Used by tutorial lesson tests to validate F-BASIC code examples.
+ */
+
+/**
+ * Extracts all fenced code block contents from a markdown string.
+ *
+ * Matches standard fenced code blocks (```language\n...\n```) and
+ * returns an array of trimmed code strings, skipping empty blocks.
+ */
+export function extractCodeBlocks(markdown: string): string[] {
+  const blocks: string[] = []
+  const regex = /```(?:\w*)\n([\s\S]*?)```/g
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(markdown)) !== null) {
+    const code = match[1]?.trim()
+    if (code != null && code.length > 0) {
+      blocks.push(code)
+    }
+  }
+  return blocks
+}

--- a/test/ide/basicsLessons.test.ts
+++ b/test/ide/basicsLessons.test.ts
@@ -10,6 +10,8 @@ import { describe, expect, it } from 'vitest'
 import { basicsLessons } from '@/features/ide/tutorial/index'
 import type { Lesson } from '@/features/ide/tutorial/types'
 
+import { extractCodeBlocks } from '../helpers/extractCodeBlocks'
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -26,22 +28,6 @@ const LESSON_KEYWORDS: Array<RegExp> = [
   /\bIF\b.*\bTHEN\b/,
   /\bFOR\b.*\bTO\b/,
 ]
-
-/**
- * Extracts all fenced code block contents from a markdown string.
- */
-function extractCodeBlocks(markdown: string): string[] {
-  const blocks: string[] = []
-  const regex = /```(?:\w*)\n([\s\S]*?)```/g
-  let match: RegExpExecArray | null
-  while ((match = regex.exec(markdown)) !== null) {
-    const code = match[1]?.trim()
-    if (code != null && code.length > 0) {
-      blocks.push(code)
-    }
-  }
-  return blocks
-}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/test/ide/basicsLessons.test.ts
+++ b/test/ide/basicsLessons.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for basics tutorial lesson data files.
+ *
+ * Validates the Lesson interface, lesson structure,
+ * content completeness, and F-BASIC syntax correctness.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { basicsLessons } from '@/features/ide/tutorial/index'
+import type { Lesson } from '@/features/ide/tutorial/types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Keywords expected in each lesson's code blocks.
+ * Mapped by lesson index to the primary F-BASIC keyword
+ * that lesson teaches.
+ */
+const LESSON_KEYWORDS: Array<RegExp> = [
+  /\bPRINT\b/,
+  /\bPRINT\b/,
+  /\bINPUT\b/,
+  /\bIF\b.*\bTHEN\b/,
+  /\bFOR\b.*\bTO\b/,
+]
+
+/**
+ * Extracts all fenced code block contents from a markdown string.
+ */
+function extractCodeBlocks(markdown: string): string[] {
+  const blocks: string[] = []
+  const regex = /```(?:\w*)\n([\s\S]*?)```/g
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(markdown)) !== null) {
+    const code = match[1]?.trim()
+    if (code != null && code.length > 0) {
+      blocks.push(code)
+    }
+  }
+  return blocks
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('basicsLessons', () => {
+  it('exports an array of exactly 5 lessons', () => {
+    expect(basicsLessons).toHaveLength(5)
+  })
+
+  it('each entry satisfies the Lesson interface', () => {
+    for (const lesson of basicsLessons) {
+      expect(typeof lesson.title).toEqual('string')
+      expect(typeof lesson.content).toEqual('string')
+    }
+  })
+
+  it('each lesson has a non-empty title', () => {
+    const expectedTitles = ['PRINT', 'Variables', 'INPUT', 'IF / THEN', 'FOR / NEXT']
+
+    for (let i = 0; i < basicsLessons.length; i++) {
+      const lesson = basicsLessons[i]!
+      expect(lesson.title.length).toBeGreaterThan(0)
+      expect(lesson.title).toEqual(expectedTitles[i])
+    }
+  })
+
+  it('each lesson has non-empty content', () => {
+    for (const lesson of basicsLessons) {
+      expect(lesson.content.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('each lesson contains at least one fenced code block', () => {
+    for (const lesson of basicsLessons) {
+      const blocks = extractCodeBlocks(lesson.content)
+      expect(blocks.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('code blocks contain expected F-BASIC keywords', () => {
+    for (let i = 0; i < basicsLessons.length; i++) {
+      const lesson = basicsLessons[i]!
+      const blocks = extractCodeBlocks(lesson.content)
+      const allCode = blocks.join('\n')
+      const keyword = LESSON_KEYWORDS[i]!
+      expect(allCode).toMatch(keyword)
+    }
+  })
+
+  it('Lesson interface can be imported and used for type annotation', () => {
+    const lesson: Lesson = {
+      title: 'Test',
+      content: '```basic\n10 PRINT "HI"\n```',
+    }
+    expect(lesson.title).toEqual('Test')
+    expect(lesson.content).toContain('PRINT')
+  })
+
+  it('all lessons export const values are usable independently', async () => {
+    const { lesson1Print } = await import(
+      '@/features/ide/tutorial/lessons/lesson1Print'
+    )
+    const { lesson2Variables } = await import(
+      '@/features/ide/tutorial/lessons/lesson2Variables'
+    )
+    const { lesson3Input } = await import(
+      '@/features/ide/tutorial/lessons/lesson3Input'
+    )
+    const { lesson4IfThen } = await import(
+      '@/features/ide/tutorial/lessons/lesson4IfThen'
+    )
+    const { lesson5ForNext } = await import(
+      '@/features/ide/tutorial/lessons/lesson5ForNext'
+    )
+
+    expect(lesson1Print.title).toEqual('PRINT')
+    expect(lesson2Variables.title).toEqual('Variables')
+    expect(lesson3Input.title).toEqual('INPUT')
+    expect(lesson4IfThen.title).toEqual('IF / THEN')
+    expect(lesson5ForNext.title).toEqual('FOR / NEXT')
+  })
+})

--- a/test/ide/screenLessons.test.ts
+++ b/test/ide/screenLessons.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for screen tutorial lesson data files.
+ *
+ * Validates the Lesson interface, lesson structure,
+ * content completeness, and F-BASIC syntax correctness.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { screenLessons } from '@/features/ide/tutorial/index'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Keywords expected in each screen lesson's code blocks.
+ * Mapped by lesson index to the primary F-BASIC keyword
+ * that lesson teaches.
+ */
+const LESSON_KEYWORDS: Array<RegExp> = [
+  /\bCLS\b/,
+  /\bCOLOR\b/,
+  /\bLOCATE\b/,
+]
+
+/**
+ * Extracts all fenced code block contents from a markdown string.
+ */
+function extractCodeBlocks(markdown: string): string[] {
+  const blocks: string[] = []
+  const regex = /```(?:\w*)\n([\s\S]*?)```/g
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(markdown)) !== null) {
+    const code = match[1]?.trim()
+    if (code != null && code.length > 0) {
+      blocks.push(code)
+    }
+  }
+  return blocks
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('screenLessons', () => {
+  it('exports an array of exactly 3 lessons', () => {
+    expect(screenLessons).toHaveLength(3)
+  })
+
+  it('each entry satisfies the Lesson interface', () => {
+    for (const lesson of screenLessons) {
+      expect(typeof lesson.title).toEqual('string')
+      expect(typeof lesson.content).toEqual('string')
+    }
+  })
+
+  it('each lesson has a non-empty title', () => {
+    const expectedTitles = ['CLS', 'COLOR', 'LOCATE']
+
+    for (let i = 0; i < screenLessons.length; i++) {
+      const lesson = screenLessons[i]!
+      expect(lesson.title.length).toBeGreaterThan(0)
+      expect(lesson.title).toEqual(expectedTitles[i])
+    }
+  })
+
+  it('each lesson has non-empty content', () => {
+    for (const lesson of screenLessons) {
+      expect(lesson.content.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('each lesson contains at least one fenced code block', () => {
+    for (const lesson of screenLessons) {
+      const blocks = extractCodeBlocks(lesson.content)
+      expect(blocks.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('code blocks contain expected F-BASIC keywords', () => {
+    for (let i = 0; i < screenLessons.length; i++) {
+      const lesson = screenLessons[i]!
+      const blocks = extractCodeBlocks(lesson.content)
+      const allCode = blocks.join('\n')
+      const keyword = LESSON_KEYWORDS[i]!
+      expect(allCode).toMatch(keyword)
+    }
+  })
+
+  it('all lessons export const values are usable independently', async () => {
+    const { lesson6Cls } = await import(
+      '@/features/ide/tutorial/lessons/lesson6Cls'
+    )
+    const { lesson7Color } = await import(
+      '@/features/ide/tutorial/lessons/lesson7Color'
+    )
+    const { lesson8Locate } = await import(
+      '@/features/ide/tutorial/lessons/lesson8Locate'
+    )
+
+    expect(lesson6Cls.title).toEqual('CLS')
+    expect(lesson7Color.title).toEqual('COLOR')
+    expect(lesson8Locate.title).toEqual('LOCATE')
+  })
+
+  it('CLS lesson explains clearing the screen', () => {
+    const lesson = screenLessons[0]!
+    expect(lesson.content).toContain('CLS')
+    expect(lesson.content).toMatch(/clear/i)
+  })
+
+  it('COLOR lesson explains color patterns', () => {
+    const lesson = screenLessons[1]!
+    expect(lesson.content).toContain('COLOR')
+    expect(lesson.content).toMatch(/color/i)
+  })
+
+  it('LOCATE lesson explains cursor positioning', () => {
+    const lesson = screenLessons[2]!
+    expect(lesson.content).toContain('LOCATE')
+    expect(lesson.content).toMatch(/cursor/i)
+  })
+})

--- a/test/ide/screenLessons.test.ts
+++ b/test/ide/screenLessons.test.ts
@@ -9,6 +9,8 @@ import { describe, expect, it } from 'vitest'
 
 import { screenLessons } from '@/features/ide/tutorial/index'
 
+import { extractCodeBlocks } from '../helpers/extractCodeBlocks'
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -23,22 +25,6 @@ const LESSON_KEYWORDS: Array<RegExp> = [
   /\bCOLOR\b/,
   /\bLOCATE\b/,
 ]
-
-/**
- * Extracts all fenced code block contents from a markdown string.
- */
-function extractCodeBlocks(markdown: string): string[] {
-  const blocks: string[] = []
-  const regex = /```(?:\w*)\n([\s\S]*?)```/g
-  let match: RegExpExecArray | null
-  while ((match = regex.exec(markdown)) !== null) {
-    const code = match[1]?.trim()
-    if (code != null && code.length > 0) {
-      blocks.push(code)
-    }
-  }
-  return blocks
-}
 
 // ---------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
## Summary
- Fixes #756 — extracts duplicated `extractCodeBlocks` helper to shared test utility

## Changes
- **`test/helpers/extractCodeBlocks.ts`** (25 lines, new) — shared helper with JSDoc
- **`test/ide/basicsLessons.test.ts`** (-14 lines) — removed local copy, added import
- **`test/ide/screenLessons.test.ts`** (-14 lines) — removed local copy, added import

## Test plan
- [x] 18/18 tests pass (8 basics + 10 screen, same as before)
- [ ] CI passes