### PR TITLE
refactor: resolve #758 - extract shared note-to-frequency logic from useComposerPlayback and MusicDSLParser

### DIFF
--- a/src/core/sound/MusicDSLParser.ts
+++ b/src/core/sound/MusicDSLParser.ts
@@ -16,6 +16,7 @@ import {
   CHANNEL_C_INDEX,
 } from './constants'
 import { validateMusicString } from './musicValidation'
+import { calculateNoteFrequency } from './noteFrequency'
 import type { SoundStateManager } from './SoundStateManager'
 import type {
   CompiledAudio,
@@ -34,19 +35,6 @@ import type {
 } from './types'
 
 export { validateMusicString }
-
-/**
- * Note names to semitone offset mapping (C = 0)
- */
-const NOTE_SEMITONES: Record<string, number> = {
-  C: 0,
-  D: 2,
-  E: 4,
-  F: 5,
-  G: 7,
-  A: 9,
-  B: 11,
-}
 
 /**
  * Tempo to milliseconds per whole note mapping
@@ -238,23 +226,6 @@ export function parseMusicToAst(musicString: string): MusicScore {
 // ============================================================================
 // STAGE 2: Compile MusicScore to CompiledAudio (audio-ready)
 // ============================================================================
-
-/**
- * Calculate frequency in Hz for a given note and octave
- * Uses equal temperament tuning with A4 = 440Hz
- */
-function calculateNoteFrequency(noteName: string, octave: number, sharp: boolean): number {
-  const baseSemitone = NOTE_SEMITONES[noteName]
-  if (baseSemitone === undefined) {
-    throw new Error(`Invalid note name: ${noteName}`)
-  }
-
-  const semitone = baseSemitone + (sharp ? 1 : 0)
-  const midiNote = (octave + 2) * 12 + semitone + 12
-  const frequency = 440 * Math.pow(2, (midiNote - 69) / 12)
-
-  return frequency
-}
 
 /**
  * Duration in ms for F-BASIC length code 0-9

--- a/src/core/sound/noteFrequency.ts
+++ b/src/core/sound/noteFrequency.ts
@@ -1,0 +1,56 @@
+/**
+ * Note Frequency Calculation
+ *
+ * Shared utility for converting note names to frequencies.
+ * Uses equal temperament tuning with A4 = 440Hz.
+ *
+ * Formula: f = 440 * 2^((midiNote - 69) / 12)
+ * where midiNote = (fbOctave + 2) * 12 + semitone + 12
+ *
+ * F-BASIC octave convention: F-BASIC octave 2 = standard MIDI octave 4.
+ * - F-BASIC octaves: 0-5
+ * - Standard musical octaves: 2-7 (F-BASIC octave + 2)
+ */
+
+/**
+ * Note names to semitone offset mapping (C = 0).
+ * Used by both the Music DSL parser and the composer playback.
+ */
+export const NOTE_SEMITONES: Readonly<Record<string, number>> = {
+  C: 0,
+  D: 2,
+  E: 4,
+  F: 5,
+  G: 7,
+  A: 9,
+  B: 11,
+} as const
+
+/**
+ * Calculate frequency in Hz for a note given its letter, F-BASIC octave, and sharp flag.
+ *
+ * This is the core frequency function used by MusicDSLParser, which already
+ * operates in F-BASIC octave space (0-5).
+ *
+ * @param noteLetter - Single letter note name (C, D, E, F, G, A, B)
+ * @param fbOctave - F-BASIC octave (0-5), where octave 2 = standard octave 4
+ * @param sharp - Whether the note is sharpened
+ * @returns Frequency in Hz
+ * @throws Error if noteLetter is not a valid note name
+ */
+export function calculateNoteFrequency(
+  noteLetter: string,
+  fbOctave: number,
+  sharp: boolean
+): number {
+  const baseSemitone = NOTE_SEMITONES[noteLetter]
+  if (baseSemitone === undefined) {
+    throw new Error(`Invalid note name: ${noteLetter}`)
+  }
+
+  const semitone = baseSemitone + (sharp ? 1 : 0)
+  const midiNote = (fbOctave + 2) * 12 + semitone + 12
+  const frequency = 440 * Math.pow(2, (midiNote - 69) / 12)
+
+  return frequency
+}

--- a/src/features/ide/composables/useComposerPlayback.ts
+++ b/src/features/ide/composables/useComposerPlayback.ts
@@ -11,6 +11,7 @@
 
 import { computed, ref } from 'vue'
 
+import { calculateNoteFrequency } from '@/core/sound/noteFrequency'
 import type { Note, Rest } from '@/core/sound/types'
 import type { NoteCellKey } from '@/features/ide/components/pianoRollConstants'
 import { NOTE_NAMES } from '@/features/ide/components/pianoRollConstants'
@@ -31,34 +32,17 @@ function isValidChannelIndex(index: number): boolean {
 }
 
 /**
- * Note names to semitone offset mapping (C = 0).
- * Matches the mapping used in MusicDSLParser for frequency calculation.
+ * Calculate frequency in Hz for a full note name (e.g. "C#4") and standard musical octave.
+ * Parses the note name to extract the base letter and sharp flag,
+ * converts standard octave to F-BASIC octave, then delegates to the shared utility.
  */
-const NOTE_SEMITONES: Record<string, number> = {
-  C: 0,
-  D: 2,
-  E: 4,
-  F: 5,
-  G: 7,
-  A: 9,
-  B: 11,
-}
-
-/**
- * Calculate frequency in Hz for a given note name and octave.
- * Uses equal temperament tuning with A4 = 440Hz.
- * Matches the formula in MusicDSLParser.
- */
-function calculateNoteFrequency(noteName: string, octave: number): number {
-  // Strip '#' and trailing digits to get just the base letter (e.g. "C#4" → "C", "B5" → "B")
+function calculateNoteFrequencyFromName(noteName: string, octave: number): number {
   const baseName = noteName.replace(/[#0-9]/g, '')
   const isSharp = noteName.includes('#')
-  const semitone = (NOTE_SEMITONES[baseName] ?? 0) + (isSharp ? 1 : 0)
   // octave is a standard musical octave (3-5); convert to F-BASIC octave (octave - 2)
   // so the formula matches MusicDSLParser's convention (F-BASIC octave 2 = MIDI octave 4)
   const fbOctave = octave - 2
-  const midiNote = (fbOctave + 2) * 12 + semitone + 12
-  return 440 * Math.pow(2, (midiNote - 69) / 12)
+  return calculateNoteFrequency(baseName, fbOctave, isSharp)
 }
 
 /**
@@ -153,7 +137,7 @@ function buildStepAudioEvents(
         if (noteName) {
           const baseOctave = noteIndexToBaseOctave(noteIndex)
           const octaveOffset = octave - 4
-          const frequency = calculateNoteFrequency(
+          const frequency = calculateNoteFrequencyFromName(
             noteName,
             baseOctave + octaveOffset
           )


### PR DESCRIPTION
## Summary
- Fixes #758

## Changes
- Created `src/core/sound/noteFrequency.ts` with shared `NOTE_SEMITONES` mapping and `calculateNoteFrequency(noteLetter, fbOctave, sharp)` utility
- Updated `MusicDSLParser.ts` to import from shared utility (400 → 370 lines)
- Updated `useComposerPlayback.ts` to import from shared utility, replaced inline function with `calculateNoteFrequencyFromName` wrapper (392 → 375 lines)

## Test plan
- [x] 104/104 tests pass (37 useComposerPlayback + 67 MusicDSLParser)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes (will trigger when PR #751 merges)