### PR TITLE
refactor: resolve #777 - remove unused channelOctaves field from ComposerState interface

### DIFF
--- a/src/features/ide/composables/codeGenerator.ts
+++ b/src/features/ide/composables/codeGenerator.ts
@@ -25,7 +25,6 @@ export interface ComposerState {
   envelope: string
   title: string
   channelNotes: NoteCellKey[][]
-  channelOctaves: number[]
 }
 
 // ---------------------------------------------------------------------------

--- a/test/features/ide/composables/codeGenerator.integration.test.ts
+++ b/test/features/ide/composables/codeGenerator.integration.test.ts
@@ -19,7 +19,6 @@ function makeState(
     envelope: 'none',
     title: '',
     channelNotes: [[], [], []],
-    channelOctaves: [4, 4, 4],
     ...overrides,
   }
 }
@@ -88,7 +87,6 @@ describe('generatePlayCode integration', () => {
       const ch1Notes: NoteCellKey[] = [createNoteCellKey(11, 0)] // C5 (octave 5)
       const state = makeState({
         channelNotes: [ch0Notes, ch1Notes, []],
-        channelOctaves: [3, 5, 4],
       })
 
       const lines = generatePlayCode(state)

--- a/test/features/ide/composables/codeGenerator.test.ts
+++ b/test/features/ide/composables/codeGenerator.test.ts
@@ -19,7 +19,6 @@ function makeState(
     envelope: 'none',
     title: '',
     channelNotes: [[], [], []],
-    channelOctaves: [4, 4, 4],
     ...overrides,
   }
 }
@@ -67,7 +66,6 @@ describe('generatePlayCode', () => {
       const notes: NoteCellKey[] = [createNoteCellKey(11, 0)] // C5
       const state = makeState({
         channelNotes: [notes, [], []],
-        channelOctaves: [4, 4, 4],
       })
 
       const lines = generatePlayCode(state)
@@ -81,7 +79,6 @@ describe('generatePlayCode', () => {
       const notes: NoteCellKey[] = [createNoteCellKey(21, 0)]
       const state = makeState({
         channelNotes: [notes, [], []],
-        channelOctaves: [4, 4, 4],
       })
 
       const lines = generatePlayCode(state)
@@ -95,7 +92,6 @@ describe('generatePlayCode', () => {
       const notes: NoteCellKey[] = [createNoteCellKey(17, 0)]
       const state = makeState({
         channelNotes: [notes, [], []],
-        channelOctaves: [4, 4, 4],
       })
 
       const lines = generatePlayCode(state)
@@ -109,7 +105,6 @@ describe('generatePlayCode', () => {
       const notes: NoteCellKey[] = [createNoteCellKey(35, 0)]
       const state = makeState({
         channelNotes: [notes, [], []],
-        channelOctaves: [3, 4, 4],
       })
 
       const lines = generatePlayCode(state)
@@ -123,7 +118,6 @@ describe('generatePlayCode', () => {
       const notes: NoteCellKey[] = [createNoteCellKey(0, 0)]
       const state = makeState({
         channelNotes: [notes, [], []],
-        channelOctaves: [5, 4, 4],
       })
 
       const lines = generatePlayCode(state)
@@ -212,7 +206,6 @@ describe('generatePlayCode', () => {
       ]
       const state = makeState({
         channelNotes: [notes, [], []],
-        channelOctaves: [4, 4, 4],
       })
 
       const lines = generatePlayCode(state)
@@ -229,7 +222,6 @@ describe('generatePlayCode', () => {
       ]
       const state = makeState({
         channelNotes: [notes, [], []],
-        channelOctaves: [5, 4, 4],
       })
 
       const lines = generatePlayCode(state)


### PR DESCRIPTION
## Summary
- Removed `channelOctaves: number[]` from `ComposerState` interface in `codeGenerator.ts`
- Removed all test references to the field (8 occurrences across 2 test files)
- Field became dead data after PR #752 removed `channelOctave` parameter from `buildChannelString`
- `useComposer.ts` internal `channelOctaves` ref is unaffected (separate UI state concern)

Resolves #777

## Test plan
- [x] 85 tests pass across 4 test files (identical before/after)
- [x] TypeScript type-check clean
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)