### PR TITLE
refactor: resolve #835 - migrate remaining interpolation i18n mocks to createI18nMock helper

### DIFF
--- a/test/App.test.ts
+++ b/test/App.test.ts
@@ -7,17 +7,18 @@ import App from '@/App.vue'
 import { COI_SERVICE_WORKER_REGISTRATION_FAILED_EVENT } from '@/shared/constants/coiServiceWorker'
 import { reloadPage } from '@/shared/utils/reloadPage'
 
+import { createI18nMock } from './helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'coi.warning.message': 'High-performance mode is unavailable because cross-origin isolation is not enabled. Try reloading, use HTTPS, and confirm COOP/COEP headers are configured.',
+  'coi.warning.reload': 'Reload',
+  'coi.warning.dismiss': 'Dismiss',
+})
+
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     locale: ref('en'),
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'coi.warning.message': 'High-performance mode is unavailable because cross-origin isolation is not enabled. Try reloading, use HTTPS, and confirm COOP/COEP headers are configured.',
-        'coi.warning.reload': 'Reload',
-        'coi.warning.dismiss': 'Dismiss',
-      }
-      return messages[key] ?? key
-    },
+    t: mockT,
   }),
 }))
 

--- a/test/features/ide/components/IdeEditorPanel.test.ts
+++ b/test/features/ide/components/IdeEditorPanel.test.ts
@@ -6,19 +6,18 @@ import { defineComponent } from 'vue'
 
 import IdeEditorPanel from '@/features/ide/components/IdeEditorPanel.vue'
 
+import { createI18nMock } from '../../../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.codeEditor.title': 'Code Editor',
+  'ide.codeEditor.loading': 'Loading editor...',
+  'ide.samples.load': 'Sample',
+  'ide.spriteViewer.openTitle': 'Open Sprite Viewer',
+  'ide.tutorial.title': 'Tutorial',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.codeEditor.title': 'Code Editor',
-        'ide.codeEditor.loading': 'Loading editor...',
-        'ide.samples.load': 'Sample',
-        'ide.spriteViewer.openTitle': 'Open Sprite Viewer',
-        'ide.tutorial.title': 'Tutorial',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameBlockStub = defineComponent({

--- a/test/features/ide/components/ScreenTab.test.ts
+++ b/test/features/ide/components/ScreenTab.test.ts
@@ -6,18 +6,16 @@ import { defineComponent } from 'vue'
 
 import ScreenTab from '@/features/ide/components/ScreenTab.vue'
 
-// Stub vue-i18n
+import { createI18nMock } from '../../../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.output.screen': 'Screen',
+  'ide.screenTab.grid': 'Grid',
+  'ide.screenTab.filter': 'CRT',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.output.screen': 'Screen',
-        'ide.screenTab.grid': 'Grid',
-        'ide.screenTab.filter': 'CRT',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 // Mock useScreenFilter with controllable state

--- a/test/features/music-composer/MusicComposerPage.test.ts
+++ b/test/features/music-composer/MusicComposerPage.test.ts
@@ -4,6 +4,12 @@ import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { type Component,defineComponent } from 'vue'
 
+import { createI18nMock } from '../../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'musicComposer.title': 'Music Composer',
+})
+
 // Stub GameLayout to avoid pulling in GameNavigation and its heavy deps
 const gameLayoutStub = defineComponent({
   name: 'GameLayout',
@@ -14,15 +20,9 @@ vi.mock('@/shared/components/ui', () => ({
   GameLayout: gameLayoutStub,
 }))
 
-// Stub vue-i18n with inline translations
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'musicComposer.title': 'Music Composer',
-      }
-      return messages[key] ?? key
-    },
+    t: mockT,
     locale: ref('en'),
   }),
 }))

--- a/test/ide/AnimationSyncSection.test.ts
+++ b/test/ide/AnimationSyncSection.test.ts
@@ -6,35 +6,34 @@ import { ACK_PENDING, ACK_RECEIVED, SyncCommandType } from '@/core/animation/sha
 import type { SyncCommand } from '@/core/animation/sharedDisplayBufferAccessor'
 import AnimationSyncSection from '@/features/ide/components/AnimationSyncSection.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.bufferInspector.animationSyncTitle': 'Animation Sync',
+  'ide.bufferInspector.animationSyncIdle': '(idle)',
+  'ide.bufferInspector.animationSyncColField': 'Field',
+  'ide.bufferInspector.animationSyncColValue': 'Value',
+  'ide.bufferInspector.animationSyncFieldType': 'Command Type',
+  'ide.bufferInspector.animationSyncFieldAction': 'Action #',
+  'ide.bufferInspector.animationSyncFieldStartX': 'startX',
+  'ide.bufferInspector.animationSyncFieldStartY': 'startY',
+  'ide.bufferInspector.animationSyncFieldDirection': 'Direction',
+  'ide.bufferInspector.animationSyncFieldSpeed': 'Speed',
+  'ide.bufferInspector.animationSyncFieldDistance': 'Distance',
+  'ide.bufferInspector.animationSyncFieldPriority': 'Priority',
+  'ide.bufferInspector.animationSyncFieldAck': 'ACK',
+  'ide.bufferInspector.animationSyncAckPending': 'Pending',
+  'ide.bufferInspector.animationSyncAckReceived': 'Received',
+  'ide.bufferInspector.animationSyncCommandTypeNone': 'None',
+  'ide.bufferInspector.animationSyncCommandTypeStartMovement': 'Start',
+  'ide.bufferInspector.animationSyncCommandTypeStopMovement': 'Stop',
+  'ide.bufferInspector.animationSyncCommandTypeEraseMovement': 'Erase',
+  'ide.bufferInspector.animationSyncCommandTypeSetPosition': 'Set',
+  'ide.bufferInspector.animationSyncCommandTypeClearAllMovements': 'Clear All',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.bufferInspector.animationSyncTitle': 'Animation Sync',
-        'ide.bufferInspector.animationSyncIdle': '(idle)',
-        'ide.bufferInspector.animationSyncColField': 'Field',
-        'ide.bufferInspector.animationSyncColValue': 'Value',
-        'ide.bufferInspector.animationSyncFieldType': 'Command Type',
-        'ide.bufferInspector.animationSyncFieldAction': 'Action #',
-        'ide.bufferInspector.animationSyncFieldStartX': 'startX',
-        'ide.bufferInspector.animationSyncFieldStartY': 'startY',
-        'ide.bufferInspector.animationSyncFieldDirection': 'Direction',
-        'ide.bufferInspector.animationSyncFieldSpeed': 'Speed',
-        'ide.bufferInspector.animationSyncFieldDistance': 'Distance',
-        'ide.bufferInspector.animationSyncFieldPriority': 'Priority',
-        'ide.bufferInspector.animationSyncFieldAck': 'ACK',
-        'ide.bufferInspector.animationSyncAckPending': 'Pending',
-        'ide.bufferInspector.animationSyncAckReceived': 'Received',
-        'ide.bufferInspector.animationSyncCommandTypeNone': 'None',
-        'ide.bufferInspector.animationSyncCommandTypeStartMovement': 'Start',
-        'ide.bufferInspector.animationSyncCommandTypeStopMovement': 'Stop',
-        'ide.bufferInspector.animationSyncCommandTypeEraseMovement': 'Erase',
-        'ide.bufferInspector.animationSyncCommandTypeSetPosition': 'Set',
-        'ide.bufferInspector.animationSyncCommandTypeClearAllMovements': 'Clear All',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 /** Factory for a SyncCommand with defaults */

--- a/test/ide/BufferInspector.test.ts
+++ b/test/ide/BufferInspector.test.ts
@@ -7,12 +7,15 @@ import { SHARED_DISPLAY_BUFFER_BYTES } from '@/core/animation/sharedDisplayBuffe
 import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
 import IdeBottomArea from '@/features/ide/components/IdeBottomArea.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
 import { createTestKeyboardBuffer } from './helpers/createTestKeyboardBuffer'
 
+const mockT = createI18nMock({
+  'ide.bufferInspector.title': 'Buffer Inspector',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => key,
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 /**

--- a/test/ide/ComposerControls.test.ts
+++ b/test/ide/ComposerControls.test.ts
@@ -5,20 +5,19 @@ import { defineComponent } from 'vue'
 
 import ComposerControls from '@/features/ide/components/ComposerControls.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.composer.title': 'Controls',
+  'ide.composer.tempo': 'Tempo',
+  'ide.composer.steps': 'Steps',
+  'ide.composer.octave': 'Octave',
+  'ide.composer.duration': 'Duration',
+  'ide.composer.envelope': 'Envelope',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.composer.title': 'Controls',
-        'ide.composer.tempo': 'Tempo',
-        'ide.composer.steps': 'Steps',
-        'ide.composer.octave': 'Octave',
-        'ide.composer.duration': 'Duration',
-        'ide.composer.envelope': 'Envelope',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 // ---------------------------------------------------------------------------

--- a/test/ide/DebugTab.test.ts
+++ b/test/ide/DebugTab.test.ts
@@ -5,15 +5,14 @@ import { defineComponent } from 'vue'
 
 import DebugTab from '@/features/ide/components/DebugTab.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.output.debug': 'Debug',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.output.debug': 'Debug',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameTabPaneStub = defineComponent({

--- a/test/ide/DisplayBufferSection.test.ts
+++ b/test/ide/DisplayBufferSection.test.ts
@@ -5,16 +5,15 @@ import { describe, expect, it, vi } from 'vitest'
 import DisplayBufferSection from '@/features/ide/components/DisplayBufferSection.vue'
 import type { ScreenBufferReader } from '@/features/ide/components/types'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.bufferInspector.displayBufferCharTitle': 'Character Codes',
+  'ide.bufferInspector.displayBufferPatternTitle': 'Color Patterns',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.bufferInspector.displayBufferCharTitle': 'Character Codes',
-        'ide.bufferInspector.displayBufferPatternTitle': 'Color Patterns',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 /** Create a mock accessor with screen char/pattern data */

--- a/test/ide/EditorViewToggle.test.ts
+++ b/test/ide/EditorViewToggle.test.ts
@@ -5,18 +5,17 @@ import { defineComponent } from 'vue'
 
 import EditorViewToggle from '@/features/ide/components/EditorViewToggle.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.editorViewToggle.codeTitle': 'Code',
+  'ide.editorViewToggle.bgTitle': 'BG',
+  'ide.editorViewToggle.code': 'Code',
+  'ide.editorViewToggle.bg': 'BG',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.editorViewToggle.codeTitle': 'Code',
-        'ide.editorViewToggle.bgTitle': 'BG',
-        'ide.editorViewToggle.code': 'Code',
-        'ide.editorViewToggle.bg': 'BG',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameButtonStub = defineComponent({

--- a/test/ide/ExportHtmlDialog.test.ts
+++ b/test/ide/ExportHtmlDialog.test.ts
@@ -9,27 +9,25 @@ import ExportHtmlDialog from '@/features/ide/components/ExportHtmlDialog.vue'
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.exportHtml.title': 'Export as HTML',
+  'ide.exportHtml.description': 'Export your program as a standalone HTML file that runs in any browser.',
+  'ide.exportHtml.exporting': 'Exporting...',
+  'ide.exportHtml.exportFailed': 'Failed to export HTML file.',
+  'ide.exportHtml.titleLabel': 'Page Title',
+  'ide.exportHtml.themeLabel': 'Theme',
+  'ide.exportHtml.themeDark': 'Dark',
+  'ide.exportHtml.themeLight': 'Light',
+  'ide.exportHtml.includeSound': 'Include sound',
+  'ide.exportHtml.includeSprites': 'Include sprites',
+  'ide.exportHtml.exportButton': 'Export',
+  'ide.exportHtml.cancelButton': 'Cancel',
+})
 
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.exportHtml.title': 'Export as HTML',
-        'ide.exportHtml.description': 'Export your program as a standalone HTML file that runs in any browser.',
-        'ide.exportHtml.exporting': 'Exporting...',
-        'ide.exportHtml.exportFailed': 'Failed to export HTML file.',
-        'ide.exportHtml.titleLabel': 'Page Title',
-        'ide.exportHtml.themeLabel': 'Theme',
-        'ide.exportHtml.themeDark': 'Dark',
-        'ide.exportHtml.themeLight': 'Light',
-        'ide.exportHtml.includeSound': 'Include sound',
-        'ide.exportHtml.includeSprites': 'Include sprites',
-        'ide.exportHtml.exportButton': 'Export',
-        'ide.exportHtml.cancelButton': 'Cancel',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const mockExportHtml = vi.fn()

--- a/test/ide/IdeControls.test.ts
+++ b/test/ide/IdeControls.test.ts
@@ -5,18 +5,17 @@ import { defineComponent } from 'vue'
 
 import IdeControls from '@/features/ide/components/IdeControls.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.controls.run': 'Run',
+  'ide.controls.stop': 'Stop',
+  'ide.controls.clear': 'Clear',
+  'ide.controls.debug': 'Debug',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.controls.run': 'Run',
-        'ide.controls.stop': 'Stop',
-        'ide.controls.clear': 'Clear',
-        'ide.controls.debug': 'Debug',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameIconButtonStub = defineComponent({

--- a/test/ide/InputModal.test.ts
+++ b/test/ide/InputModal.test.ts
@@ -5,18 +5,17 @@ import { defineComponent, nextTick } from 'vue'
 
 import InputModal from '@/features/ide/components/InputModal.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.inputModal.inputPlaceholder': 'Separate multiple values with commas',
+  'ide.inputModal.linputPlaceholder': 'Enter text (up to 31 chars)',
+  'ide.input.submit': 'OK',
+  'ide.input.cancel': 'Cancel',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.inputModal.inputPlaceholder': 'Separate multiple values with commas',
-        'ide.inputModal.linputPlaceholder': 'Enter text (up to 31 chars)',
-        'ide.input.submit': 'OK',
-        'ide.input.cancel': 'Cancel',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameInputStub = defineComponent({

--- a/test/ide/InputModeToggle.test.ts
+++ b/test/ide/InputModeToggle.test.ts
@@ -5,18 +5,17 @@ import { defineComponent } from 'vue'
 
 import InputModeToggle from '@/features/ide/components/InputModeToggle.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.inputModeToggle.joystickTitle': 'Joystick Mode (STICK/STRIG)',
+  'ide.inputModeToggle.keyboardTitle': 'Keyboard Mode (INKEY$)',
+  'ide.inputModeToggle.joystick': 'Joy',
+  'ide.inputModeToggle.keyboard': 'Key',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.inputModeToggle.joystickTitle': 'Joystick Mode (STICK/STRIG)',
-        'ide.inputModeToggle.keyboardTitle': 'Keyboard Mode (INKEY$)',
-        'ide.inputModeToggle.joystick': 'Joy',
-        'ide.inputModeToggle.keyboard': 'Key',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameButtonStub = defineComponent({

--- a/test/ide/JoystickBufferSection.test.ts
+++ b/test/ide/JoystickBufferSection.test.ts
@@ -10,20 +10,19 @@ import {
 } from '@/core/devices/sharedJoystickBuffer'
 import JoystickBufferSection from '@/features/ide/components/JoystickBufferSection.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.bufferInspector.joystickTitle': 'Joystick Buffer',
+  'ide.bufferInspector.joystickUnavailable': 'No joystick buffer',
+  'ide.bufferInspector.joystick0': 'Joy 0',
+  'ide.bufferInspector.joystick1': 'Joy 1',
+  'ide.bufferInspector.joystickStick': 'STICK',
+  'ide.bufferInspector.joystickStrig': 'STRIG',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.bufferInspector.joystickTitle': 'Joystick Buffer',
-        'ide.bufferInspector.joystickUnavailable': 'No joystick buffer',
-        'ide.bufferInspector.joystick0': 'Joy 0',
-        'ide.bufferInspector.joystick1': 'Joy 1',
-        'ide.bufferInspector.joystickStick': 'STICK',
-        'ide.bufferInspector.joystickStrig': 'STRIG',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 function mountWithBuffer(bufferSize: number) {

--- a/test/ide/KeyboardBufferSection.test.ts
+++ b/test/ide/KeyboardBufferSection.test.ts
@@ -7,19 +7,18 @@ import { consumeKeyAvailable, setInkeyState } from '@/core/devices/sharedKeyboar
 import KeyboardBufferSection from '@/features/ide/components/KeyboardBufferSection.vue'
 import { POLL_INTERVAL_MS } from '@/features/ide/components/keyboardBufferSectionConstants'
 
+import { createI18nMock } from '../helpers/createI18nMock'
 import { createTestKeyboardBuffer } from './helpers/createTestKeyboardBuffer'
+
+const mockT = createI18nMock({
+  'ide.bufferInspector.keyboardBufferTitle': 'Keyboard Buffer',
+  'ide.bufferInspector.keyboardCharCode': 'Char Code',
+  'ide.bufferInspector.keyboardModifiers': 'Modifiers',
+  'ide.bufferInspector.keyboardAvailable': 'Available',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.bufferInspector.keyboardBufferTitle': 'Keyboard Buffer',
-        'ide.bufferInspector.keyboardCharCode': 'Char Code',
-        'ide.bufferInspector.keyboardModifiers': 'Modifiers',
-        'ide.bufferInspector.keyboardAvailable': 'Available',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 

--- a/test/ide/LessonContent.test.ts
+++ b/test/ide/LessonContent.test.ts
@@ -7,16 +7,14 @@ import LessonContent from '@/features/ide/components/LessonContent.vue'
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.tutorial.tryIt': 'Try It',
+})
 
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.tutorial.tryIt': 'Try It',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 // ---------------------------------------------------------------------------

--- a/test/ide/ProgramToolbar.test.ts
+++ b/test/ide/ProgramToolbar.test.ts
@@ -10,31 +10,32 @@ const mockOpen = vi.fn()
 const mockSave = vi.fn()
 const isDirtyRef = ref(true)
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.toolbar.new': 'New',
+  'ide.toolbar.import': 'Import',
+  'ide.toolbar.export': 'Export',
+  'ide.toolbar.discardConfirm': 'Discard unsaved changes?',
+  'ide.toolbar.programNamePlaceholder': 'Program name',
+  'ide.toolbar.unsavedChanges': 'Unsaved changes',
+  'ide.toolbar.openFailed': 'Failed to open file',
+  'ide.toolbar.saveFailed': 'Failed to save file',
+  'ide.share.title': 'Share',
+  'ide.share.description': 'Copy this URL to share your program.',
+  'ide.share.copy': 'Copy URL',
+  'ide.share.copied': 'Copied!',
+  'ide.share.close': 'Close',
+  'ide.share.encoding': 'Generating share URL...',
+  'ide.share.encodeFailed': 'Failed to generate share URL.',
+  'ide.share.tooLarge': 'This program is too large to share.',
+  'common.confirmDialog.confirm': 'OK',
+  'common.confirmDialog.cancel': 'Cancel',
+})
+
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.toolbar.new': 'New',
-        'ide.toolbar.import': 'Import',
-        'ide.toolbar.export': 'Export',
-        'ide.toolbar.discardConfirm': 'Discard unsaved changes?',
-        'ide.toolbar.programNamePlaceholder': 'Program name',
-        'ide.toolbar.unsavedChanges': 'Unsaved changes',
-        'ide.toolbar.openFailed': 'Failed to open file',
-        'ide.toolbar.saveFailed': 'Failed to save file',
-        'ide.share.title': 'Share',
-        'ide.share.description': 'Copy this URL to share your program.',
-        'ide.share.copy': 'Copy URL',
-        'ide.share.copied': 'Copied!',
-        'ide.share.close': 'Close',
-        'ide.share.encoding': 'Generating share URL...',
-        'ide.share.encodeFailed': 'Failed to generate share URL.',
-        'ide.share.tooLarge': 'This program is too large to share.',
-        'common.confirmDialog.confirm': 'OK',
-        'common.confirmDialog.cancel': 'Cancel',
-      }
-      return messages[key] ?? key
-    },
+    t: mockT,
     locale: ref('en'),
   }),
 }))

--- a/test/ide/RuntimeOutput.test.ts
+++ b/test/ide/RuntimeOutput.test.ts
@@ -5,18 +5,17 @@ import { defineComponent } from 'vue'
 
 import RuntimeOutput from '@/features/ide/components/RuntimeOutput.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.output.title': 'Runtime Output',
+  'ide.output.screen': 'Screen',
+  'ide.output.variables': 'Variables',
+  'ide.output.debug': 'Debug',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.output.title': 'Runtime Output',
-        'ide.output.screen': 'Screen',
-        'ide.output.variables': 'Variables',
-        'ide.output.debug': 'Debug',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameTabsStub = defineComponent({

--- a/test/ide/ShareDialog.test.ts
+++ b/test/ide/ShareDialog.test.ts
@@ -9,23 +9,21 @@ import ShareDialog from '@/features/ide/components/ShareDialog.vue'
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.share.title': 'Share',
+  'ide.share.description': 'Copy this URL to share your program with others.',
+  'ide.share.copy': 'Copy URL',
+  'ide.share.copied': 'Copied!',
+  'ide.share.close': 'Close',
+  'ide.share.encoding': 'Generating share URL...',
+  'ide.share.encodeFailed': 'Failed to generate share URL.',
+  'ide.share.tooLarge': 'This program is too large to share via URL.',
+})
 
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.share.title': 'Share',
-        'ide.share.description': 'Copy this URL to share your program with others.',
-        'ide.share.copy': 'Copy URL',
-        'ide.share.copied': 'Copied!',
-        'ide.share.close': 'Close',
-        'ide.share.encoding': 'Generating share URL...',
-        'ide.share.encodeFailed': 'Failed to generate share URL.',
-        'ide.share.tooLarge': 'This program is too large to share via URL.',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const mockEncodeProgram = vi.fn()

--- a/test/ide/SpriteSlotsSection.test.ts
+++ b/test/ide/SpriteSlotsSection.test.ts
@@ -5,26 +5,25 @@ import { describe, expect, it, vi } from 'vitest'
 import type { SpriteState } from '@/core/sprite/types'
 import SpriteSlotsSection from '@/features/ide/components/SpriteSlotsSection.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.bufferInspector.spriteSlotsTitle': 'Sprite Slots',
+  'ide.bufferInspector.spriteSlotsDisabled': 'SPRITE OFF',
+  'ide.bufferInspector.spriteSlotsOn': 'ON',
+  'ide.bufferInspector.spriteSlotsOff': 'OFF',
+  'ide.bufferInspector.spriteSlotsDefined': 'Yes',
+  'ide.bufferInspector.spriteSlotsNone': '-',
+  'ide.bufferInspector.spriteSlotsColNumber': '#',
+  'ide.bufferInspector.spriteSlotsColX': 'X',
+  'ide.bufferInspector.spriteSlotsColY': 'Y',
+  'ide.bufferInspector.spriteSlotsColVisible': 'Visible',
+  'ide.bufferInspector.spriteSlotsColPriority': 'Priority',
+  'ide.bufferInspector.spriteSlotsColDefinition': 'Definition',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.bufferInspector.spriteSlotsTitle': 'Sprite Slots',
-        'ide.bufferInspector.spriteSlotsDisabled': 'SPRITE OFF',
-        'ide.bufferInspector.spriteSlotsOn': 'ON',
-        'ide.bufferInspector.spriteSlotsOff': 'OFF',
-        'ide.bufferInspector.spriteSlotsDefined': 'Yes',
-        'ide.bufferInspector.spriteSlotsNone': '-',
-        'ide.bufferInspector.spriteSlotsColNumber': '#',
-        'ide.bufferInspector.spriteSlotsColX': 'X',
-        'ide.bufferInspector.spriteSlotsColY': 'Y',
-        'ide.bufferInspector.spriteSlotsColVisible': 'Visible',
-        'ide.bufferInspector.spriteSlotsColPriority': 'Priority',
-        'ide.bufferInspector.spriteSlotsColDefinition': 'Definition',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 /** Factory for a single SpriteState */

--- a/test/ide/StateInspector.test.ts
+++ b/test/ide/StateInspector.test.ts
@@ -7,26 +7,25 @@ import type { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplay
 import IdeBottomArea from '@/features/ide/components/IdeBottomArea.vue'
 import enIde from '@/shared/i18n/locales/en/ide.json'
 
+import { createI18nMock } from '../helpers/createI18nMock'
 import { createTestKeyboardBuffer } from './helpers/createTestKeyboardBuffer'
 
+const mockT = createI18nMock({
+  'ide.stateInspector.title': 'State Inspector',
+  'ide.stateInspector.tabPalette': 'PALETTE',
+  'ide.stateInspector.tabSprite': 'SPRITE',
+  'ide.stateInspector.tabMove': 'MOVE',
+  'ide.stateInspector.tabBg': 'BG',
+  'ide.stateInspector.backdrop': 'Backdrop',
+  'ide.stateInspector.cgen': 'CGEN',
+  'ide.stateInspector.spriteEnabled': 'SPRITE ON',
+  'ide.stateInspector.on': 'ON',
+  'ide.stateInspector.off': 'OFF',
+  'ide.stateInspector.empty': '(none)',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.stateInspector.tabPalette': 'PALETTE',
-        'ide.stateInspector.tabSprite': 'SPRITE',
-        'ide.stateInspector.tabMove': 'MOVE',
-        'ide.stateInspector.tabBg': 'BG',
-        'ide.stateInspector.backdrop': 'Backdrop',
-        'ide.stateInspector.cgen': 'CGEN',
-        'ide.stateInspector.spriteEnabled': 'SPRITE ON',
-        'ide.stateInspector.on': 'ON',
-        'ide.stateInspector.off': 'OFF',
-        'ide.stateInspector.empty': '(none)',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 type InspectorAccessor = Pick<

--- a/test/ide/TutorialPanel.test.ts
+++ b/test/ide/TutorialPanel.test.ts
@@ -5,20 +5,19 @@ import { defineComponent } from 'vue'
 
 import TutorialPanel from '@/features/ide/components/TutorialPanel.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.tutorial.title': 'Tutorial',
+  'ide.tutorial.defaultTitle': 'F-BASIC Tutorial',
+  'ide.tutorial.closeAriaLabel': 'Close tutorial',
+  'ide.tutorial.prev': 'Previous lesson',
+  'ide.tutorial.next': 'Next lesson',
+  'ide.tutorial.noContent': 'No lesson content available.',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.tutorial.title': 'Tutorial',
-        'ide.tutorial.defaultTitle': 'F-BASIC Tutorial',
-        'ide.tutorial.closeAriaLabel': 'Close tutorial',
-        'ide.tutorial.prev': 'Previous lesson',
-        'ide.tutorial.next': 'Next lesson',
-        'ide.tutorial.noContent': 'No lesson content available.',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameIconButtonStub = defineComponent({

--- a/test/ide/VariablesTab.test.ts
+++ b/test/ide/VariablesTab.test.ts
@@ -5,15 +5,14 @@ import { defineComponent } from 'vue'
 
 import VariablesTab from '@/features/ide/components/VariablesTab.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.output.variables': 'Variables',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'ide.output.variables': 'Variables',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 const gameTabPaneStub = defineComponent({

--- a/test/router/composerRoute.test.ts
+++ b/test/router/composerRoute.test.ts
@@ -3,15 +3,16 @@ import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import type { RouteRecordNormalized } from 'vue-router'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'navigation.appTitle': 'F-BASIC IDE',
+})
+
 // Stub vue-i18n for router (needed by i18n module)
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'navigation.appTitle': 'F-BASIC IDE',
-      }
-      return messages[key] ?? key
-    },
+    t: mockT,
     locale: ref('en'),
   }),
   createI18n: vi.fn(() => ({})),

--- a/test/shared/components/ConfirmDialog.test.ts
+++ b/test/shared/components/ConfirmDialog.test.ts
@@ -5,16 +5,15 @@ import { nextTick } from 'vue'
 
 import ConfirmDialog from '@/shared/components/ui/ConfirmDialog.vue'
 
+import { createI18nMock } from '../../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'common.confirmDialog.confirm': 'Confirm',
+  'common.confirmDialog.cancel': 'Cancel',
+})
+
 vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => {
-      const messages: Record<string, string> = {
-        'common.confirmDialog.confirm': 'Confirm',
-        'common.confirmDialog.cancel': 'Cancel',
-      }
-      return messages[key] ?? key
-    },
-  }),
+  useI18n: () => ({ t: mockT }),
 }))
 
 describe('ConfirmDialog', () => {


### PR DESCRIPTION
## Summary
- Fixes #835

## Changes
- Migrated 26 test files from inline i18n mock patterns (`(key: string) => { const messages = {...}; return messages[key] ?? key }`) to use the `createI18nMock` helper
- Skipped 4 files that use patterns incompatible with `createI18nMock` (fallback overload, JSON.stringify params, no i18n mock)
- Net reduction of 25 lines across all files

## Test plan
- [x] All 3972 tests pass (279 test files)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes