### PR TITLE
refactor: resolve #809 - use unique keyword for lesson 17 in LESSON_KEYWORDS

### DIFF
--- a/test/ide/gamesLessons.test.ts
+++ b/test/ide/gamesLessons.test.ts
@@ -29,7 +29,7 @@ const LESSON_KEYWORDS: Array<RegExp> = [
   /\bPLAY\b/,
   /\bBGPLAY\b/,
   /\bGOTO\b/,
-  /\bBGPLAY\b/,
+  /\bSCORE\b/,
 ]
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #809

## Changes
- Changed `LESSON_KEYWORDS[8]` (lesson 17 - Building a Game Part 2) from duplicate `/\bBGPLAY\b/` to unique `/\bSCORE\b/`, matching lesson 17's game-scoring content
- Lesson 15 (index 6) retains `/\bBGPLAY\b/` as its unique keyword

## Test plan
- [x] 17/17 targeted tests pass (before and after change)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes