### PR TITLE
refactor: resolve #795 - move COMPOSER_DEFAULT_VOLUME to shared sound constants

### DIFF
--- a/src/core/sound/constants.ts
+++ b/src/core/sound/constants.ts
@@ -51,3 +51,11 @@ export const CHANNEL_C_DEFAULT_ENVELOPE = 0
  * Channel C uses 50% duty cycle (Y2)
  */
 export const CHANNEL_C_DEFAULT_DUTY = 2
+
+/**
+ * Default volume for composer playback preview (0-15 scale)
+ *
+ * Used by the music composer's real-time preview to set initial channel volume.
+ * The F-BASIC volume range is 0-15; 10 provides a comfortable listening level.
+ */
+export const COMPOSER_DEFAULT_VOLUME = 10

--- a/src/features/ide/composables/useComposerPlayback.ts
+++ b/src/features/ide/composables/useComposerPlayback.ts
@@ -11,7 +11,7 @@
 
 import { computed, ref } from 'vue'
 
-import { CHANNEL_C_DEFAULT_DUTY, CHANNEL_C_DEFAULT_ENVELOPE } from '@/core/sound/constants'
+import { CHANNEL_C_DEFAULT_DUTY, CHANNEL_C_DEFAULT_ENVELOPE, COMPOSER_DEFAULT_VOLUME } from '@/core/sound/constants'
 import { calculateNoteFrequency } from '@/core/sound/noteFrequency'
 import type { Note, Rest } from '@/core/sound/types'
 import type { NoteCellKey } from '@/features/ide/components/pianoRollConstants'
@@ -26,9 +26,6 @@ import { useWebAudioPlayer } from '@/features/ide/composables/useWebAudioPlayer'
 
 /** Number of sound channels in F-BASIC. */
 const CHANNEL_COUNT = 3
-
-/** Default volume for composer playback preview (0-15 scale). */
-const COMPOSER_DEFAULT_VOLUME = 10
 
 /** Returns true if the given index is a valid channel index (0 to CHANNEL_COUNT - 1). */
 function isValidChannelIndex(index: number): boolean {


### PR DESCRIPTION
## Summary
- Fixes #795

## Changes
- Moved `COMPOSER_DEFAULT_VOLUME` constant from local definition in `useComposerPlayback.ts` to shared `src/core/sound/constants.ts`
- Updated import in `useComposerPlayback.ts` to reference the shared constant
- Consistent with PR #760's intent of centralizing sound constants

## Test plan
- [ ] Targeted tests pass (37/37 useComposerPlayback tests)
- [ ] CI passes