### PR TITLE
test: resolve #762 - add tempo boundary tests for out-of-range clamping in codeGenerator

### DIFF
--- a/test/features/ide/composables/codeGenerator.test.ts
+++ b/test/features/ide/composables/codeGenerator.test.ts
@@ -262,6 +262,18 @@ describe('generatePlayCode', () => {
 
       expect(lines[0]).toContain(`C${expectedLength}"`)
     })
+
+    it('falls back to length 5 for unrecognized duration', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        duration: 'invalid',
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain('C5"')
+    })
   })
 
   // -------------------------------------------------------------------------
@@ -316,6 +328,18 @@ describe('generatePlayCode', () => {
 
       expect(lines[0]).toContain('M1V15')
     })
+
+    it('falls back to M0V15 for unrecognized envelope', () => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        envelope: 'invalid',
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain('M0V15')
+    })
   })
 
   // -------------------------------------------------------------------------
@@ -357,6 +381,25 @@ describe('generatePlayCode', () => {
       const lines = generatePlayCode(state)
 
       expect(lines[0]).toContain('T1')
+    })
+
+    it.each([
+      [0, 'T8'],
+      [-100, 'T8'],
+      [39, 'T8'],
+      [241, 'T1'],
+      [300, 'T1'],
+      [999, 'T1'],
+    ] as const)('clamps out-of-range tempo %i to %s', (tempo, expectedT) => {
+      const notes: NoteCellKey[] = [createNoteCellKey(23, 0)]
+      const state = makeState({
+        tempo,
+        channelNotes: [notes, [], []],
+      })
+
+      const lines = generatePlayCode(state)
+
+      expect(lines[0]).toContain(expectedT)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #762

## Changes
- Added 6 parameterized tempo boundary tests: tempo 0, -100, 39 (clamped to T8), and tempo 241, 300, 999 (clamped to T1)
- Added duration fallback test: unrecognized duration string falls back to length 5
- Added envelope fallback test: unrecognized envelope string falls back to M0V15

## Test plan
- [ ] 33/33 codeGenerator tests pass (25 existing + 8 new)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)