### PR TITLE
fix: resolve #761 - use i18n for MusicComposerPage h1 heading instead of hardcoded English text

### DIFF
--- a/src/features/music-composer/MusicComposerPage.vue
+++ b/src/features/music-composer/MusicComposerPage.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 import { GameLayout } from '@/shared/components/ui'
 
 /**
@@ -10,12 +12,14 @@ import { GameLayout } from '@/shared/components/ui'
 defineOptions({
   name: 'MusicComposerPage',
 })
+
+const { t } = useI18n()
 </script>
 
 <template>
   <GameLayout>
     <div class="music-composer-page">
-      <h1>Music Composer</h1>
+      <h1>{{ t('musicComposer.title') }}</h1>
     </div>
   </GameLayout>
 </template>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -560,6 +560,9 @@
     "exporting": "Exporting...",
     "exportFailed": "Failed to export HTML file."
   },
+  "musicComposer": {
+    "title": "Music Composer"
+  },
   "tutorial": {
     "title": "Tutorial",
     "defaultTitle": "F-BASIC Tutorial",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -560,6 +560,9 @@
     "exporting": "エクスポート中...",
     "exportFailed": "HTMLファイルのエクスポートに失敗しました。"
   },
+  "musicComposer": {
+    "title": "ミュージックコンポーザー"
+  },
   "tutorial": {
     "title": "チュートリアル",
     "defaultTitle": "F-BASICチュートリアル",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -560,6 +560,9 @@
     "exporting": "正在导出...",
     "exportFailed": "导出 HTML 文件失败。"
   },
+  "musicComposer": {
+    "title": "音乐作曲器"
+  },
   "tutorial": {
     "title": "教程",
     "defaultTitle": "F-BASIC 教程",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -560,6 +560,9 @@
     "exporting": "正在匯出...",
     "exportFailed": "匯出 HTML 檔案失敗。"
   },
+  "musicComposer": {
+    "title": "音樂作曲器"
+  },
   "tutorial": {
     "title": "教學",
     "defaultTitle": "F-BASIC 教學",

--- a/test/features/music-composer/MusicComposerPage.test.ts
+++ b/test/features/music-composer/MusicComposerPage.test.ts
@@ -48,7 +48,7 @@ describe('MusicComposerPage', () => {
     wrapper.unmount()
   })
 
-  it('renders a placeholder heading with "Music Composer"', async () => {
+  it('renders a placeholder heading with i18n key musicComposer.title', async () => {
     const { default: pageComponent } = (await import(
       '@/features/music-composer/MusicComposerPage.vue'
     )) as { default: Component }
@@ -64,7 +64,7 @@ describe('MusicComposerPage', () => {
 
     const heading = wrapper.find('h1')
     expect(heading.exists()).toBe(true)
-    expect(heading.text()).toEqual('Music Composer')
+    expect(heading.text()).toEqual('musicComposer.title')
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## Summary
- Fixes #761

## Changes
- Replaced hardcoded `<h1>Music Composer</h1>` with `<h1>{{ t('musicComposer.title') }}</h1>` in MusicComposerPage.vue
- Added `musicComposer.title` i18n key to all 4 locale files (en, ja, zh-CN, zh-TW)
- Updated test assertion to match i18n mock pattern

## Test plan
- [x] 3/3 tests pass (MusicComposerPage)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes (will trigger when PR #754 merges)