### PR TITLE
fix: resolve #799 - add fallback filename for empty title in HTML export

### DIFF
--- a/src/features/ide/composables/useHtmlExporter.ts
+++ b/src/features/ide/composables/useHtmlExporter.ts
@@ -10,6 +10,9 @@ import { ref } from 'vue'
 
 import type { CompactBg } from '@/core/types/program-types'
 
+/** Default filename used when the export title is empty or whitespace-only. */
+export const DEFAULT_EXPORT_FILENAME = 'program.html'
+
 /** Options for the HTML export. */
 export interface HtmlExportOptions {
   /** Title for the exported HTML page. */
@@ -74,6 +77,23 @@ function triggerDownload(blob: Blob, filename: string): void {
 }
 
 /**
+ * Converts a user-provided title into a safe export filename.
+ *
+ * Falls back to {@link DEFAULT_EXPORT_FILENAME} when the title is empty
+ * or consists solely of whitespace, preventing filenames like `.html`.
+ *
+ * @param title - The user-provided page title
+ * @returns A filename string ending in `.html`
+ */
+export function toExportFilename(title: string): string {
+  const trimmed = title.trim()
+  if (trimmed.length === 0) {
+    return DEFAULT_EXPORT_FILENAME
+  }
+  return `${title}.html`
+}
+
+/**
  * Composable for exporting an F-BASIC program as a standalone HTML file.
  *
  * @param source - The F-BASIC program source code
@@ -100,7 +120,7 @@ export function useHtmlExporter(
     try {
       const html = buildMinimalHtml(source.value, options)
       const blob = new Blob([html], { type: HTML_MIME_TYPE })
-      const filename = `${options.title}.html`
+      const filename = toExportFilename(options.title)
       triggerDownload(blob, filename)
     } catch (err) {
       exportError.value = err instanceof Error ? err.message : String(err)

--- a/test/ide/useHtmlExporter.test.ts
+++ b/test/ide/useHtmlExporter.test.ts
@@ -10,7 +10,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
-import { useHtmlExporter } from '@/features/ide/composables/useHtmlExporter'
+import {
+  DEFAULT_EXPORT_FILENAME,
+  toExportFilename,
+  useHtmlExporter,
+} from '@/features/ide/composables/useHtmlExporter'
 
 // ============================================================================
 // Helpers
@@ -27,6 +31,32 @@ function mountComposable(code = '10 PRINT "HELLO"') {
 // ============================================================================
 // Tests
 // ============================================================================
+
+describe('toExportFilename', () => {
+  it('returns DEFAULT_EXPORT_FILENAME when title is empty string', () => {
+    expect(toExportFilename('')).toEqual(DEFAULT_EXPORT_FILENAME)
+  })
+
+  it('returns DEFAULT_EXPORT_FILENAME when title is whitespace only', () => {
+    expect(toExportFilename('   ')).toEqual(DEFAULT_EXPORT_FILENAME)
+  })
+
+  it('returns DEFAULT_EXPORT_FILENAME when title is tabs only', () => {
+    expect(toExportFilename('\t\t')).toEqual(DEFAULT_EXPORT_FILENAME)
+  })
+
+  it('returns filename with .html extension for a normal title', () => {
+    expect(toExportFilename('My Program')).toEqual('My Program.html')
+  })
+
+  it('preserves non-ASCII characters in title', () => {
+    expect(toExportFilename('プログラム')).toEqual('プログラム.html')
+  })
+
+  it('does not trim meaningful whitespace from title', () => {
+    expect(toExportFilename(' Hello ')).toEqual(' Hello .html')
+  })
+})
 
 describe('useHtmlExporter', () => {
   let createObjectURLSpy: ReturnType<typeof vi.spyOn>
@@ -239,7 +269,7 @@ describe('useHtmlExporter', () => {
       globalThis.Blob = savedBlob
     })
 
-    it('uses .html extension when title is empty string', async () => {
+    it('uses fallback filename when title is empty string', async () => {
       const { exportHtml } = mountComposable()
 
       await exportHtml({
@@ -250,7 +280,7 @@ describe('useHtmlExporter', () => {
       })
 
       const anchor = capturedAnchors[0]!
-      expect(anchor.getAttribute('download')).toEqual('.html')
+      expect(anchor.getAttribute('download')).toEqual(DEFAULT_EXPORT_FILENAME)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #799

## Changes
- Added `DEFAULT_EXPORT_FILENAME` constant (`'program.html'`) and `toExportFilename(title)` function to `useHtmlExporter.ts`
- When title is empty/whitespace, returns `'program.html'` instead of producing `.html` (hidden file on Unix)
- 6 new test cases covering empty, whitespace, and normal title scenarios

## Test plan
- [ ] Targeted tests pass (6/6 new + 17/17 existing ExportHtmlDialog tests)
- [ ] CI passes