### PR TITLE
feat: resolve #629 - add i18n infrastructure for tutorial lesson content

### DIFF
--- a/src/features/ide/tutorial/index.ts
+++ b/src/features/ide/tutorial/index.ts
@@ -23,6 +23,9 @@ import { lesson15BackgroundMusic } from './lessons/lesson15BackgroundMusic'
 import { lesson16BuildingAGame1 } from './lessons/lesson16BuildingAGame1'
 import { lesson17BuildingAGame2 } from './lessons/lesson17BuildingAGame2'
 import type { Lesson } from './types'
+export type { ResolvedLessonContent } from './resolveLessonLocale'
+export { resolveLessonLocale } from './resolveLessonLocale'
+export type { Lesson, LessonTranslations } from './types'
 
 /**
  * Ordered array of basics tutorial lessons.

--- a/src/features/ide/tutorial/resolveLessonLocale.ts
+++ b/src/features/ide/tutorial/resolveLessonLocale.ts
@@ -1,0 +1,65 @@
+/**
+ * resolveLessonLocale — locale-aware lesson content resolution.
+ *
+ * Provides a pure utility function that resolves the correct
+ * title and content for a lesson based on the current locale,
+ * falling back to the base (English) values when no translation
+ * is available.
+ */
+
+import type { Lesson, LessonTranslations } from './types'
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolved lesson content with locale-aware title and body.
+ */
+export interface ResolvedLessonContent {
+  title: string
+  content: string
+}
+
+/**
+ * Resolves the title and content for a lesson in the given locale.
+ *
+ * Lookup strategy:
+ * 1. If `lesson.translations[locale]` exists, use its `title` and `content`.
+ * 2. Otherwise, fall back to the base `lesson.title` and `lesson.content`.
+ *
+ * @param lesson - The lesson data (base + optional translations).
+ * @param locale - The current locale identifier (e.g. `'ja'`, `'zh-CN'`).
+ * @returns An object with the resolved `title` and `content`.
+ */
+export function resolveLessonLocale(
+  lesson: Lesson,
+  locale: string,
+): ResolvedLessonContent {
+  const translation = getTranslation(lesson, locale)
+  if (translation) {
+    return {
+      title: translation.title,
+      content: translation.content,
+    }
+  }
+
+  return {
+    title: lesson.title,
+    content: lesson.content,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Retrieves the translation for the given locale, or `undefined` if none.
+ */
+function getTranslation(
+  lesson: Lesson,
+  locale: string,
+): LessonTranslations | undefined {
+  return lesson.translations?.[locale]
+}

--- a/src/features/ide/tutorial/types.ts
+++ b/src/features/ide/tutorial/types.ts
@@ -6,18 +6,44 @@
  */
 
 /**
+ * Localized title and content for a single lesson.
+ *
+ * Used by the optional `translations` field on {@link Lesson}
+ * to provide per-locale overrides without modifying the
+ * base (English) lesson data.
+ */
+export interface LessonTranslations {
+  /** Localized display title shown in the lesson navigation. */
+  title: string
+
+  /**
+   * Localized markdown content for the lesson body.
+   *
+   * Must follow the same markdown syntax as the base `content` field
+   * on {@link Lesson}.
+   */
+  content: string
+}
+
+/**
  * Represents a single tutorial lesson.
  *
  * Each lesson contains a title for navigation display and
  * markdown content that may include headings, paragraphs,
  * inline formatting, and fenced code blocks.
+ *
+ * Translations are optional and keyed by locale identifier
+ * (e.g. `'ja'`, `'zh-CN'`, `'zh-TW'`). When a translation
+ * for the current locale is available, it takes precedence
+ * over the base `title` and `content`. Use
+ * {@link resolveLessonLocale} to resolve the correct values.
  */
 export interface Lesson {
-  /** Display title shown in the lesson navigation. */
+  /** Display title shown in the lesson navigation (English default). */
   title: string
 
   /**
-   * Markdown content for the lesson body.
+   * Markdown content for the lesson body (English default).
    *
    * Supported syntax:
    * - Headings: `#` `##` `###`
@@ -31,4 +57,14 @@ export interface Lesson {
    * allows users to load the code into the editor.
    */
   content: string
+
+  /**
+   * Optional per-locale translations keyed by locale identifier.
+   *
+   * Example: `{ 'ja': { title: '...', content: '...' } }`
+   *
+   * When omitted, the base `title` and `content` serve as the
+   * fallback for all locales.
+   */
+  translations?: Record<string, LessonTranslations>
 }


### PR DESCRIPTION
## Summary
- Fixes #629 (Step 7 of 7 for #537)

## Changes
- Added `LessonTranslations` interface to `types.ts` for per-locale title/content overrides
- Added optional `translations?: Record<string, LessonTranslations>` field to `Lesson` interface
- Created `resolveLessonLocale.ts` utility with locale-aware content resolution (English fallback)
- Updated `index.ts` barrel exports for new types and utility

## Test plan
- [ ] Targeted tests pass (17/17 gamesLessons.test.ts)
- [ ] CI passes