### PR TITLE
refactor: resolve #797 - add TODO comments for unused options in buildMinimalHtml stub

### DIFF
--- a/src/features/ide/composables/useHtmlExporter.ts
+++ b/src/features/ide/composables/useHtmlExporter.ts
@@ -38,6 +38,9 @@ const HTML_MIME_TYPE = 'text/html;charset=utf-8'
  * @returns HTML string with the program source embedded
  */
 function buildMinimalHtml(source: string, options: HtmlExportOptions): string {
+  // TODO(#772): Use options.theme to embed the correct theme stylesheet
+  // TODO(#773): Use options.includeSound to conditionally embed sound data
+  // TODO(#773): Use options.includeSprites to conditionally embed sprite data
   const escapedSource = source
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')


### PR DESCRIPTION
## Summary
- Fixes #797

## Changes
- Added 3 TODO comments inside `buildMinimalHtml()` documenting the unused `options.theme`, `options.includeSound`, and `options.includeSprites` fields
- Each TODO references the relevant future issue (#772 for theme, #773 for sound/sprites)

## Test plan
- [ ] Targeted tests pass (17/17 useHtmlExporter tests)
- [ ] CI passes