### PR TITLE
refactor: resolve #819 - replace pass-through i18n mock with inline translations in test files

### DIFF
--- a/test/App.test.ts
+++ b/test/App.test.ts
@@ -10,7 +10,14 @@ import { reloadPage } from '@/shared/utils/reloadPage'
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     locale: ref('en'),
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'coi.warning.message': 'High-performance mode is unavailable because cross-origin isolation is not enabled. Try reloading, use HTTPS, and confirm COOP/COEP headers are configured.',
+        'coi.warning.reload': 'Reload',
+        'coi.warning.dismiss': 'Dismiss',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -105,7 +112,7 @@ describe('App', () => {
 
     const dismissButton = wrapper
       .findAll('button')
-      .find(button => button.text().trim() === 'coi.warning.dismiss')
+      .find(button => button.text().trim() === 'Dismiss')
     expect(dismissButton).toBeTruthy()
 
     await dismissButton!.trigger('click')
@@ -127,7 +134,7 @@ describe('App', () => {
 
     const reloadButton = wrapper
       .findAll('button')
-      .find(button => button.text().trim() === 'coi.warning.reload')
+      .find(button => button.text().trim() === 'Reload')
     expect(reloadButton).toBeTruthy()
 
     await reloadButton!.trigger('click')

--- a/test/features/ide/components/IdeEditorPanel.test.ts
+++ b/test/features/ide/components/IdeEditorPanel.test.ts
@@ -8,7 +8,16 @@ import IdeEditorPanel from '@/features/ide/components/IdeEditorPanel.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.codeEditor.title': 'Code Editor',
+        'ide.codeEditor.loading': 'Loading editor...',
+        'ide.samples.load': 'Sample',
+        'ide.spriteViewer.openTitle': 'Open Sprite Viewer',
+        'ide.tutorial.title': 'Tutorial',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 

--- a/test/features/ide/components/ScreenTab.test.ts
+++ b/test/features/ide/components/ScreenTab.test.ts
@@ -9,7 +9,14 @@ import ScreenTab from '@/features/ide/components/ScreenTab.vue'
 // Stub vue-i18n
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.output.screen': 'Screen',
+        'ide.screenTab.grid': 'Grid',
+        'ide.screenTab.filter': 'CRT',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -129,7 +136,7 @@ describe('ScreenTab', () => {
     const wrapper = mountScreenTab()
 
     const filterButton = wrapper.find('[data-testid="ide-filter-toggle"]')
-    expect(filterButton.text()).toEqual('ide.screenTab.filter')
+    expect(filterButton.text()).toEqual('CRT')
     wrapper.unmount()
   })
 

--- a/test/features/music-composer/MusicComposerPage.test.ts
+++ b/test/features/music-composer/MusicComposerPage.test.ts
@@ -17,7 +17,12 @@ vi.mock('@/shared/components/ui', () => ({
 // Stub vue-i18n
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'musicComposer.title': 'Music Composer',
+      }
+      return messages[key] ?? key
+    },
     locale: ref('en'),
   }),
 }))
@@ -64,7 +69,7 @@ describe('MusicComposerPage', () => {
 
     const heading = wrapper.find('h1')
     expect(heading.exists()).toBe(true)
-    expect(heading.text()).toEqual('musicComposer.title')
+    expect(heading.text()).toEqual('Music Composer')
     wrapper.unmount()
   })
 

--- a/test/ide/AnimationSyncSection.test.ts
+++ b/test/ide/AnimationSyncSection.test.ts
@@ -8,7 +8,32 @@ import AnimationSyncSection from '@/features/ide/components/AnimationSyncSection
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.bufferInspector.animationSyncTitle': 'Animation Sync',
+        'ide.bufferInspector.animationSyncIdle': '(idle)',
+        'ide.bufferInspector.animationSyncColField': 'Field',
+        'ide.bufferInspector.animationSyncColValue': 'Value',
+        'ide.bufferInspector.animationSyncFieldType': 'Command Type',
+        'ide.bufferInspector.animationSyncFieldAction': 'Action #',
+        'ide.bufferInspector.animationSyncFieldStartX': 'startX',
+        'ide.bufferInspector.animationSyncFieldStartY': 'startY',
+        'ide.bufferInspector.animationSyncFieldDirection': 'Direction',
+        'ide.bufferInspector.animationSyncFieldSpeed': 'Speed',
+        'ide.bufferInspector.animationSyncFieldDistance': 'Distance',
+        'ide.bufferInspector.animationSyncFieldPriority': 'Priority',
+        'ide.bufferInspector.animationSyncFieldAck': 'ACK',
+        'ide.bufferInspector.animationSyncAckPending': 'Pending',
+        'ide.bufferInspector.animationSyncAckReceived': 'Received',
+        'ide.bufferInspector.animationSyncCommandTypeNone': 'None',
+        'ide.bufferInspector.animationSyncCommandTypeStartMovement': 'Start',
+        'ide.bufferInspector.animationSyncCommandTypeStopMovement': 'Stop',
+        'ide.bufferInspector.animationSyncCommandTypeEraseMovement': 'Erase',
+        'ide.bufferInspector.animationSyncCommandTypeSetPosition': 'Set',
+        'ide.bufferInspector.animationSyncCommandTypeClearAllMovements': 'Clear All',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -52,7 +77,7 @@ describe('AnimationSyncSection', () => {
 
     const title = wrapper.find('.animation-sync-title')
     expect(title.exists()).toBe(true)
-    expect(title.text()).toBe('ide.bufferInspector.animationSyncTitle')
+    expect(title.text()).toBe('Animation Sync')
     wrapper.unmount()
   })
 
@@ -65,7 +90,7 @@ describe('AnimationSyncSection', () => {
     })
 
     expect(wrapper.find('.animation-sync-idle').exists()).toBe(true)
-    expect(wrapper.find('.animation-sync-idle').text()).toBe('ide.bufferInspector.animationSyncIdle')
+    expect(wrapper.find('.animation-sync-idle').text()).toBe('(idle)')
     expect(wrapper.find('.animation-sync-table').exists()).toBe(false)
     wrapper.unmount()
   })
@@ -93,8 +118,8 @@ describe('AnimationSyncSection', () => {
 
     const headers = wrapper.findAll('.sync-hdr')
     expect(headers.length).toBe(2)
-    expect(headers[0]!.text()).toBe('ide.bufferInspector.animationSyncColField')
-    expect(headers[1]!.text()).toBe('ide.bufferInspector.animationSyncColValue')
+    expect(headers[0]!.text()).toBe('Field')
+    expect(headers[1]!.text()).toBe('Value')
     wrapper.unmount()
   })
 
@@ -107,9 +132,9 @@ describe('AnimationSyncSection', () => {
     })
 
     const cells = wrapper.findAll('.sync-cell')
-    expect(cells[0]!.text()).toBe('ide.bufferInspector.animationSyncFieldType')
+    expect(cells[0]!.text()).toBe('Command Type')
     expect(cells[1]!.text()).toBe(
-      'ide.bufferInspector.animationSyncCommandTypeStartMovement',
+      'Start',
     )
     wrapper.unmount()
   })
@@ -124,7 +149,7 @@ describe('AnimationSyncSection', () => {
 
     const cells = wrapper.findAll('.sync-cell')
     // Action row is the 2nd row: field at index 2, value at index 3
-    expect(cells[2]!.text()).toBe('ide.bufferInspector.animationSyncFieldAction')
+    expect(cells[2]!.text()).toBe('Action #')
     expect(cells[3]!.text()).toBe('3')
     wrapper.unmount()
   })
@@ -155,17 +180,17 @@ describe('AnimationSyncSection', () => {
     // Row 5: speed (indices 10,11)
     // Row 6: distance (indices 12,13)
     // Row 7: priority (indices 14,15)
-    expect(cells[4]!.text()).toBe('ide.bufferInspector.animationSyncFieldStartX')
+    expect(cells[4]!.text()).toBe('startX')
     expect(cells[5]!.text()).toBe('10')
-    expect(cells[6]!.text()).toBe('ide.bufferInspector.animationSyncFieldStartY')
+    expect(cells[6]!.text()).toBe('startY')
     expect(cells[7]!.text()).toBe('20')
-    expect(cells[8]!.text()).toBe('ide.bufferInspector.animationSyncFieldDirection')
+    expect(cells[8]!.text()).toBe('Direction')
     expect(cells[9]!.text()).toBe('3')
-    expect(cells[10]!.text()).toBe('ide.bufferInspector.animationSyncFieldSpeed')
+    expect(cells[10]!.text()).toBe('Speed')
     expect(cells[11]!.text()).toBe('5')
-    expect(cells[12]!.text()).toBe('ide.bufferInspector.animationSyncFieldDistance')
+    expect(cells[12]!.text()).toBe('Distance')
     expect(cells[13]!.text()).toBe('100')
-    expect(cells[14]!.text()).toBe('ide.bufferInspector.animationSyncFieldPriority')
+    expect(cells[14]!.text()).toBe('Priority')
     expect(cells[15]!.text()).toBe('1')
     wrapper.unmount()
   })
@@ -180,8 +205,8 @@ describe('AnimationSyncSection', () => {
 
     const cells = wrapper.findAll('.sync-cell')
     // ACK is the last row: field at 16, value at 17
-    expect(cells[16]!.text()).toBe('ide.bufferInspector.animationSyncFieldAck')
-    expect(cells[17]!.text()).toBe('ide.bufferInspector.animationSyncAckPending')
+    expect(cells[16]!.text()).toBe('ACK')
+    expect(cells[17]!.text()).toBe('Pending')
     wrapper.unmount()
   })
 
@@ -194,19 +219,19 @@ describe('AnimationSyncSection', () => {
     })
 
     const cells = wrapper.findAll('.sync-cell')
-    expect(cells[16]!.text()).toBe('ide.bufferInspector.animationSyncFieldAck')
-    expect(cells[17]!.text()).toBe('ide.bufferInspector.animationSyncAckReceived')
+    expect(cells[16]!.text()).toBe('ACK')
+    expect(cells[17]!.text()).toBe('Received')
     wrapper.unmount()
   })
 
   it('maps all SyncCommandType values to i18n keys', () => {
     const cases: [SyncCommandType, string][] = [
-      [SyncCommandType.NONE, 'ide.bufferInspector.animationSyncCommandTypeNone'],
-      [SyncCommandType.START_MOVEMENT, 'ide.bufferInspector.animationSyncCommandTypeStartMovement'],
-      [SyncCommandType.STOP_MOVEMENT, 'ide.bufferInspector.animationSyncCommandTypeStopMovement'],
-      [SyncCommandType.ERASE_MOVEMENT, 'ide.bufferInspector.animationSyncCommandTypeEraseMovement'],
-      [SyncCommandType.SET_POSITION, 'ide.bufferInspector.animationSyncCommandTypeSetPosition'],
-      [SyncCommandType.CLEAR_ALL_MOVEMENTS, 'ide.bufferInspector.animationSyncCommandTypeClearAllMovements'],
+      [SyncCommandType.NONE, 'None'],
+      [SyncCommandType.START_MOVEMENT, 'Start'],
+      [SyncCommandType.STOP_MOVEMENT, 'Stop'],
+      [SyncCommandType.ERASE_MOVEMENT, 'Erase'],
+      [SyncCommandType.SET_POSITION, 'Set'],
+      [SyncCommandType.CLEAR_ALL_MOVEMENTS, 'Clear All'],
     ]
 
     for (const [commandType, expectedName] of cases) {
@@ -218,7 +243,7 @@ describe('AnimationSyncSection', () => {
       })
 
       const cells = wrapper.findAll('.sync-cell')
-      expect(cells[0]!.text()).toBe('ide.bufferInspector.animationSyncFieldType')
+      expect(cells[0]!.text()).toBe('Command Type')
       expect(cells[1]!.text()).toBe(expectedName)
       wrapper.unmount()
     }

--- a/test/ide/BufferInspector.test.ts
+++ b/test/ide/BufferInspector.test.ts
@@ -13,7 +13,12 @@ import { createTestKeyboardBuffer } from './helpers/createTestKeyboardBuffer'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.bufferInspector.title': 'Buffer Inspector',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -116,7 +121,7 @@ describe('BufferInspector', () => {
 
     const block = wrapper.find('.game-block-stub')
     expect(block.exists()).toBe(true)
-    expect(block.attributes('data-title')).toBe('ide.bufferInspector.title')
+    expect(block.attributes('data-title')).toBe('Buffer Inspector')
     wrapper.unmount()
   })
 

--- a/test/ide/ComposerControls.test.ts
+++ b/test/ide/ComposerControls.test.ts
@@ -7,7 +7,17 @@ import ComposerControls from '@/features/ide/components/ComposerControls.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.composer.title': 'Controls',
+        'ide.composer.tempo': 'Tempo',
+        'ide.composer.steps': 'Steps',
+        'ide.composer.octave': 'Octave',
+        'ide.composer.duration': 'Duration',
+        'ide.composer.envelope': 'Envelope',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 

--- a/test/ide/DebugTab.test.ts
+++ b/test/ide/DebugTab.test.ts
@@ -7,7 +7,12 @@ import DebugTab from '@/features/ide/components/DebugTab.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.output.debug': 'Debug',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 

--- a/test/ide/DisplayBufferSection.test.ts
+++ b/test/ide/DisplayBufferSection.test.ts
@@ -7,7 +7,13 @@ import type { ScreenBufferReader } from '@/features/ide/components/types'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.bufferInspector.displayBufferCharTitle': 'Character Codes',
+        'ide.bufferInspector.displayBufferPatternTitle': 'Color Patterns',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -53,7 +59,7 @@ describe('DisplayBufferSection', () => {
 
     const charTitle = wrapper.find('.display-buffer-char-title')
     expect(charTitle.exists()).toBe(true)
-    expect(charTitle.text()).toBe('ide.bufferInspector.displayBufferCharTitle')
+    expect(charTitle.text()).toBe('Character Codes')
     wrapper.unmount()
   })
 
@@ -66,7 +72,7 @@ describe('DisplayBufferSection', () => {
 
     const patternTitle = wrapper.find('.display-buffer-pattern-title')
     expect(patternTitle.exists()).toBe(true)
-    expect(patternTitle.text()).toBe('ide.bufferInspector.displayBufferPatternTitle')
+    expect(patternTitle.text()).toBe('Color Patterns')
     wrapper.unmount()
   })
 

--- a/test/ide/EditorViewToggle.test.ts
+++ b/test/ide/EditorViewToggle.test.ts
@@ -7,7 +7,15 @@ import EditorViewToggle from '@/features/ide/components/EditorViewToggle.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.editorViewToggle.codeTitle': 'Code',
+        'ide.editorViewToggle.bgTitle': 'BG',
+        'ide.editorViewToggle.code': 'Code',
+        'ide.editorViewToggle.bg': 'BG',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -129,8 +137,8 @@ describe('EditorViewToggle', () => {
     // Compact mode uses GameIconButton (no text, just icons)
     const buttons = wrapper.findAll('button')
     // Both buttons should have title attributes (from GameIconButton)
-    expect(buttons[0]!.attributes('title')).toEqual('ide.editorViewToggle.codeTitle')
-    expect(buttons[1]!.attributes('title')).toEqual('ide.editorViewToggle.bgTitle')
+    expect(buttons[0]!.attributes('title')).toEqual('Code')
+    expect(buttons[1]!.attributes('title')).toEqual('BG')
     wrapper.unmount()
   })
 })

--- a/test/ide/ErrorPanel.test.ts
+++ b/test/ide/ErrorPanel.test.ts
@@ -7,7 +7,20 @@ import ErrorPanel from '@/features/ide/components/ErrorPanel.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string, params?: Record<string, string | number>) => {
+      const messages: Record<string, string> = {
+        'ide.output.errorLine': 'Line {line}',
+        'ide.errorPanel.sourceLabel': 'At:',
+        'ide.errorPanel.stackTrace': 'Stack trace',
+      }
+      let text = messages[key] ?? key
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          text = text.replace(`{${k}}`, String(v))
+        }
+      }
+      return text
+    },
   }),
 }))
 
@@ -88,7 +101,7 @@ describe('ErrorPanel', () => {
 
     const lineSpan = wrapper.find('.error-line-number')
     expect(lineSpan.exists()).toBe(true)
-    expect(lineSpan.text()).toEqual('(ide.output.errorLine)')
+    expect(lineSpan.text()).toEqual('(Line 42)')
     wrapper.unmount()
   })
 
@@ -125,7 +138,7 @@ describe('ErrorPanel', () => {
     const sourceDiv = wrapper.find('.error-source-line')
     expect(sourceDiv.exists()).toBe(true)
     expect(sourceDiv.find('code').text()).toEqual('10 PRINT "Hello"')
-    expect(sourceDiv.find('.error-source-label').text()).toEqual('ide.errorPanel.sourceLabel')
+    expect(sourceDiv.find('.error-source-label').text()).toEqual('At:')
     wrapper.unmount()
   })
 
@@ -151,7 +164,7 @@ describe('ErrorPanel', () => {
 
     const details = wrapper.find('details.error-stack-details')
     expect(details.exists()).toBe(true)
-    expect(details.find('summary').text()).toEqual('ide.errorPanel.stackTrace')
+    expect(details.find('summary').text()).toEqual('Stack trace')
     expect(details.find('pre.error-stack').text()).toEqual('at line 10\nat line 5')
     wrapper.unmount()
   })

--- a/test/ide/ExportHtmlDialog.test.ts
+++ b/test/ide/ExportHtmlDialog.test.ts
@@ -12,7 +12,23 @@ import ExportHtmlDialog from '@/features/ide/components/ExportHtmlDialog.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.exportHtml.title': 'Export as HTML',
+        'ide.exportHtml.description': 'Export your program as a standalone HTML file that runs in any browser.',
+        'ide.exportHtml.exporting': 'Exporting...',
+        'ide.exportHtml.exportFailed': 'Failed to export HTML file.',
+        'ide.exportHtml.titleLabel': 'Page Title',
+        'ide.exportHtml.themeLabel': 'Theme',
+        'ide.exportHtml.themeDark': 'Dark',
+        'ide.exportHtml.themeLight': 'Light',
+        'ide.exportHtml.includeSound': 'Include sound',
+        'ide.exportHtml.includeSprites': 'Include sprites',
+        'ide.exportHtml.exportButton': 'Export',
+        'ide.exportHtml.cancelButton': 'Cancel',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -96,7 +112,7 @@ describe('ExportHtmlDialog', () => {
     const overlay = wrapper.find('.game-dialog-overlay')
     expect(overlay.attributes('role')).toEqual('dialog')
     expect(overlay.attributes('aria-modal')).toEqual('true')
-    expect(overlay.attributes('aria-label')).toEqual('ide.exportHtml.title')
+    expect(overlay.attributes('aria-label')).toEqual('Export as HTML')
     wrapper.unmount()
   })
 
