### PR TITLE
refactor: resolve #757 - extract shared CSS dialog styles from ExportHtmlDialog and ShareDialog

### DIFF
--- a/src/features/ide/components/ExportHtmlDialog.vue
+++ b/src/features/ide/components/ExportHtmlDialog.vue
@@ -92,18 +92,18 @@ onUnmounted(() => {
   <Teleport to="body">
     <div
       v-if="visible"
-      class="export-html-dialog-overlay"
+      class="game-dialog-overlay"
       role="dialog"
       aria-modal="true"
       :aria-label="t('ide.exportHtml.title')"
       @click="handleOverlayClick"
     >
-      <div class="export-html-dialog">
-        <h3 class="export-html-dialog-title">
+      <div class="game-dialog">
+        <h3 class="game-dialog-title">
           {{ t('ide.exportHtml.title') }}
         </h3>
 
-        <p class="export-html-dialog-description">
+        <p class="game-dialog-description">
           {{ t('ide.exportHtml.description') }}
         </p>
 
@@ -111,7 +111,7 @@ onUnmounted(() => {
         <div
           v-if="isExporting"
           data-testid="export-html-exporting"
-          class="export-html-dialog-loading"
+          class="game-dialog-loading"
         >
           {{ t('ide.exportHtml.exporting') }}
         </div>
@@ -120,7 +120,7 @@ onUnmounted(() => {
         <div
           v-else-if="exportError"
           data-testid="export-html-error"
-          class="export-html-dialog-error"
+          class="game-dialog-error"
         >
           {{ t('ide.exportHtml.exportFailed') }}
         </div>
@@ -192,16 +192,16 @@ onUnmounted(() => {
           </div>
 
           <!-- Actions -->
-          <div class="export-html-dialog-actions">
+          <div class="game-dialog-actions">
             <button
-              class="export-html-dialog-btn export-html-dialog-btn-export"
+              class="game-dialog-btn game-dialog-btn-primary"
               data-testid="export-html-export-button"
               @click="handleExport"
             >
               {{ t('ide.exportHtml.exportButton') }}
             </button>
             <button
-              class="export-html-dialog-btn export-html-dialog-btn-cancel"
+              class="game-dialog-btn game-dialog-btn-secondary"
               data-testid="export-html-cancel-button"
               @click="handleClose"
             >
@@ -215,55 +215,14 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
-.export-html-dialog-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--base-alpha-gray-00-60);
+@import url('@/shared/styles/dialog.css');
+
+/* Export-html-specific: description has larger bottom margin */
+.game-dialog-description {
+  margin-bottom: 1rem;
 }
 
-.export-html-dialog {
-  background: var(--game-surface-bg-gradient);
-  border: 2px solid var(--game-surface-border);
-  border-radius: 12px;
-  padding: 1.5rem;
-  min-width: 420px;
-  max-width: 90vw;
-  box-shadow: var(--game-shadow-base);
-}
-
-.export-html-dialog-title {
-  margin: 0 0 0.75rem;
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--game-text-primary);
-}
-
-.export-html-dialog-description {
-  margin: 0 0 1rem;
-  font-size: 0.875rem;
-  color: var(--game-text-secondary);
-  line-height: 1.4;
-}
-
-.export-html-dialog-loading {
-  padding: 1rem 0;
-  text-align: center;
-  color: var(--game-text-secondary);
-  font-size: 0.875rem;
-}
-
-.export-html-dialog-error {
-  padding: 0.75rem;
-  color: var(--semantic-solid-danger);
-  font-size: 0.875rem;
-  background: var(--base-alpha-danger-10);
-  border-radius: 6px;
-}
-
+/* Export-html-specific: form field */
 .export-html-dialog-field {
   margin-bottom: 0.75rem;
 }
@@ -293,6 +252,7 @@ onUnmounted(() => {
   box-shadow: 0 0 0 2px var(--base-alpha-primary-20);
 }
 
+/* Export-html-specific: fieldset for theme selection */
 .export-html-dialog-fieldset {
   margin: 0 0 0.75rem;
   border: none;
@@ -313,6 +273,7 @@ onUnmounted(() => {
   cursor: pointer;
 }
 
+/* Export-html-specific: toggle checkboxes */
 .export-html-dialog-toggles {
   display: flex;
   flex-direction: column;
@@ -327,45 +288,5 @@ onUnmounted(() => {
   font-size: 0.875rem;
   color: var(--game-text-primary);
   cursor: pointer;
-}
-
-.export-html-dialog-actions {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: flex-end;
-}
-
-.export-html-dialog-btn {
-  padding: 0.5rem 1rem;
-  border: 1px solid var(--game-surface-border);
-  border-radius: 6px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.export-html-dialog-btn:focus-visible {
-  outline: 2px solid var(--base-solid-primary);
-  outline-offset: 2px;
-}
-
-.export-html-dialog-btn-export {
-  background: var(--base-solid-primary);
-  color: var(--game-text-contrast);
-  border-color: var(--base-solid-primary);
-}
-
-.export-html-dialog-btn-export:hover {
-  opacity: 0.9;
-}
-
-.export-html-dialog-btn-cancel {
-  background: transparent;
-  color: var(--game-text-secondary);
-}
-
-.export-html-dialog-btn-cancel:hover {
-  background: var(--game-surface-bg-start);
 }
 </style>

--- a/src/features/ide/components/ShareDialog.vue
+++ b/src/features/ide/components/ShareDialog.vue
@@ -122,27 +122,27 @@ onUnmounted(() => {
   <Teleport to="body">
     <div
       v-if="visible"
-      class="share-dialog-overlay"
+      class="game-dialog-overlay"
       role="dialog"
       aria-modal="true"
       :aria-label="t('ide.share.title')"
       @click="handleOverlayClick"
     >
-      <div class="share-dialog">
-        <h3 class="share-dialog-title">
+      <div class="game-dialog">
+        <h3 class="game-dialog-title">
           {{ t('ide.share.title') }}
         </h3>
 
-        <div v-if="isEncoding" class="share-dialog-loading">
+        <div v-if="isEncoding" class="game-dialog-loading">
           {{ t('ide.share.encoding') }}
         </div>
 
-        <div v-else-if="error" class="share-dialog-error">
+        <div v-else-if="error" class="game-dialog-error">
           {{ t('ide.share.encodeFailed') }}
         </div>
 
         <template v-else>
-          <p class="share-dialog-description">
+          <p class="game-dialog-description">
             {{ t('ide.share.description') }}
           </p>
 
@@ -161,16 +161,16 @@ onUnmounted(() => {
             {{ t('ide.share.tooLarge') }}
           </p>
 
-          <div class="share-dialog-actions">
+          <div class="game-dialog-actions">
             <button
-              class="share-dialog-btn share-dialog-btn-copy"
+              class="game-dialog-btn game-dialog-btn-primary"
               data-testid="share-copy-button"
               @click="handleCopy"
             >
               {{ copyLabel }}
             </button>
             <button
-              class="share-dialog-btn share-dialog-btn-close"
+              class="game-dialog-btn game-dialog-btn-secondary"
               data-testid="share-close-button"
               @click="handleClose"
             >
@@ -184,55 +184,9 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
-.share-dialog-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--base-alpha-gray-00-60);
-}
+@import url('@/shared/styles/dialog.css');
 
-.share-dialog {
-  background: var(--game-surface-bg-gradient);
-  border: 2px solid var(--game-surface-border);
-  border-radius: 12px;
-  padding: 1.5rem;
-  min-width: 420px;
-  max-width: 90vw;
-  box-shadow: var(--game-shadow-base);
-}
-
-.share-dialog-title {
-  margin: 0 0 0.75rem;
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--game-text-primary);
-}
-
-.share-dialog-description {
-  margin: 0 0 0.75rem;
-  font-size: 0.875rem;
-  color: var(--game-text-secondary);
-  line-height: 1.4;
-}
-
-.share-dialog-loading {
-  padding: 1rem 0;
-  text-align: center;
-  color: var(--game-text-secondary);
-  font-size: 0.875rem;
-}
-
-.share-dialog-error {
-  padding: 0.75rem;
-  color: var(--semantic-solid-danger);
-  font-size: 0.875rem;
-  background: var(--base-alpha-danger-10);
-  border-radius: 6px;
-}
-
+/* Share-specific: URL input container */
 .share-dialog-url-container {
   margin-bottom: 0.5rem;
 }
@@ -255,50 +209,11 @@ onUnmounted(() => {
   box-shadow: 0 0 0 2px var(--base-alpha-primary-20);
 }
 
+/* Share-specific: too-large warning */
 .share-dialog-warning {
   margin: 0.5rem 0 0.75rem;
   font-size: 0.8rem;
   color: var(--semantic-solid-warning);
   line-height: 1.4;
-}
-
-.share-dialog-actions {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: flex-end;
-}
-
-.share-dialog-btn {
-  padding: 0.5rem 1rem;
-  border: 1px solid var(--game-surface-border);
-  border-radius: 6px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.share-dialog-btn:focus-visible {
-  outline: 2px solid var(--base-solid-primary);
-  outline-offset: 2px;
-}
-
-.share-dialog-btn-copy {
-  background: var(--base-solid-primary);
-  color: var(--game-text-contrast);
-  border-color: var(--base-solid-primary);
-}
-
-.share-dialog-btn-copy:hover {
-  opacity: 0.9;
-}
-
-.share-dialog-btn-close {
-  background: transparent;
-  color: var(--game-text-secondary);
-}
-
-.share-dialog-btn-close:hover {
-  background: var(--game-surface-bg-start);
 }
 </style>

--- a/src/shared/styles/dialog.css
+++ b/src/shared/styles/dialog.css
@@ -1,0 +1,103 @@
+/**
+ * Shared dialog styles for modal dialogs (ExportHtmlDialog, ShareDialog, etc.).
+ * All selectors are scoped under the game-dialog-* namespace.
+ */
+
+/* Overlay — fixed backdrop behind the dialog */
+.game-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--base-alpha-gray-00-60);
+}
+
+/* Dialog container */
+.game-dialog {
+  background: var(--game-surface-bg-gradient);
+  border: 2px solid var(--game-surface-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  min-width: 420px;
+  max-width: 90vw;
+  box-shadow: var(--game-shadow-base);
+}
+
+/* Title heading */
+.game-dialog-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--game-text-primary);
+}
+
+/* Description paragraph below title */
+.game-dialog-description {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  color: var(--game-text-secondary);
+  line-height: 1.4;
+}
+
+/* Loading state message */
+.game-dialog-loading {
+  padding: 1rem 0;
+  text-align: center;
+  color: var(--game-text-secondary);
+  font-size: 0.875rem;
+}
+
+/* Error state message */
+.game-dialog-error {
+  padding: 0.75rem;
+  color: var(--semantic-solid-danger);
+  font-size: 0.875rem;
+  background: var(--base-alpha-danger-10);
+  border-radius: 6px;
+}
+
+/* Action buttons row */
+.game-dialog-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+/* Base button style */
+.game-dialog-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--game-surface-border);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.game-dialog-btn:focus-visible {
+  outline: 2px solid var(--base-solid-primary);
+  outline-offset: 2px;
+}
+
+/* Primary action button (e.g. Copy, Export) */
+.game-dialog-btn-primary {
+  background: var(--base-solid-primary);
+  color: var(--game-text-contrast);
+  border-color: var(--base-solid-primary);
+}
+
+.game-dialog-btn-primary:hover {
+  opacity: 0.9;
+}
+
+/* Secondary action button (e.g. Close, Cancel) */
+.game-dialog-btn-secondary {
+  background: transparent;
+  color: var(--game-text-secondary);
+}
+
+.game-dialog-btn-secondary:hover {
+  background: var(--game-surface-bg-start);
+}

--- a/test/ide/ExportHtmlDialog.test.ts
+++ b/test/ide/ExportHtmlDialog.test.ts
@@ -77,7 +77,7 @@ describe('ExportHtmlDialog', () => {
   // -- Visibility ------------------------------------------------------------
   it('renders nothing when visible is false', () => {
     const wrapper = mountDialog({ visible: false })
-    expect(wrapper.find('.export-html-dialog-overlay').exists()).toBe(false)
+    expect(wrapper.find('.game-dialog-overlay').exists()).toBe(false)
     wrapper.unmount()
   })
 
@@ -85,7 +85,7 @@ describe('ExportHtmlDialog', () => {
     const wrapper = mountDialog({ visible: true })
     await nextTick()
 
-    expect(wrapper.find('.export-html-dialog-overlay').exists()).toBe(true)
+    expect(wrapper.find('.game-dialog-overlay').exists()).toBe(true)
     wrapper.unmount()
   })
 
@@ -93,7 +93,7 @@ describe('ExportHtmlDialog', () => {
     const wrapper = mountDialog({ visible: true })
     await nextTick()
 
-    const overlay = wrapper.find('.export-html-dialog-overlay')
+    const overlay = wrapper.find('.game-dialog-overlay')
     expect(overlay.attributes('role')).toEqual('dialog')
     expect(overlay.attributes('aria-modal')).toEqual('true')
     expect(overlay.attributes('aria-label')).toEqual('ide.exportHtml.title')
@@ -216,7 +216,7 @@ describe('ExportHtmlDialog', () => {
     const wrapper = mountDialog({ visible: true })
     await nextTick()
 
-    const overlay = wrapper.find('.export-html-dialog-overlay')
+    const overlay = wrapper.find('.game-dialog-overlay')
     await overlay.trigger('click')
 
     expect(wrapper.emitted('close')).toHaveLength(1)
@@ -227,7 +227,7 @@ describe('ExportHtmlDialog', () => {
     const wrapper = mountDialog({ visible: true })
     await nextTick()
 
-    const dialog = wrapper.find('.export-html-dialog')
+    const dialog = wrapper.find('.game-dialog')
     await dialog.trigger('click')
 
     expect(wrapper.emitted('close')).toBeUndefined()

--- a/test/ide/ShareDialog.test.ts
+++ b/test/ide/ShareDialog.test.ts
@@ -100,7 +100,7 @@ describe('ShareDialog', () => {
   // -- Visibility ------------------------------------------------------------
   it('renders nothing when visible is false', () => {
     const wrapper = mountDialog({ visible: false })
-    expect(wrapper.find('.share-dialog-overlay').exists()).toBe(false)
+    expect(wrapper.find('.game-dialog-overlay').exists()).toBe(false)
     wrapper.unmount()
   })
 
@@ -109,7 +109,7 @@ describe('ShareDialog', () => {
     await openDialog(wrapper)
     await waitForEncoding()
 
-    expect(wrapper.find('.share-dialog-overlay').exists()).toBe(true)
+    expect(wrapper.find('.game-dialog-overlay').exists()).toBe(true)
     wrapper.unmount()
   })
 
@@ -118,7 +118,7 @@ describe('ShareDialog', () => {
     await openDialog(wrapper)
     await waitForEncoding()
 
-    const overlay = wrapper.find('.share-dialog-overlay')
+    const overlay = wrapper.find('.game-dialog-overlay')
     expect(overlay.attributes('role')).toEqual('dialog')
     expect(overlay.attributes('aria-modal')).toEqual('true')
     expect(overlay.attributes('aria-label')).toEqual('ide.share.title')
@@ -138,13 +138,13 @@ describe('ShareDialog', () => {
     await nextTick()
     await nextTick()
 
-    expect(wrapper.find('.share-dialog-loading').exists()).toBe(true)
-    expect(wrapper.find('.share-dialog-loading').text()).toEqual('ide.share.encoding')
+    expect(wrapper.find('.game-dialog-loading').exists()).toBe(true)
+    expect(wrapper.find('.game-dialog-loading').text()).toEqual('ide.share.encoding')
 
     resolveEncode(DEFAULT_ENCODE_RESULT)
     await waitForEncoding()
 
-    expect(wrapper.find('.share-dialog-loading').exists()).toBe(false)
+    expect(wrapper.find('.game-dialog-loading').exists()).toBe(false)
     wrapper.unmount()
   })
 
@@ -155,8 +155,8 @@ describe('ShareDialog', () => {
     await openDialog(wrapper)
     await waitForEncoding()
 
-    expect(wrapper.find('.share-dialog-error').exists()).toBe(true)
-    expect(wrapper.find('.share-dialog-error').text()).toEqual('ide.share.encodeFailed')
+    expect(wrapper.find('.game-dialog-error').exists()).toBe(true)
+    expect(wrapper.find('.game-dialog-error').text()).toEqual('ide.share.encodeFailed')
     wrapper.unmount()
   })
 
@@ -309,7 +309,7 @@ describe('ShareDialog', () => {
     await openDialog(wrapper)
     await waitForEncoding()
 
-    const overlay = wrapper.find('.share-dialog-overlay')
+    const overlay = wrapper.find('.game-dialog-overlay')
     await overlay.trigger('click')
 
     expect(wrapper.emitted('close')).toHaveLength(1)
@@ -321,7 +321,7 @@ describe('ShareDialog', () => {
     await openDialog(wrapper)
     await waitForEncoding()
 
-    const dialog = wrapper.find('.share-dialog')
+    const dialog = wrapper.find('.game-dialog')
     await dialog.trigger('click')
 
     expect(wrapper.emitted('close')).toBeUndefined()


### PR DESCRIPTION
## Summary
- Fixes #757

## Changes
- Created `src/shared/styles/dialog.css` with shared `game-dialog-*` namespace (overlay, container, title, description, loading, error, actions, buttons)
- Updated `ShareDialog.vue` to import shared CSS and use `game-dialog-*` classes (305 → 219 lines)
- Updated `ExportHtmlDialog.vue` to import shared CSS and use `game-dialog-*` classes (371 → 292 lines)
- Updated test selectors in both test files to match renamed classes

## Test plan
- [x] 37/37 tests pass (17 ExportHtmlDialog + 20 ShareDialog)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes