### PR TITLE
refactor: resolve #778 - extract z-index 1000 to CSS custom property in dialog styles

### DIFF
--- a/src/features/ide/components/InputModal.vue
+++ b/src/features/ide/components/InputModal.vue
@@ -91,7 +91,7 @@ watch(
 .input-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--z-index-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/features/ide/components/JoystickKeybindingPanel.vue
+++ b/src/features/ide/components/JoystickKeybindingPanel.vue
@@ -228,7 +228,7 @@ const isConfiguring = (joystickId: number, button: keyof JoystickKeyBindings): b
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: var(--z-index-dialog-overlay);
   padding: 1rem;
 }
 

--- a/src/features/ide/components/MyProgramsLibrary.vue
+++ b/src/features/ide/components/MyProgramsLibrary.vue
@@ -257,7 +257,7 @@ function handleClose(): void {
 .my-programs-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--z-index-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/features/ide/components/SampleSelector.vue
+++ b/src/features/ide/components/SampleSelector.vue
@@ -147,7 +147,7 @@ const categoryColors: Record<string, string> = {
 .sample-selector-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--z-index-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/shared/components/ui/ConfirmDialog.vue
+++ b/src/shared/components/ui/ConfirmDialog.vue
@@ -124,7 +124,7 @@ onUnmounted(() => {
 .confirm-dialog-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--z-index-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/shared/styles/dialog.css
+++ b/src/shared/styles/dialog.css
@@ -7,7 +7,7 @@
 .game-dialog-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--z-index-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/shared/styles/navigation.css
+++ b/src/shared/styles/navigation.css
@@ -6,7 +6,7 @@
 .game-navigation {
   border-bottom: 1px solid var(--game-nav-border);
   flex-shrink: 0;
-  z-index: 1000;
+  z-index: var(--z-index-navigation);
 }
 
 .nav-container {
@@ -238,7 +238,7 @@
   transform: translateY(-10px);
   pointer-events: none;
   transition: all 0.2s ease;
-  z-index: 1001;
+  z-index: var(--z-index-nav-dropdown);
   display: flex;
   flex-direction: column;
   gap: 0.25rem;

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -146,6 +146,10 @@
     --game-radius-sm: 4px;
     --game-radius-md: 6px;
     --game-radius-lg: 8px;
+    /* Stacking Order */
+    --z-index-dialog-overlay: 1000;
+    --z-index-navigation: 1000;
+    --z-index-nav-dropdown: 1001;
     /* Game UI Fonts */
     /* English (default) */
     --game-font-family: 'Rajdhani', 'Orbitron', system-ui, sans-serif;


### PR DESCRIPTION
## Summary
- Fixes #778

## Changes
- Added 3 CSS custom properties in `src/shared/styles/theme.css`: `--z-index-dialog-overlay`, `--z-index-navigation`, `--z-index-nav-dropdown`
- Replaced hardcoded `z-index: 1000` with `var(--z-index-dialog-overlay)` in 7 dialog/modal overlay components
- Replaced hardcoded `z-index: 1000`/`1001` with `var(--z-index-navigation)`/`var(--z-index-nav-dropdown)` in navigation.css
- Follows CRT layer z-index pattern established in PRs #729/#744

## Test plan
- [ ] All 3849 tests pass
- [ ] CI passes