@@ -242,7 +258,7 @@ describe('ExportHtmlDialog', () => {
     await nextTick()
 
     expect(wrapper.find('[data-testid="export-html-exporting"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="export-html-exporting"]').text()).toEqual('ide.exportHtml.exporting')
+    expect(wrapper.find('[data-testid="export-html-exporting"]').text()).toEqual('Exporting...')
     wrapper.unmount()
   })
 
@@ -253,7 +269,7 @@ describe('ExportHtmlDialog', () => {
     await nextTick()
 
     expect(wrapper.find('[data-testid="export-html-error"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="export-html-error"]').text()).toEqual('ide.exportHtml.exportFailed')
+    expect(wrapper.find('[data-testid="export-html-error"]').text()).toEqual('Failed to export HTML file.')
     wrapper.unmount()
   })
 

--- a/test/ide/IdeControls.test.ts
+++ b/test/ide/IdeControls.test.ts
@@ -7,7 +7,15 @@ import IdeControls from '@/features/ide/components/IdeControls.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.controls.run': 'Run',
+        'ide.controls.stop': 'Stop',
+        'ide.controls.clear': 'Clear',
+        'ide.controls.debug': 'Debug',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 

--- a/test/ide/InputModal.test.ts
+++ b/test/ide/InputModal.test.ts
@@ -7,7 +7,15 @@ import InputModal from '@/features/ide/components/InputModal.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.inputModal.inputPlaceholder': 'Separate multiple values with commas',
+        'ide.inputModal.linputPlaceholder': 'Enter text (up to 31 chars)',
+        'ide.input.submit': 'OK',
+        'ide.input.cancel': 'Cancel',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -67,7 +75,7 @@ describe('InputModal', () => {
     })
 
     const input = wrapper.find('[data-testid="input-modal-field"]')
-    expect(input.attributes('placeholder')).toEqual('ide.inputModal.inputPlaceholder')
+    expect(input.attributes('placeholder')).toEqual('Separate multiple values with commas')
     wrapper.unmount()
   })
 
@@ -78,7 +86,7 @@ describe('InputModal', () => {
     })
 
     const input = wrapper.find('[data-testid="input-modal-field"]')
-    expect(input.attributes('placeholder')).toEqual('ide.inputModal.linputPlaceholder')
+    expect(input.attributes('placeholder')).toEqual('Enter text (up to 31 chars)')
     wrapper.unmount()
   })
 

--- a/test/ide/InputModeToggle.test.ts
+++ b/test/ide/InputModeToggle.test.ts
@@ -7,7 +7,15 @@ import InputModeToggle from '@/features/ide/components/InputModeToggle.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.inputModeToggle.joystickTitle': 'Joystick Mode (STICK/STRIG)',
+        'ide.inputModeToggle.keyboardTitle': 'Keyboard Mode (INKEY$)',
+        'ide.inputModeToggle.joystick': 'Joy',
+        'ide.inputModeToggle.keyboard': 'Key',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -112,8 +120,8 @@ describe('InputModeToggle', () => {
     })
 
     const buttons = wrapper.findAll('button')
-    expect(buttons[0]!.attributes('title')).toEqual('ide.inputModeToggle.joystickTitle')
-    expect(buttons[1]!.attributes('title')).toEqual('ide.inputModeToggle.keyboardTitle')
+    expect(buttons[0]!.attributes('title')).toEqual('Joystick Mode (STICK/STRIG)')
+    expect(buttons[1]!.attributes('title')).toEqual('Keyboard Mode (INKEY$)')
     wrapper.unmount()
   })
 

--- a/test/ide/JoystickBufferSection.test.ts
+++ b/test/ide/JoystickBufferSection.test.ts
@@ -12,7 +12,17 @@ import JoystickBufferSection from '@/features/ide/components/JoystickBufferSecti
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.bufferInspector.joystickTitle': 'Joystick Buffer',
+        'ide.bufferInspector.joystickUnavailable': 'No joystick buffer',
+        'ide.bufferInspector.joystick0': 'Joy 0',
+        'ide.bufferInspector.joystick1': 'Joy 1',
+        'ide.bufferInspector.joystickStick': 'STICK',
+        'ide.bufferInspector.joystickStrig': 'STRIG',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -50,7 +60,7 @@ describe('JoystickBufferSection', () => {
 
     const title = wrapper.find('.joystick-buffer-title')
     expect(title.exists()).toBe(true)
-    expect(title.text()).toBe('ide.bufferInspector.joystickTitle')
+    expect(title.text()).toBe('Joystick Buffer')
     wrapper.unmount()
   })
 
@@ -64,7 +74,7 @@ describe('JoystickBufferSection', () => {
 
     expect(wrapper.find('.joystick-buffer-unavailable').exists()).toBe(true)
     expect(wrapper.find('.joystick-buffer-unavailable').text()).toBe(
-      'ide.bufferInspector.joystickUnavailable'
+      'No joystick buffer'
     )
     wrapper.unmount()
   })
@@ -93,8 +103,8 @@ describe('JoystickBufferSection', () => {
 
     const labels = wrapper.findAll('.joystick-buffer-label')
     expect(labels.length).toBe(2)
-    expect(labels[0]!.text()).toBe('ide.bufferInspector.joystick0')
-    expect(labels[1]!.text()).toBe('ide.bufferInspector.joystick1')
+    expect(labels[0]!.text()).toBe('Joy 0')
+    expect(labels[1]!.text()).toBe('Joy 1')
     wrapper.unmount()
   })
 
@@ -151,8 +161,8 @@ describe('JoystickBufferSection', () => {
     const strigLabels = wrapper.findAll('.joystick-strig-label')
     expect(stickLabels.length).toBe(2)
     expect(strigLabels.length).toBe(2)
-    expect(stickLabels[0]!.text()).toBe('ide.bufferInspector.joystickStick')
-    expect(strigLabels[0]!.text()).toBe('ide.bufferInspector.joystickStrig')
+    expect(stickLabels[0]!.text()).toBe('STICK')
+    expect(strigLabels[0]!.text()).toBe('STRIG')
     wrapper.unmount()
   })
 

--- a/test/ide/JoystickControl.test.ts
+++ b/test/ide/JoystickControl.test.ts
@@ -7,7 +7,23 @@ import JoystickControl from '@/features/ide/components/JoystickControl.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string, params?: Record<string, string | number>) => {
+      const messages: Record<string, string> = {
+        'ide.joystick.control': 'Joystick Control',
+        'ide.joystick.joystick0': 'Joystick 0',
+        'ide.joystick.joystick1': 'Joystick 1',
+        'ide.joystick.joystick': 'Joystick {id}',
+        'ide.joystick.keyboardHint': 'Keyboard control enabled',
+        'ide.joystick.configureKeys': 'Configure Keys',
+      }
+      let text = messages[key] ?? key
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          text = text.replace(`{${k}}`, String(v))
+        }
+      }
+      return text
+    },
   }),
 }))
 
@@ -221,7 +237,7 @@ describe('JoystickControl', () => {
       },
     })
 
-    const configureButton = wrapper.findAll('.game-button-stub').find(b => b.text() === 'ide.joystick.configureKeys')!
+    const configureButton = wrapper.findAll('.game-button-stub').find(b => b.text() === 'Configure Keys')!
     await configureButton.trigger('click')
 
     const panel = wrapper.find('.joystick-keybinding-panel-stub')

--- a/test/ide/KeyboardBufferSection.test.ts
+++ b/test/ide/KeyboardBufferSection.test.ts
@@ -10,7 +10,15 @@ import { POLL_INTERVAL_MS } from '@/features/ide/components/keyboardBufferSectio
 import { createTestKeyboardBuffer } from './helpers/createTestKeyboardBuffer'
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.bufferInspector.keyboardBufferTitle': 'Keyboard Buffer',
+        'ide.bufferInspector.keyboardCharCode': 'Char Code',
+        'ide.bufferInspector.keyboardModifiers': 'Modifiers',
+        'ide.bufferInspector.keyboardAvailable': 'Available',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -47,7 +55,7 @@ describe('KeyboardBufferSection', () => {
 
     const title = wrapper.find('.keyboard-buffer-title')
     expect(title.exists()).toBe(true)
-    expect(title.text()).toBe('ide.bufferInspector.keyboardBufferTitle')
+    expect(title.text()).toBe('Keyboard Buffer')
     wrapper.unmount()
   })
 
@@ -70,9 +78,9 @@ describe('KeyboardBufferSection', () => {
 
     const labels = wrapper.findAll('.keyboard-buffer-label')
     expect(labels.length).toBe(3)
-    expect(labels[0]!.text()).toBe('ide.bufferInspector.keyboardCharCode')
-    expect(labels[1]!.text()).toBe('ide.bufferInspector.keyboardModifiers')
-    expect(labels[2]!.text()).toBe('ide.bufferInspector.keyboardAvailable')
+    expect(labels[0]!.text()).toBe('Char Code')
+    expect(labels[1]!.text()).toBe('Modifiers')
+    expect(labels[2]!.text()).toBe('Available')
     wrapper.unmount()
   })
 

--- a/test/ide/LessonContent.test.ts
+++ b/test/ide/LessonContent.test.ts
@@ -10,7 +10,12 @@ import LessonContent from '@/features/ide/components/LessonContent.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.tutorial.tryIt': 'Try It',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -170,7 +175,7 @@ describe('LessonContent', () => {
     })
 
     const tryButton = wrapper.find('[data-testid="lesson-try-it-button"]')
-    expect(tryButton.text()).toEqual('ide.tutorial.tryIt')
+    expect(tryButton.text()).toEqual('Try It')
     wrapper.unmount()
   })
 

--- a/test/ide/LogLevelPanel.test.ts
+++ b/test/ide/LogLevelPanel.test.ts
@@ -7,7 +7,20 @@ import LogLevelPanel from '@/features/ide/components/LogLevelPanel.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string, params?: Record<string, string | number>) => {
+      const messages: Record<string, string> = {
+        'ide.logLevels.title': 'Log Levels',
+        'ide.logLevels.description': 'Set verbosity per area. {warn} = quiet; {debug} = verbose.',
+        'ide.logLevels.ariaLabelFor': 'Log level for {name}',
+      }
+      let text = messages[key] ?? key
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          text = text.replace(`{${k}}`, String(v))
+        }
+      }
+      return text
+    },
   }),
 }))
 
@@ -191,7 +204,7 @@ describe('LogLevelPanel', () => {
     })
 
     const firstSelect = wrapper.find('select')
-    expect(firstSelect.attributes('aria-label')).toEqual('ide.logLevels.ariaLabelFor')
+    expect(firstSelect.attributes('aria-label')).toEqual('Log level for Screen')
     wrapper.unmount()
   })
 })

--- a/test/ide/MovementCard.test.ts
+++ b/test/ide/MovementCard.test.ts
@@ -13,7 +13,46 @@ const gameIconStub = defineComponent({
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string, params?: Record<string, string | number>) => {
+      const messages: Record<string, string> = {
+        'ide.movementCard.actionNumber': 'Action number',
+        'ide.movementCard.statusActive': 'Active',
+        'ide.movementCard.statusPaused': 'Paused',
+        'ide.movementCard.directionAria': 'direction {direction}',
+        'ide.movementCard.characterTypes.MARIO': 'Mario',
+        'ide.movementCard.characterTypes.LADY': 'Lady',
+        'ide.movementCard.characterTypes.FIGHTER_FLY': 'Fighter Fly',
+        'ide.movementCard.characterTypes.ACHILLES': 'Achilles',
+        'ide.movementCard.characterTypes.PENGUIN': 'Penguin',
+        'ide.movementCard.characterTypes.FIREBALL': 'Fireball',
+        'ide.movementCard.characterTypes.CAR': 'Car',
+        'ide.movementCard.characterTypes.SPINNER': 'Spinner',
+        'ide.movementCard.characterTypes.STAR_KILLER': 'Star Killer',
+        'ide.movementCard.characterTypes.STARSHIP': 'Starship',
+        'ide.movementCard.characterTypes.EXPLOSION': 'Explosion',
+        'ide.movementCard.characterTypes.SMILEY': 'Smiley',
+        'ide.movementCard.characterTypes.LASER': 'Laser',
+        'ide.movementCard.characterTypes.SHELL_CREEPER': 'Shellcreeper',
+        'ide.movementCard.characterTypes.SIDE_STEPPER': 'Sidestepper',
+        'ide.movementCard.characterTypes.NITPICKER': 'Nitpicker',
+        'ide.movementCard.directions.0': 'none',
+        'ide.movementCard.directions.1': 'up',
+        'ide.movementCard.directions.2': 'up-right',
+        'ide.movementCard.directions.3': 'right',
+        'ide.movementCard.directions.4': 'down-right',
+        'ide.movementCard.directions.5': 'down',
+        'ide.movementCard.directions.6': 'down-left',
+        'ide.movementCard.directions.7': 'left',
+        'ide.movementCard.directions.8': 'up-left',
+      }
+      let text = messages[key] ?? key
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          text = text.replace(`{${k}}`, String(v))
+        }
+      }
+      return text
+    },
   }),
 }))
 
@@ -49,35 +88,35 @@ describe('MovementCard', () => {
     it('uses i18n key for MARIO character type (code 0)', () => {
       const wrapper = mountCard(createSlotData({ characterType: 0 }))
       const charSpan = wrapper.find('.move-card-char')
-      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.MARIO')
+      expect(charSpan.attributes('title')).toEqual('Mario')
       wrapper.unmount()
     })
 
     it('uses i18n key for PENGUIN character type (code 4)', () => {
       const wrapper = mountCard(createSlotData({ characterType: 4 }))
       const charSpan = wrapper.find('.move-card-char')
-      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.PENGUIN')
+      expect(charSpan.attributes('title')).toEqual('Penguin')
       wrapper.unmount()
     })
 
     it('uses i18n key for FIREBALL character type (code 5)', () => {
       const wrapper = mountCard(createSlotData({ characterType: 5 }))
       const charSpan = wrapper.find('.move-card-char')
-      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.FIREBALL')
+      expect(charSpan.attributes('title')).toEqual('Fireball')
       wrapper.unmount()
     })
 
     it('uses i18n key for STAR_KILLER character type (code 8)', () => {
       const wrapper = mountCard(createSlotData({ characterType: 8 }))
       const charSpan = wrapper.find('.move-card-char')
-      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.STAR_KILLER')
+      expect(charSpan.attributes('title')).toEqual('Star Killer')
       wrapper.unmount()
     })
 
     it('uses i18n key for SHELL_CREEPER character type (code 13)', () => {
       const wrapper = mountCard(createSlotData({ characterType: 13 }))
       const charSpan = wrapper.find('.move-card-char')
-      expect(charSpan.attributes('title')).toEqual('ide.movementCard.characterTypes.SHELL_CREEPER')
+      expect(charSpan.attributes('title')).toEqual('Shellcreeper')
       wrapper.unmount()
     })
 
@@ -99,14 +138,14 @@ describe('MovementCard', () => {
     it('shows active status icon when slot is active', () => {
       const wrapper = mountCard(createSlotData({ isActive: true }))
       const statusSpan = wrapper.find('.move-card-status')
-      expect(statusSpan.attributes('title')).toEqual('ide.movementCard.statusActive')
+      expect(statusSpan.attributes('title')).toEqual('Active')
       wrapper.unmount()
     })
 
     it('shows paused status icon when slot is paused', () => {
       const wrapper = mountCard(createSlotData({ isActive: false }))
       const statusSpan = wrapper.find('.move-card-status')
-      expect(statusSpan.attributes('title')).toEqual('ide.movementCard.statusPaused')
+      expect(statusSpan.attributes('title')).toEqual('Paused')
       wrapper.unmount()
     })
 
@@ -114,7 +153,7 @@ describe('MovementCard', () => {
       const wrapper = mountCard(createSlotData({ direction: 3 }))
       const dirSpan = wrapper.find('.move-card-dir')
       expect(dirSpan.attributes('aria-label')).toEqual(
-        'ide.movementCard.directionAria',
+        'direction right',
       )
       wrapper.unmount()
     })
@@ -129,7 +168,7 @@ describe('MovementCard', () => {
     it('displays truncated character type label in card text', () => {
       const wrapper = mountCard(createSlotData({ characterType: 0 }))
       const charSpan = wrapper.find('.move-card-char')
-      // With i18n mock returning the key, the key is sliced to 5 chars
+      // With i18n mock returning translated text, 'Mario' is sliced to 5 chars
       const text = charSpan.text()
       expect(text.length).toBeLessThanOrEqual(5)
       wrapper.unmount()

--- a/test/ide/RuntimeOutput.test.ts
+++ b/test/ide/RuntimeOutput.test.ts
@@ -7,7 +7,15 @@ import RuntimeOutput from '@/features/ide/components/RuntimeOutput.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.output.title': 'Runtime Output',
+        'ide.output.screen': 'Screen',
+        'ide.output.variables': 'Variables',
+        'ide.output.debug': 'Debug',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 

--- a/test/ide/SampleSelector.test.ts
+++ b/test/ide/SampleSelector.test.ts
@@ -8,7 +8,25 @@ import SampleSelector from '@/features/ide/components/SampleSelector.vue'
 // Mock vue-i18n to return the key as translation
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string, fallbackOrParams?: string | Record<string, string | number>) => {
+      const messages: Record<string, string> = {
+        'ide.samples.title': 'Load Sample',
+        'ide.samples.closeAriaLabel': 'Close',
+        'ide.samples.emptyCategory': 'No samples in this category',
+        'ide.samples.bgIndicatorTitle': 'Includes BG data',
+        'common.buttons.cancel': 'Cancel',
+      }
+      if (typeof fallbackOrParams === 'string') {
+        return messages[key] ?? fallbackOrParams
+      }
+      let text = messages[key] ?? key
+      if (fallbackOrParams) {
+        for (const [k, v] of Object.entries(fallbackOrParams)) {
+          text = text.replace(`{${k}}`, String(v))
+        }
+      }
+      return text
+    },
   }),
 }))
 

--- a/test/ide/ShareDialog.test.ts
+++ b/test/ide/ShareDialog.test.ts
@@ -12,7 +12,19 @@ import ShareDialog from '@/features/ide/components/ShareDialog.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.share.title': 'Share',
+        'ide.share.description': 'Copy this URL to share your program with others.',
+        'ide.share.copy': 'Copy URL',
+        'ide.share.copied': 'Copied!',
+        'ide.share.close': 'Close',
+        'ide.share.encoding': 'Generating share URL...',
+        'ide.share.encodeFailed': 'Failed to generate share URL.',
+        'ide.share.tooLarge': 'This program is too large to share via URL.',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -121,7 +133,7 @@ describe('ShareDialog', () => {
     const overlay = wrapper.find('.game-dialog-overlay')
     expect(overlay.attributes('role')).toEqual('dialog')
     expect(overlay.attributes('aria-modal')).toEqual('true')
-    expect(overlay.attributes('aria-label')).toEqual('ide.share.title')
+    expect(overlay.attributes('aria-label')).toEqual('Share')
     wrapper.unmount()
   })
 
@@ -139,7 +151,7 @@ describe('ShareDialog', () => {
     await nextTick()
 
     expect(wrapper.find('.game-dialog-loading').exists()).toBe(true)
-    expect(wrapper.find('.game-dialog-loading').text()).toEqual('ide.share.encoding')
+    expect(wrapper.find('.game-dialog-loading').text()).toEqual('Generating share URL...')
 
     resolveEncode(DEFAULT_ENCODE_RESULT)
     await waitForEncoding()
@@ -156,7 +168,7 @@ describe('ShareDialog', () => {
     await waitForEncoding()
 
     expect(wrapper.find('.game-dialog-error').exists()).toBe(true)
-    expect(wrapper.find('.game-dialog-error').text()).toEqual('ide.share.encodeFailed')
+    expect(wrapper.find('.game-dialog-error').text()).toEqual('Failed to generate share URL.')
     wrapper.unmount()
   })
 
@@ -193,7 +205,7 @@ describe('ShareDialog', () => {
     await waitForEncoding()
 
     expect(wrapper.find('.share-dialog-warning').exists()).toBe(true)
-    expect(wrapper.find('.share-dialog-warning').text()).toEqual('ide.share.tooLarge')
+    expect(wrapper.find('.share-dialog-warning').text()).toEqual('This program is too large to share via URL.')
     wrapper.unmount()
   })
 
@@ -216,7 +228,7 @@ describe('ShareDialog', () => {
     await nextTick()
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('http://localhost/#/share/abc123')
-    expect(wrapper.find('[data-testid="share-copy-button"]').text()).toEqual('ide.share.copied')
+    expect(wrapper.find('[data-testid="share-copy-button"]').text()).toEqual('Copied!')
     wrapper.unmount()
   })
 
@@ -228,12 +240,12 @@ describe('ShareDialog', () => {
     await wrapper.find('[data-testid="share-copy-button"]').trigger('click')
     await nextTick()
 
-    expect(wrapper.find('[data-testid="share-copy-button"]').text()).toEqual('ide.share.copied')
+    expect(wrapper.find('[data-testid="share-copy-button"]').text()).toEqual('Copied!')
 
     vi.advanceTimersByTime(2000)
     await nextTick()
 
-    expect(wrapper.find('[data-testid="share-copy-button"]').text()).toEqual('ide.share.copy')
+    expect(wrapper.find('[data-testid="share-copy-button"]').text()).toEqual('Copy URL')
     wrapper.unmount()
   })
 

--- a/test/ide/SpriteSlotsSection.test.ts
+++ b/test/ide/SpriteSlotsSection.test.ts
@@ -7,7 +7,23 @@ import SpriteSlotsSection from '@/features/ide/components/SpriteSlotsSection.vue
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.bufferInspector.spriteSlotsTitle': 'Sprite Slots',
+        'ide.bufferInspector.spriteSlotsDisabled': 'SPRITE OFF',
+        'ide.bufferInspector.spriteSlotsOn': 'ON',
+        'ide.bufferInspector.spriteSlotsOff': 'OFF',
+        'ide.bufferInspector.spriteSlotsDefined': 'Yes',
+        'ide.bufferInspector.spriteSlotsNone': '-',
+        'ide.bufferInspector.spriteSlotsColNumber': '#',
+        'ide.bufferInspector.spriteSlotsColX': 'X',
+        'ide.bufferInspector.spriteSlotsColY': 'Y',
+        'ide.bufferInspector.spriteSlotsColVisible': 'Visible',
+        'ide.bufferInspector.spriteSlotsColPriority': 'Priority',
+        'ide.bufferInspector.spriteSlotsColDefinition': 'Definition',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -59,7 +75,7 @@ describe('SpriteSlotsSection', () => {
     })
 
     expect(wrapper.find('.sprite-slots-disabled').exists()).toBe(true)
-    expect(wrapper.find('.sprite-slots-disabled').text()).toBe('ide.bufferInspector.spriteSlotsDisabled')
+    expect(wrapper.find('.sprite-slots-disabled').text()).toBe('SPRITE OFF')
     wrapper.unmount()
   })
 
@@ -85,7 +101,7 @@ describe('SpriteSlotsSection', () => {
 
     const title = wrapper.find('.sprite-slots-title')
     expect(title.exists()).toBe(true)
-    expect(title.text()).toBe('ide.bufferInspector.spriteSlotsTitle')
+    expect(title.text()).toBe('Sprite Slots')
     wrapper.unmount()
   })
 
@@ -157,8 +173,8 @@ describe('SpriteSlotsSection', () => {
 
     const visibleCells = wrapper.findAll('.sprite-slots-cell-visible')
     expect(visibleCells.length).toBe(2)
-    expect(visibleCells[0]!.text()).toBe('ide.bufferInspector.spriteSlotsOn')
-    expect(visibleCells[1]!.text()).toBe('ide.bufferInspector.spriteSlotsOff')
+    expect(visibleCells[0]!.text()).toBe('ON')
+    expect(visibleCells[1]!.text()).toBe('OFF')
     wrapper.unmount()
   })
 
@@ -207,8 +223,8 @@ describe('SpriteSlotsSection', () => {
 
     const defCells = wrapper.findAll('.sprite-slots-cell-definition')
     expect(defCells.length).toBe(2)
-    expect(defCells[0]!.text()).toBe('ide.bufferInspector.spriteSlotsNone')
-    expect(defCells[1]!.text()).toBe('ide.bufferInspector.spriteSlotsDefined')
+    expect(defCells[0]!.text()).toBe('-')
+    expect(defCells[1]!.text()).toBe('Yes')
     wrapper.unmount()
   })
 
@@ -222,12 +238,12 @@ describe('SpriteSlotsSection', () => {
 
     const headers = wrapper.findAll('.sprite-slots-header-cell')
     expect(headers.length).toBe(6)
-    expect(headers[0]!.text()).toBe('ide.bufferInspector.spriteSlotsColNumber')
-    expect(headers[1]!.text()).toBe('ide.bufferInspector.spriteSlotsColX')
-    expect(headers[2]!.text()).toBe('ide.bufferInspector.spriteSlotsColY')
-    expect(headers[3]!.text()).toBe('ide.bufferInspector.spriteSlotsColVisible')
-    expect(headers[4]!.text()).toBe('ide.bufferInspector.spriteSlotsColPriority')
-    expect(headers[5]!.text()).toBe('ide.bufferInspector.spriteSlotsColDefinition')
+    expect(headers[0]!.text()).toBe('#')
+    expect(headers[1]!.text()).toBe('X')
+    expect(headers[2]!.text()).toBe('Y')
+    expect(headers[3]!.text()).toBe('Visible')
+    expect(headers[4]!.text()).toBe('Priority')
+    expect(headers[5]!.text()).toBe('Definition')
     wrapper.unmount()
   })
 })

--- a/test/ide/StateInspector.test.ts
+++ b/test/ide/StateInspector.test.ts
@@ -9,7 +9,22 @@ import enIde from '@/shared/i18n/locales/en/ide.json'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.stateInspector.title': 'State Inspector',
+        'ide.stateInspector.tabPalette': 'PALETTE',
+        'ide.stateInspector.tabSprite': 'SPRITE',
+        'ide.stateInspector.tabMove': 'MOVE',
+        'ide.stateInspector.tabBg': 'BG',
+        'ide.stateInspector.backdrop': 'Backdrop',
+        'ide.stateInspector.cgen': 'CGEN',
+        'ide.stateInspector.spriteEnabled': 'SPRITE ON',
+        'ide.stateInspector.on': 'ON',
+        'ide.stateInspector.off': 'OFF',
+        'ide.stateInspector.empty': '(none)',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 

--- a/test/ide/TutorialPanel.test.ts
+++ b/test/ide/TutorialPanel.test.ts
@@ -7,7 +7,17 @@ import TutorialPanel from '@/features/ide/components/TutorialPanel.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.tutorial.title': 'Tutorial',
+        'ide.tutorial.defaultTitle': 'F-BASIC Tutorial',
+        'ide.tutorial.closeAriaLabel': 'Close tutorial',
+        'ide.tutorial.prev': 'Previous lesson',
+        'ide.tutorial.next': 'Next lesson',
+        'ide.tutorial.noContent': 'No lesson content available.',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 
@@ -40,7 +50,7 @@ describe('TutorialPanel', () => {
     })
 
     const panel = wrapper.find('[role="complementary"]')
-    expect(panel.attributes('aria-label')).toEqual('ide.tutorial.title')
+    expect(panel.attributes('aria-label')).toEqual('Tutorial')
     wrapper.unmount()
   })
 
@@ -64,7 +74,7 @@ describe('TutorialPanel', () => {
       },
     })
 
-    expect(wrapper.text()).toContain('ide.tutorial.defaultTitle')
+    expect(wrapper.text()).toContain('F-BASIC Tutorial')
     wrapper.unmount()
   })
 
@@ -93,7 +103,7 @@ describe('TutorialPanel', () => {
 
     const closeButton = wrapper.find('[data-testid="tutorial-close-button"]')
     expect(closeButton.exists()).toBe(true)
-    expect(closeButton.attributes('title')).toEqual('ide.tutorial.closeAriaLabel')
+    expect(closeButton.attributes('title')).toEqual('Close tutorial')
     wrapper.unmount()
   })
 

--- a/test/ide/VariablesTab.test.ts
+++ b/test/ide/VariablesTab.test.ts
@@ -7,7 +7,12 @@ import VariablesTab from '@/features/ide/components/VariablesTab.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'ide.output.variables': 'Variables',
+      }
+      return messages[key] ?? key
+    },
   }),
 }))
 

--- a/test/router/composerRoute.test.ts
+++ b/test/router/composerRoute.test.ts
@@ -6,7 +6,12 @@ import type { RouteRecordNormalized } from 'vue-router'
 // Stub vue-i18n for router (needed by i18n module)
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'navigation.appTitle': 'F-BASIC IDE',
+      }
+      return messages[key] ?? key
+    },
     locale: ref('en'),
   }),
   createI18n: vi.fn(() => ({})),


### PR DESCRIPTION
## Summary
- Fixes #819

## Changes
- Replaced pass-through `t: (key: string) => key` i18n mock with inline translation maps in 29 test files
- Follows ConfirmDialog.test.ts pattern: `{ [key]: translatedValue }` with `?? key` fallback
- Updated test assertions to check translated text instead of raw i18n keys
- Handled i18n interpolation cases (ErrorPanel, JoystickControl, LogLevelPanel, MovementCard) with `params` argument support
- Handled fallback overload case (SampleSelector) with string second argument support

## Files changed (29)
- Batch 1: AnimationSyncSection, BufferInspector, ComposerControls, DebugTab, DisplayBufferSection, EditorViewToggle, ErrorPanel
- Batch 2: ExportHtmlDialog, IdeControls, InputModal, InputModeToggle, JoystickBufferSection, JoystickControl, KeyboardBufferSection
- Batch 3: LessonContent, LogLevelPanel, MovementCard, RuntimeOutput, SampleSelector, ShareDialog, SpriteSlotsSection
- Batch 4: StateInspector, TutorialPanel, VariablesTab, MusicComposerPage, App, composerRoute, IdeEditorPanel, ScreenTab

## Test plan
- [ ] All 3977 tests pass (278 test files)
- [ ] CI passes