### PR TITLE
refactor: resolve #834 - use split/join in createI18nMock for repeated placeholder support

### DIFF
--- a/test/helpers/createI18nMock.test.ts
+++ b/test/helpers/createI18nMock.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { createI18nMock } from './createI18nMock'
+
+describe('createI18nMock', () => {
+  it('returns the key when message is not found', () => {
+    const t = createI18nMock({})
+    expect(t('missing.key')).toEqual('missing.key')
+  })
+
+  it('returns the message without params when no params given', () => {
+    const t = createI18nMock({ greeting: 'Hello world' })
+    expect(t('greeting')).toEqual('Hello world')
+  })
+
+  it('replaces a single placeholder', () => {
+    const t = createI18nMock({ greeting: 'Hello {name}' })
+    expect(t('greeting', { name: 'Alice' })).toEqual('Hello Alice')
+  })
+
+  it('replaces all occurrences of a repeated placeholder', () => {
+    const t = createI18nMock({
+      echo: 'Hello {name} and {name}',
+    })
+    expect(t('echo', { name: 'Alice' })).toEqual('Hello Alice and Alice')
+  })
+
+  it('replaces multiple distinct placeholders', () => {
+    const t = createI18nMock({
+      intro: 'Hello {name}, you are {age} years old',
+    })
+    expect(t('intro', { name: 'Bob', age: 30 })).toEqual(
+      'Hello Bob, you are 30 years old',
+    )
+  })
+
+  it('replaces repeated placeholder among multiple distinct ones', () => {
+    const t = createI18nMock({
+      msg: '{a} and {b} and {a}',
+    })
+    expect(t('msg', { a: 'X', b: 'Y' })).toEqual('X and Y and X')
+  })
+})

--- a/test/helpers/createI18nMock.ts
+++ b/test/helpers/createI18nMock.ts
@@ -13,7 +13,7 @@ export function createI18nMock(
     let text = messages[key] ?? key
     if (params) {
       for (const [k, v] of Object.entries(params)) {
-        text = text.replace(`{${k}}`, String(v))
+        text = text.split(`{${k}}`).join(String(v))
       }
     }
     return text


### PR DESCRIPTION
## Summary
- Fixes #834

## Changes
- Changed `String.replace()` to `String.split().join()` in `test/helpers/createI18nMock.ts` for ES2020-compatible full replacement of all placeholder occurrences
- Added 6 unit tests for `createI18nMock` helper covering: missing key fallback, no params, single placeholder, repeated placeholder (bug scenario), multiple distinct placeholders, repeated + distinct combined

## Notes
Issue suggested `replaceAll` but project targets ES2020 (`tsconfig.json`), and `replaceAll` is ES2021. Used `split().join()` idiom instead — identical behavior, fully compatible.

## Test plan
- [x] 48 tests pass (6 new + 42 existing across 5 files)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)