### PR TITLE
refactor: resolve #775 - use Number.isInteger in shared isValidChannelIndex for consistency

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -175,7 +175,7 @@ export const CHANNEL_COUNT = 3
  * Shared by the composer UI (useComposer) and the execution layer (SoundService).
  */
 export function isValidChannelIndex(index: number): boolean {
-  return !Number.isNaN(index) && index >= 0 && index < CHANNEL_COUNT
+  return Number.isInteger(index) && index >= 0 && index < CHANNEL_COUNT
 }
 
 // Screen dimensions and coordinate limits


### PR DESCRIPTION
## Summary
- Fixes #775

## Changes
- Changed `isValidChannelIndex` in `src/core/constants.ts` from `!Number.isNaN(index)` to `Number.isInteger(index)` for consistency with PR #743 pattern used in `setActiveChannel`, `clearChannel`, `setOctave`, `getChannelOctave`

## Test plan
- [ ] Targeted tests pass (52 tests, no regressions)
- [ ] CI passes