### PR TITLE
refactor: resolve #845 - move createI18nMock import to top of ProgramToolbar.test.ts

### DIFF
--- a/test/ide/ProgramToolbar.test.ts
+++ b/test/ide/ProgramToolbar.test.ts
@@ -5,12 +5,12 @@ import { ref } from 'vue'
 
 import ProgramToolbar from '@/features/ide/components/ProgramToolbar.vue'
 
+import { createI18nMock } from '../helpers/createI18nMock'
+
 const mockNewProgram = vi.fn()
 const mockOpen = vi.fn()
 const mockSave = vi.fn()
 const isDirtyRef = ref(true)
-
-import { createI18nMock } from '../helpers/createI18nMock'
 
 const mockT = createI18nMock({
   'ide.toolbar.new': 'New',


### PR DESCRIPTION
## Summary
- Fixes #845

## Changes
- Moved `import { createI18nMock }` from after `const` declarations to the import block at the top of `test/ide/ProgramToolbar.test.ts`, matching the convention used in all other migrated test files (PR #842).

## Test plan
- [ ] Targeted tests pass (12/12 ProgramToolbar.test.ts)
- [ ] CI passes