### PR TITLE
fix: resolve #808 - add BGMSTOP mention to lesson 15 background music

### DIFF
--- a/src/features/ide/tutorial/lessons/lesson15BackgroundMusic.ts
+++ b/src/features/ide/tutorial/lessons/lesson15BackgroundMusic.ts
@@ -1,8 +1,8 @@
 /**
  * Lesson 15: Background Music — Non-blocking music with BGPLAY.
  *
- * Covers BGPLAY for playing background music
- * and combining music with programs.
+ * Covers BGPLAY for playing background music,
+ * BGMSTOP for stopping it, and combining music with programs.
  */
 
 import type { Lesson } from '../types'
@@ -70,16 +70,31 @@ export const lesson15BackgroundMusic: Lesson = {
     '50 LOCATE 0,22',
     '```',
 
-    '## PLAY vs BGPLAY',
+    '## Stopping Background Music',
+
+    'Use `BGMSTOP` to stop background music',
+    'entirely. This is different from calling',
+    '`BGPLAY` again — it silences the music',
+    'without starting a new song:',
+    '```basic',
+    '10 BGPLAY "T5O4C4D4E4F4G4A4B4"',
+    '20 PAUSE 40',
+    '30 BGMSTOP',
+    '40 PRINT "MUSIC STOPPED"',
+    '```',
+
+    '## PLAY vs BGPLAY vs BGMSTOP',
 
     '- `PLAY` — Waits for music to finish',
     '  before continuing the program',
     '- `BGPLAY` — Music plays in the background',
     '  while the program continues',
     '- `BGPLAY` again — Replaces the current song',
+    '- `BGMSTOP` — Stops background music entirely',
 
     'Use `PLAY` for sound effects and short sounds.',
     'Use `BGPLAY` for background music in games.',
+    'Use `BGMSTOP` to silence the music.',
 
     '## Try It',
 

--- a/test/ide/gamesLessons.test.ts
+++ b/test/ide/gamesLessons.test.ts
@@ -175,9 +175,10 @@ describe('gamesLessons', () => {
     expect(lesson.content).toMatch(/tempo/i)
   })
 
-  it('Background Music lesson explains BGPLAY', () => {
+  it('Background Music lesson explains BGPLAY and BGMSTOP', () => {
     const lesson = gamesLessons[6]!
     expect(lesson.content).toMatch(/\bBGPLAY\b/)
+    expect(lesson.content).toMatch(/\bBGMSTOP\b/)
     expect(lesson.content).toMatch(/music/i)
   })
 


### PR DESCRIPTION
## Summary
- Fixes #808 — adds `BGMSTOP` documentation to Lesson 15 (Background Music)

## Changes
- Added "Stopping Background Music" section with `BGMSTOP` code example to lesson 15
- Updated "PLAY vs BGPLAY" comparison section to include `BGMSTOP`
- Added test assertion verifying `BGMSTOP` is mentioned in lesson content

## Test plan
- [x] Targeted tests pass (17/17 in gamesLessons.test.ts)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes