### PR TITLE
refactor: resolve #828 - remove dead i18n keys after StateInspector/BufferInspector dissolution

### DIFF
--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -385,7 +385,6 @@
     "openLogLevels": "Open log levels"
   },
   "stateInspector": {
-    "title": "State Inspector",
     "tabPalette": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
@@ -404,7 +403,6 @@
     "empty": "(none)"
   },
   "bufferInspector": {
-    "title": "Buffer Inspector",
     "spriteSlotsTitle": "Sprite Slots",
     "spriteSlotsDisabled": "SPRITE OFF",
     "spriteSlotsOn": "ON",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -385,7 +385,6 @@
     "openLogLevels": "ログレベルを開く"
   },
   "stateInspector": {
-    "title": "状態インスペクタ",
     "tabPalette": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
@@ -404,7 +403,6 @@
     "empty": "（なし）"
   },
   "bufferInspector": {
-    "title": "バッファインスペクタ",
     "spriteSlotsTitle": "スプライトスロット",
     "spriteSlotsDisabled": "SPRITE OFF",
     "spriteSlotsOn": "ON",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -385,7 +385,6 @@
     "openLogLevels": "打开日志级别"
   },
   "stateInspector": {
-    "title": "状态检查",
     "tabPalette": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
@@ -404,7 +403,6 @@
     "empty": "（无）"
   },
   "bufferInspector": {
-    "title": "缓冲区检查器",
     "spriteSlotsTitle": "精灵槽位",
     "spriteSlotsDisabled": "精灵已关闭",
     "spriteSlotsOn": "开",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -385,7 +385,6 @@
     "openLogLevels": "開啟日誌級別"
   },
   "stateInspector": {
-    "title": "狀態檢查",
     "tabPalette": "PALETTE",
     "tabSprite": "SPRITE",
     "tabMove": "MOVE",
@@ -404,7 +403,6 @@
     "empty": "（無）"
   },
   "bufferInspector": {
-    "title": "緩衝區檢查器",
     "spriteSlotsTitle": "精靈槽位",
     "spriteSlotsDisabled": "精靈已關閉",
     "spriteSlotsOn": "開",

--- a/test/ide/BufferInspector.test.ts
+++ b/test/ide/BufferInspector.test.ts
@@ -11,12 +11,7 @@ import { createTestKeyboardBuffer } from './helpers/createTestKeyboardBuffer'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.bufferInspector.title': 'Buffer Inspector',
-      }
-      return messages[key] ?? key
-    },
+    t: (key: string) => key,
   }),
 }))
 

--- a/test/ide/StateInspector.test.ts
+++ b/test/ide/StateInspector.test.ts
@@ -13,7 +13,6 @@ vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (key: string) => {
       const messages: Record<string, string> = {
-        'ide.stateInspector.title': 'State Inspector',
         'ide.stateInspector.tabPalette': 'PALETTE',
         'ide.stateInspector.tabSprite': 'SPRITE',
         'ide.stateInspector.tabMove': 'MOVE',


### PR DESCRIPTION
## Summary
- Fixes #828

## Changes
- Removed dead `stateInspector.title` and `bufferInspector.title` keys from all 4 locale files (en, ja, zh-CN, zh-TW)
- Cleaned up unused mock keys in `StateInspector.test.ts` and `BufferInspector.test.ts`
- Verified no remaining references to these keys in src/ or test/

## Test plan
- [x] 5/5 targeted tests pass (StateInspector.test.ts + BufferInspector.test.ts)
- [x] No remaining references to removed keys
- [x] TypeScript type-check clean
- [ ] CI passes