### PR TITLE
refactor: resolve #827 - extract duplicated i18n interpolation mock logic to shared test helper

### DIFF
--- a/test/helpers/createI18nMock.ts
+++ b/test/helpers/createI18nMock.ts
@@ -1,0 +1,21 @@
+/**
+ * Creates a mock `t` translation function that looks up keys in the provided
+ * messages map and performs simple `{param}` interpolation.
+ *
+ * @param messages - A map from i18n key to translated string (may contain
+ *                   `{placeholder}` tokens).
+ * @returns A `t` function with the same signature as vue-i18n's `t`.
+ */
+export function createI18nMock(
+  messages: Record<string, string>,
+): (key: string, params?: Record<string, string | number>) => string {
+  return (key: string, params?: Record<string, string | number>) => {
+    let text = messages[key] ?? key
+    if (params) {
+      for (const [k, v] of Object.entries(params)) {
+        text = text.replace(`{${k}}`, String(v))
+      }
+    }
+    return text
+  }
+}

--- a/test/ide/ErrorPanel.test.ts
+++ b/test/ide/ErrorPanel.test.ts
@@ -5,23 +5,16 @@ import { defineComponent } from 'vue'
 
 import ErrorPanel from '@/features/ide/components/ErrorPanel.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.output.errorLine': 'Line {line}',
+  'ide.errorPanel.sourceLabel': 'At:',
+  'ide.errorPanel.stackTrace': 'Stack trace',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string, params?: Record<string, string | number>) => {
-      const messages: Record<string, string> = {
-        'ide.output.errorLine': 'Line {line}',
-        'ide.errorPanel.sourceLabel': 'At:',
-        'ide.errorPanel.stackTrace': 'Stack trace',
-      }
-      let text = messages[key] ?? key
-      if (params) {
-        for (const [k, v] of Object.entries(params)) {
-          text = text.replace(`{${k}}`, String(v))
-        }
-      }
-      return text
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameIconStub = defineComponent({

--- a/test/ide/JoystickControl.test.ts
+++ b/test/ide/JoystickControl.test.ts
@@ -5,26 +5,19 @@ import { defineComponent, reactive, ref } from 'vue'
 
 import JoystickControl from '@/features/ide/components/JoystickControl.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.joystick.control': 'Joystick Control',
+  'ide.joystick.joystick0': 'Joystick 0',
+  'ide.joystick.joystick1': 'Joystick 1',
+  'ide.joystick.joystick': 'Joystick {id}',
+  'ide.joystick.keyboardHint': 'Keyboard control enabled',
+  'ide.joystick.configureKeys': 'Configure Keys',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string, params?: Record<string, string | number>) => {
-      const messages: Record<string, string> = {
-        'ide.joystick.control': 'Joystick Control',
-        'ide.joystick.joystick0': 'Joystick 0',
-        'ide.joystick.joystick1': 'Joystick 1',
-        'ide.joystick.joystick': 'Joystick {id}',
-        'ide.joystick.keyboardHint': 'Keyboard control enabled',
-        'ide.joystick.configureKeys': 'Configure Keys',
-      }
-      let text = messages[key] ?? key
-      if (params) {
-        for (const [k, v] of Object.entries(params)) {
-          text = text.replace(`{${k}}`, String(v))
-        }
-      }
-      return text
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const mockStartDpadHold = vi.fn()

--- a/test/ide/LogLevelPanel.test.ts
+++ b/test/ide/LogLevelPanel.test.ts
@@ -5,23 +5,16 @@ import { defineComponent, nextTick } from 'vue'
 
 import LogLevelPanel from '@/features/ide/components/LogLevelPanel.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.logLevels.title': 'Log Levels',
+  'ide.logLevels.description': 'Set verbosity per area. {warn} = quiet; {debug} = verbose.',
+  'ide.logLevels.ariaLabelFor': 'Log level for {name}',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string, params?: Record<string, string | number>) => {
-      const messages: Record<string, string> = {
-        'ide.logLevels.title': 'Log Levels',
-        'ide.logLevels.description': 'Set verbosity per area. {warn} = quiet; {debug} = verbose.',
-        'ide.logLevels.ariaLabelFor': 'Log level for {name}',
-      }
-      let text = messages[key] ?? key
-      if (params) {
-        for (const [k, v] of Object.entries(params)) {
-          text = text.replace(`{${k}}`, String(v))
-        }
-      }
-      return text
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const { mockSetLogLevelByName, mockGetLogLevelName, mockLoggerRegistry } = vi.hoisted(() => ({

--- a/test/ide/MovementCard.test.ts
+++ b/test/ide/MovementCard.test.ts
@@ -6,55 +6,48 @@ import { defineComponent } from 'vue'
 import type { MovementSlotData } from '@/features/ide/components/MovementCard.vue'
 import MovementCard from '@/features/ide/components/MovementCard.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.movementCard.actionNumber': 'Action number',
+  'ide.movementCard.statusActive': 'Active',
+  'ide.movementCard.statusPaused': 'Paused',
+  'ide.movementCard.directionAria': 'direction {direction}',
+  'ide.movementCard.characterTypes.MARIO': 'Mario',
+  'ide.movementCard.characterTypes.LADY': 'Lady',
+  'ide.movementCard.characterTypes.FIGHTER_FLY': 'Fighter Fly',
+  'ide.movementCard.characterTypes.ACHILLES': 'Achilles',
+  'ide.movementCard.characterTypes.PENGUIN': 'Penguin',
+  'ide.movementCard.characterTypes.FIREBALL': 'Fireball',
+  'ide.movementCard.characterTypes.CAR': 'Car',
+  'ide.movementCard.characterTypes.SPINNER': 'Spinner',
+  'ide.movementCard.characterTypes.STAR_KILLER': 'Star Killer',
+  'ide.movementCard.characterTypes.STARSHIP': 'Starship',
+  'ide.movementCard.characterTypes.EXPLOSION': 'Explosion',
+  'ide.movementCard.characterTypes.SMILEY': 'Smiley',
+  'ide.movementCard.characterTypes.LASER': 'Laser',
+  'ide.movementCard.characterTypes.SHELL_CREEPER': 'Shellcreeper',
+  'ide.movementCard.characterTypes.SIDE_STEPPER': 'Sidestepper',
+  'ide.movementCard.characterTypes.NITPICKER': 'Nitpicker',
+  'ide.movementCard.directions.0': 'none',
+  'ide.movementCard.directions.1': 'up',
+  'ide.movementCard.directions.2': 'up-right',
+  'ide.movementCard.directions.3': 'right',
+  'ide.movementCard.directions.4': 'down-right',
+  'ide.movementCard.directions.5': 'down',
+  'ide.movementCard.directions.6': 'down-left',
+  'ide.movementCard.directions.7': 'left',
+  'ide.movementCard.directions.8': 'up-left',
+})
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: mockT }),
+}))
+
 const gameIconStub = defineComponent({
   props: ['icon', 'size'],
   template: '<span :data-icon="icon" />',
 })
-
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string, params?: Record<string, string | number>) => {
-      const messages: Record<string, string> = {
-        'ide.movementCard.actionNumber': 'Action number',
-        'ide.movementCard.statusActive': 'Active',
-        'ide.movementCard.statusPaused': 'Paused',
-        'ide.movementCard.directionAria': 'direction {direction}',
-        'ide.movementCard.characterTypes.MARIO': 'Mario',
-        'ide.movementCard.characterTypes.LADY': 'Lady',
-        'ide.movementCard.characterTypes.FIGHTER_FLY': 'Fighter Fly',
-        'ide.movementCard.characterTypes.ACHILLES': 'Achilles',
-        'ide.movementCard.characterTypes.PENGUIN': 'Penguin',
-        'ide.movementCard.characterTypes.FIREBALL': 'Fireball',
-        'ide.movementCard.characterTypes.CAR': 'Car',
-        'ide.movementCard.characterTypes.SPINNER': 'Spinner',
-        'ide.movementCard.characterTypes.STAR_KILLER': 'Star Killer',
-        'ide.movementCard.characterTypes.STARSHIP': 'Starship',
-        'ide.movementCard.characterTypes.EXPLOSION': 'Explosion',
-        'ide.movementCard.characterTypes.SMILEY': 'Smiley',
-        'ide.movementCard.characterTypes.LASER': 'Laser',
-        'ide.movementCard.characterTypes.SHELL_CREEPER': 'Shellcreeper',
-        'ide.movementCard.characterTypes.SIDE_STEPPER': 'Sidestepper',
-        'ide.movementCard.characterTypes.NITPICKER': 'Nitpicker',
-        'ide.movementCard.directions.0': 'none',
-        'ide.movementCard.directions.1': 'up',
-        'ide.movementCard.directions.2': 'up-right',
-        'ide.movementCard.directions.3': 'right',
-        'ide.movementCard.directions.4': 'down-right',
-        'ide.movementCard.directions.5': 'down',
-        'ide.movementCard.directions.6': 'down-left',
-        'ide.movementCard.directions.7': 'left',
-        'ide.movementCard.directions.8': 'up-left',
-      }
-      let text = messages[key] ?? key
-      if (params) {
-        for (const [k, v] of Object.entries(params)) {
-          text = text.replace(`{${k}}`, String(v))
-        }
-      }
-      return text
-    },
-  }),
-}))
 
 function createSlotData(overrides: Partial<MovementSlotData> = {}): MovementSlotData {
   return {


### PR DESCRIPTION
## Summary
- Fixes #827

## Changes
- Created `test/helpers/createI18nMock.ts` — shared factory function for i18n mocks with interpolation support
- Updated 4 test files to use `createI18nMock()` instead of inline mock logic:
  - `test/ide/ErrorPanel.test.ts`
  - `test/ide/JoystickControl.test.ts`
  - `test/ide/LogLevelPanel.test.ts`
  - `test/ide/MovementCard.test.ts`
- Net: +89/-96 lines (reduced duplication)

## Test plan
- [x] 42/42 targeted tests pass across all 4 affected files
- [x] TypeScript type-check clean
- [x] ESLint clean
- [ ] CI passes