### PR TITLE
feat: resolve #771 - add file download mechanism to useHtmlExporter stub

### DIFF
--- a/src/features/ide/composables/useHtmlExporter.ts
+++ b/src/features/ide/composables/useHtmlExporter.ts
@@ -2,8 +2,8 @@
  * useHtmlExporter composable
  *
  * Orchestrates exporting an F-BASIC program as a standalone HTML file.
- * This is a stub — the actual export logic will be implemented in later steps
- * (issues tracking parent #538).
+ * Step 2a: Adds Blob creation and file download trigger mechanism.
+ * Full runtime embedding will be added in later steps (#772, #773).
  */
 
 import { ref } from 'vue'
@@ -22,15 +22,66 @@ export interface HtmlExportOptions {
   includeSprites: boolean
 }
 
+/** MIME type for HTML content. */
+const HTML_MIME_TYPE = 'text/html;charset=utf-8'
+
+/**
+ * Generates a minimal HTML wrapper containing the F-BASIC program source.
+ * This is a placeholder — the full standalone HTML with embedded runtime
+ * will be generated in later steps (#772, #773).
+ *
+ * @param source - The F-BASIC program source code
+ * @param options - Export configuration options
+ * @returns HTML string with the program source embedded
+ */
+function buildMinimalHtml(source: string, options: HtmlExportOptions): string {
+  const escapedSource = source
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+
+  return [
+    '<!DOCTYPE html>',
+    '<html lang="en">',
+    '<head>',
+    '  <meta charset="UTF-8">',
+    `  <title>${options.title}</title>`,
+    '</head>',
+    '<body>',
+    '  <pre>',
+    escapedSource,
+    '  </pre>',
+    '</body>',
+    '</html>',
+  ].join('\n')
+}
+
+/**
+ * Triggers a file download by creating a temporary anchor element.
+ *
+ * @param blob - The content to download
+ * @param filename - The filename for the downloaded file
+ */
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+  URL.revokeObjectURL(url)
+}
+
 /**
  * Composable for exporting an F-BASIC program as a standalone HTML file.
  *
- * @param _source - The F-BASIC program source code (unused in stub)
- * @param _bg - Optional BG data (unused in stub)
+ * @param source - The F-BASIC program source code
+ * @param _bg - Optional BG data (reserved for future use)
  * @returns Reactive export state and the exportHtml function
  */
 export function useHtmlExporter(
-  _source: { value: string },
+  source: { value: string },
   _bg?: { value: CompactBg | undefined },
 ) {
   const isExporting = ref(false)
@@ -38,17 +89,19 @@ export function useHtmlExporter(
 
   /**
    * Triggers the HTML export with the given options.
+   * Creates a Blob with minimal HTML content and triggers a file download.
    *
-   * @param _options - Export configuration options
+   * @param options - Export configuration options
    */
-  async function exportHtml(_options: HtmlExportOptions): Promise<void> {
+  async function exportHtml(options: HtmlExportOptions): Promise<void> {
     isExporting.value = true
     exportError.value = ''
 
     try {
-      // Stub: actual export logic will be implemented in later steps.
-      // For now, simulate a brief async operation.
-      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      const html = buildMinimalHtml(source.value, options)
+      const blob = new Blob([html], { type: HTML_MIME_TYPE })
+      const filename = `${options.title}.html`
+      triggerDownload(blob, filename)
     } catch (err) {
       exportError.value = err instanceof Error ? err.message : String(err)
     } finally {

--- a/test/ide/useHtmlExporter.test.ts
+++ b/test/ide/useHtmlExporter.test.ts
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+/**
+ * Tests for useHtmlExporter composable
+ *
+ * Covers: file download mechanism including Blob creation,
+ * URL.createObjectURL / revokeObjectURL lifecycle,
+ * temporary anchor element creation and click trigger.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useHtmlExporter } from '@/features/ide/composables/useHtmlExporter'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createSourceRef(code: string) {
+  return ref(code)
+}
+
+function mountComposable(code = '10 PRINT "HELLO"') {
+  return useHtmlExporter(createSourceRef(code))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useHtmlExporter', () => {
+  let createObjectURLSpy: ReturnType<typeof vi.spyOn>
+  let revokeObjectURLSpy: ReturnType<typeof vi.spyOn>
+  let createElementSpy: ReturnType<typeof vi.spyOn>
+  let appendChildSpy: ReturnType<typeof vi.spyOn>
+  let removeChildSpy: ReturnType<typeof vi.spyOn>
+
+  /** Captured anchor elements from createElement calls */
+  let capturedAnchors: HTMLAnchorElement[] = []
+  /** Elements appended to document.body */
+  let appendedElements: Element[] = []
+  /** Elements removed from document.body */
+  let removedElements: Element[] = []
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedAnchors = []
+    appendedElements = []
+    removedElements = []
+
+    // Spy on URL methods
+    createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url')
+    revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL')
+
+    // Spy on document.createElement to capture anchor creation
+    const realCreateElement = document.createElement.bind(document)
+    createElementSpy = vi.spyOn(document, 'createElement').mockImplementation(
+      (tag: string) => {
+        const el = realCreateElement(tag)
+        if (tag === 'a') {
+          capturedAnchors.push(el as HTMLAnchorElement)
+        }
+        return el
+      },
+    )
+
+    // Spy on appendChild/removeChild to track DOM insertion
+    const realAppendChild = document.body.appendChild.bind(document.body)
+    appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(
+      (node: Node) => {
+        appendedElements.push(node as Element)
+        return realAppendChild(node)
+      },
+    )
+
+    const realRemoveChild = document.body.removeChild.bind(document.body)
+    removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation(
+      (node: Node) => {
+        removedElements.push(node as Element)
+        return realRemoveChild(node)
+      },
+    )
+  })
+
+  afterEach(() => {
+    createObjectURLSpy.mockRestore()
+    revokeObjectURLSpy.mockRestore()
+    createElementSpy.mockRestore()
+    appendChildSpy.mockRestore()
+    removeChildSpy.mockRestore()
+  })
+
+  // -- Download mechanism ----------------------------------------------------
+
+  describe('download mechanism', () => {
+    it('creates a Blob with HTML content type when exportHtml is called', async () => {
+      const { exportHtml } = mountComposable('10 PRINT "HELLO"')
+
+      const blobSpy = vi.spyOn(globalThis, 'Blob')
+
+      await exportHtml({
+        title: 'Test Program',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      expect(blobSpy).toHaveBeenCalledTimes(1)
+      const [content, options] = blobSpy.mock.calls[0]!
+      expect(options).toEqual({ type: 'text/html;charset=utf-8' })
+      expect(content).toBeInstanceOf(Array)
+      expect((content as string[])[0]).toContain('<!DOCTYPE html>')
+      expect((content as string[])[0]).toContain('10 PRINT "HELLO"')
+
+      blobSpy.mockRestore()
+    })
+
+    it('calls URL.createObjectURL with the blob', async () => {
+      const { exportHtml } = mountComposable('10 CLS')
+
+      await exportHtml({
+        title: 'My Program',
+        theme: 'dark',
+        includeSound: true,
+        includeSprites: true,
+      })
+
+      expect(createObjectURLSpy).toHaveBeenCalledTimes(1)
+      const blobArg = createObjectURLSpy.mock.calls[0]![0]
+      expect(blobArg).toBeInstanceOf(Blob)
+    })
+
+    it('creates a temporary anchor element with download attribute set to filename', async () => {
+      const { exportHtml } = mountComposable('10 PRINT "HI"')
+
+      await exportHtml({
+        title: 'My Program',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      expect(capturedAnchors).toHaveLength(1)
+      const anchor = capturedAnchors[0]!
+      expect(anchor.getAttribute('download')).toEqual('My Program.html')
+      expect(anchor.getAttribute('href')).toEqual('blob:mock-url')
+    })
+
+    it('triggers click on the anchor element', async () => {
+      const { exportHtml } = mountComposable('10 PRINT "HI"')
+
+      await exportHtml({
+        title: 'My Program',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      const anchor = capturedAnchors[0]!
+      // The anchor must be appended to the body for click to work
+      expect(appendedElements).toContain(anchor)
+    })
+
+    it('calls URL.revokeObjectURL for cleanup after download', async () => {
+      const { exportHtml } = mountComposable('10 PRINT "HI"')
+
+      await exportHtml({
+        title: 'My Program',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      expect(revokeObjectURLSpy).toHaveBeenCalledTimes(1)
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url')
+    })
+
+    it('removes the anchor element from the DOM after download', async () => {
+      const { exportHtml } = mountComposable('10 PRINT "HI"')
+
+      await exportHtml({
+        title: 'My Program',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      const anchor = capturedAnchors[0]!
+      expect(removedElements).toContain(anchor)
+    })
+  })
+
+  // -- Reactive state ---------------------------------------------------------
+
+  describe('reactive state', () => {
+    it('isExporting is false initially', () => {
+      const { isExporting } = mountComposable()
+      expect(isExporting.value).toEqual(false)
+    })
+
+    it('exportError is empty string initially', () => {
+      const { exportError } = mountComposable()
+      expect(exportError.value).toEqual('')
+    })
+
+    it('isExporting returns to false after successful export', async () => {
+      const { isExporting, exportHtml } = mountComposable()
+
+      await exportHtml({
+        title: 'Test',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      expect(isExporting.value).toEqual(false)
+    })
+
+    it('sets exportError when Blob creation fails', async () => {
+      const { exportHtml, exportError } = mountComposable()
+
+      // Mock Blob constructor to throw — must use class syntax per vitest docs
+      const savedBlob = globalThis.Blob
+      class FailingBlob {
+        constructor() {
+          throw new Error('Blob creation failed')
+        }
+      }
+      globalThis.Blob = FailingBlob as typeof Blob
+
+      await exportHtml({
+        title: 'Test',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      expect(exportError.value).toEqual('Blob creation failed')
+      globalThis.Blob = savedBlob
+    })
+
+    it('uses .html extension when title is empty string', async () => {
+      const { exportHtml } = mountComposable()
+
+      await exportHtml({
+        title: '',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      const anchor = capturedAnchors[0]!
+      expect(anchor.getAttribute('download')).toEqual('.html')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #771

## Changes
- Implemented `buildMinimalHtml()` in useHtmlExporter.ts — generates minimal HTML wrapper with program source
- Implemented `triggerDownload()` — creates Blob, uses URL.createObjectURL, triggers anchor click download, revokes URL
- Updated `exportHtml()` to call build + download instead of being a no-op stub
- Added 11 tests in new `test/ide/useHtmlExporter.test.ts`: Blob creation, createObjectURL, anchor attributes, click trigger, revokeObjectURL, DOM cleanup, reactive state, error handling

## Test plan
- [x] 11/11 useHtmlExporter tests pass
- [x] 17/17 ExportHtmlDialog tests pass (no regressions)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes