### PR TITLE
test: resolve #832 - use toEqual for tab name array assertions in IdeBottomArea tests

### DIFF
--- a/test/ide/BufferInspector.test.ts
+++ b/test/ide/BufferInspector.test.ts
@@ -68,10 +68,7 @@ describe('IdeBottomArea tab structure', () => {
     expect(tabPanes.length).toBe(4)
 
     const names = tabPanes.map(p => p.attributes('data-name'))
-    expect(names).toContain('palettes')
-    expect(names).toContain('sprite')
-    expect(names).toContain('move')
-    expect(names).toContain('buffer')
+    expect(names).toEqual(['palettes', 'sprite', 'move', 'buffer'])
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## Summary
- Fixes #832

## Changes
- Replaced 4 individual `.toContain()` calls with a single `.toEqual(['palettes', 'sprite', 'move', 'buffer'])` assertion in `test/ide/BufferInspector.test.ts`
- Follows project convention (CLAUDE.md) of using `.toEqual()` for exact matching

## Test plan
- [ ] Targeted tests pass (3/3)
- [ ] CI passes