### PR TITLE
feat: resolve #772 - create HTML template assembly for export wrapper

### DIFF
--- a/src/features/ide/composables/buildExportHtml.ts
+++ b/src/features/ide/composables/buildExportHtml.ts
@@ -1,0 +1,129 @@
+/**
+ * buildExportHtml — Assembles a standalone HTML document for F-BASIC program export.
+ *
+ * Produces a self-contained HTML file containing:
+ * - A canvas element (256x240, F-BASIC sprite screen dimensions)
+ * - Inline CSS for the selected theme (dark or light) and canvas centering
+ * - The F-BASIC program source embedded in a `<script id="fbasic-program">` tag
+ * - An empty `<script id="fbasic-runtime">` placeholder for the runtime bundle
+ *
+ * The runtime bundle (from #632) will be injected into the placeholder
+ * by the build step (#635) or a dedicated wiring step.
+ */
+
+import { SCREEN_DIMENSIONS } from '@/core/constants'
+import type { HtmlExportOptions } from '@/features/ide/composables/useHtmlExporter'
+
+/** Canvas width and height matching F-BASIC sprite screen dimensions. */
+const CANVAS_WIDTH = SCREEN_DIMENSIONS.SPRITE.WIDTH
+const CANVAS_HEIGHT = SCREEN_DIMENSIONS.SPRITE.HEIGHT
+
+/** CSS background color for dark theme. */
+const DARK_BG = '#000'
+
+/** CSS background color for light theme. */
+const LIGHT_BG = '#fff'
+
+/** CSS text color for dark theme (off-white for readability). */
+const DARK_TEXT = '#e0e0e0'
+
+/** CSS text color for light theme (near-black for readability). */
+const LIGHT_TEXT = '#1a1a1a'
+
+/**
+ * Returns the CSS color values for the given theme.
+ */
+function getThemeColors(theme: 'dark' | 'light'): { bg: string; text: string } {
+  return theme === 'dark'
+    ? { bg: DARK_BG, text: DARK_TEXT }
+    : { bg: LIGHT_BG, text: LIGHT_TEXT }
+}
+
+/**
+ * Escapes HTML special characters in a string for safe inclusion in
+ * HTML attribute values (e.g., `<title>`).
+ *
+ * Note: This is NOT used for the `<script>` content — script tags
+ * don't parse HTML entities, so we use a different escaping strategy
+ * there (breaking the `</script>` sequence).
+ */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/** Closing script tag fragment, split to avoid `</script>` in source. */
+const SCRIPT_CLOSE = '</' + 'script>'
+
+/**
+ * Escapes the `</script>` sequence in program source to prevent it
+ * from prematurely closing the enclosing `<script>` tag.
+ *
+ * Inside a `<script>` element, the only sequence that needs escaping
+ * is `</script>` — HTML entities are not parsed. We split this into
+ * `<\/script>` which is equivalent JavaScript but won't trigger the
+ * HTML parser's tag-closing behavior.
+ */
+function escapeScriptContent(source: string): string {
+  return source.replace(/<\/script/gi, '<\\/script')
+}
+
+/**
+ * Builds the inline CSS for the exported HTML page.
+ *
+ * Centers the canvas, applies the theme background, and scales the
+ * canvas to fill available width while maintaining aspect ratio.
+ */
+function buildThemeCss(theme: 'dark' | 'light'): string {
+  const { bg, text } = getThemeColors(theme)
+
+  return [
+    `*{margin:0;padding:0;box-sizing:border-box}`,
+    `html,body{width:100%;height:100%;overflow:hidden;background-color:${bg};color:${text};font-family:monospace}`,
+    `body{display:flex;justify-content:center;align-items:center}`,
+    `#fbasic-screen{max-width:100%;max-height:100%;image-rendering:pixelated;image-rendering:crisp-edges}`,
+  ].join('\n')
+}
+
+/**
+ * Generates a standalone HTML document for exporting an F-BASIC program.
+ *
+ * The resulting HTML contains a canvas element, inline theme CSS, the
+ * program source embedded in a script tag, and a runtime placeholder.
+ * The runtime bundle will be injected into `<script id="fbasic-runtime">`
+ * during the build or wiring step.
+ *
+ * @param source - The F-BASIC program source code
+ * @param options - Export configuration options
+ * @returns A complete HTML document string
+ */
+export function buildExportHtml(
+  source: string,
+  options: HtmlExportOptions,
+): string {
+  const css = buildThemeCss(options.theme)
+  const escapedTitle = escapeHtml(options.title)
+  const escapedSource = escapeScriptContent(source)
+
+  return [
+    '<!DOCTYPE html>',
+    '<html lang="en">',
+    '<head>',
+    '  <meta charset="UTF-8">',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1.0">',
+    `  <title>${escapedTitle}</title>`,
+    '  <style>',
+    css,
+    '  </style>',
+    '</head>',
+    `<body data-include-sound="${options.includeSound}" data-include-sprites="${options.includeSprites}">`,
+    `  <canvas id="fbasic-screen" width="${CANVAS_WIDTH}" height="${CANVAS_HEIGHT}"></canvas>`,
+    `  <script id="fbasic-program" type="text/plain">${escapedSource}${SCRIPT_CLOSE}`,
+    `  <script id="fbasic-runtime">${SCRIPT_CLOSE}`,
+    '</body>',
+    '</html>',
+  ].join('\n')
+}

--- a/src/features/ide/composables/useHtmlExporter.ts
+++ b/src/features/ide/composables/useHtmlExporter.ts
@@ -2,13 +2,14 @@
  * useHtmlExporter composable
  *
  * Orchestrates exporting an F-BASIC program as a standalone HTML file.
- * Step 2a: Adds Blob creation and file download trigger mechanism.
- * Full runtime embedding will be added in later steps (#772, #773).
+ * Uses buildExportHtml to assemble the HTML template with canvas, theme CSS,
+ * embedded program source, and a runtime script placeholder.
  */
 
 import { ref } from 'vue'
 
 import type { CompactBg } from '@/core/types/program-types'
+import { buildExportHtml } from '@/features/ide/composables/buildExportHtml'
 
 /** Default filename used when the export title is empty or whitespace-only. */
 export const DEFAULT_EXPORT_FILENAME = 'program.html'
@@ -27,40 +28,6 @@ export interface HtmlExportOptions {
 
 /** MIME type for HTML content. */
 const HTML_MIME_TYPE = 'text/html;charset=utf-8'
-
-/**
- * Generates a minimal HTML wrapper containing the F-BASIC program source.
- * This is a placeholder — the full standalone HTML with embedded runtime
- * will be generated in later steps (#772, #773).
- *
- * @param source - The F-BASIC program source code
- * @param options - Export configuration options
- * @returns HTML string with the program source embedded
- */
-function buildMinimalHtml(source: string, options: HtmlExportOptions): string {
-  // TODO(#772): Use options.theme to embed the correct theme stylesheet
-  // TODO(#773): Use options.includeSound to conditionally embed sound data
-  // TODO(#773): Use options.includeSprites to conditionally embed sprite data
-  const escapedSource = source
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-
-  return [
-    '<!DOCTYPE html>',
-    '<html lang="en">',
-    '<head>',
-    '  <meta charset="UTF-8">',
-    `  <title>${options.title}</title>`,
-    '</head>',
-    '<body>',
-    '  <pre>',
-    escapedSource,
-    '  </pre>',
-    '</body>',
-    '</html>',
-  ].join('\n')
-}
 
 /**
  * Triggers a file download by creating a temporary anchor element.
@@ -112,7 +79,8 @@ export function useHtmlExporter(
 
   /**
    * Triggers the HTML export with the given options.
-   * Creates a Blob with minimal HTML content and triggers a file download.
+   * Assembles the HTML template with canvas, theme CSS, and program source,
+   * creates a Blob, and triggers a file download.
    *
    * @param options - Export configuration options
    */
@@ -121,7 +89,7 @@ export function useHtmlExporter(
     exportError.value = ''
 
     try {
-      const html = buildMinimalHtml(source.value, options)
+      const html = buildExportHtml(source.value, options)
       const blob = new Blob([html], { type: HTML_MIME_TYPE })
       const filename = toExportFilename(options.title)
       triggerDownload(blob, filename)

--- a/test/ide/buildExportHtml.test.ts
+++ b/test/ide/buildExportHtml.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for buildExportHtml
+ *
+ * Verifies the HTML template assembly for the export wrapper.
+ * The template must include: canvas element, theme CSS, program source
+ * embedding, and a runtime script placeholder.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { buildExportHtml } from '@/features/ide/composables/buildExportHtml'
+import type { HtmlExportOptions } from '@/features/ide/composables/useHtmlExporter'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const defaultOptions: HtmlExportOptions = {
+  title: 'Test Program',
+  theme: 'dark',
+  includeSound: false,
+  includeSprites: false,
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('buildExportHtml', () => {
+  // -- Document structure -----------------------------------------------------
+
+  describe('document structure', () => {
+    it('returns a string starting with <!DOCTYPE html>', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html.startsWith('<!DOCTYPE html>')).toBe(true)
+    })
+
+    it('contains exactly one <html> element', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const matches = html.match(/<html[^>]*>/g)
+      expect(matches).toHaveLength(1)
+    })
+
+    it('contains exactly one <head> element', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const matches = html.match(/<head>/g)
+      expect(matches).toHaveLength(1)
+    })
+
+    it('contains exactly one <body> element', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const matches = html.match(/<body[^>]*>/g)
+      expect(matches).toHaveLength(1)
+    })
+
+    it('contains charset meta tag with UTF-8', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toContain('charset="UTF-8"')
+    })
+
+    it('contains viewport meta tag', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toContain('viewport')
+    })
+  })
+
+  // -- Title ------------------------------------------------------------------
+
+  describe('title', () => {
+    it('sets the page title from options.title', () => {
+      const html = buildExportHtml('10 PRINT "HI"', {
+        ...defaultOptions,
+        title: 'My Game',
+      })
+      expect(html).toContain('<title>My Game</title>')
+    })
+
+    it('escapes HTML entities in the title', () => {
+      const html = buildExportHtml('10 PRINT "HI"', {
+        ...defaultOptions,
+        title: '<script>alert("xss")</script>',
+      })
+      expect(html).not.toContain('<script>alert("xss")</script>')
+      expect(html).toContain('&lt;script&gt;')
+    })
+  })
+
+  // -- Canvas element ---------------------------------------------------------
+
+  describe('canvas element', () => {
+    it('contains a canvas element', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toMatch(/<canvas/)
+    })
+
+    it('canvas has id "fbasic-screen"', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toContain('id="fbasic-screen"')
+    })
+
+    it('canvas has width 256', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toMatch(/<canvas[^>]*width="256"/)
+    })
+
+    it('canvas has height 240', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toMatch(/<canvas[^>]*height="240"/)
+    })
+  })
+
+  // -- Theme CSS --------------------------------------------------------------
+
+  describe('theme CSS', () => {
+    it('includes inline CSS in a <style> tag', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toMatch(/<style[^>]*>/)
+    })
+
+    it('applies dark theme background when theme is dark', () => {
+      const html = buildExportHtml('10 PRINT "HI"', {
+        ...defaultOptions,
+        theme: 'dark',
+      })
+      // Dark theme should have a dark background color (near-black)
+      expect(html).toContain('background-color:#000')
+    })
+
+    it('applies light theme background when theme is light', () => {
+      const html = buildExportHtml('10 PRINT "HI"', {
+        ...defaultOptions,
+        theme: 'light',
+      })
+      // Light theme should have a light background color (near-white)
+      expect(html).toContain('background-color:#fff')
+    })
+
+    it('centers the canvas using flexbox', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toContain('display:flex')
+      expect(html).toContain('justify-content:center')
+    })
+  })
+
+  // -- Program source embedding -----------------------------------------------
+
+  describe('program source embedding', () => {
+    it('embeds program source in a script tag with id fbasic-program', () => {
+      const html = buildExportHtml('10 PRINT "HELLO"', defaultOptions)
+      expect(html).toContain('id="fbasic-program"')
+      expect(html).toContain('10 PRINT "HELLO"')
+    })
+
+    it('preserves multi-line program source', () => {
+      const source = '10 PRINT "LINE1"\n20 PRINT "LINE2"\n30 END'
+      const html = buildExportHtml(source, defaultOptions)
+      expect(html).toContain('10 PRINT "LINE1"')
+      expect(html).toContain('20 PRINT "LINE2"')
+      expect(html).toContain('30 END')
+    })
+
+    it('escapes HTML entities in program source', () => {
+      const html = buildExportHtml('<div>test</div>', defaultOptions)
+      // Inside a <script> tag, < and > don't need escaping,
+      // but the </script> sequence must be broken to avoid closing the tag
+      expect(html).not.toContain('</script></script>')
+    })
+
+    it('escapes the closing script tag sequence in program source', () => {
+      const source = '10 PRINT "</script>"'
+      const html = buildExportHtml(source, defaultOptions)
+      // The literal "</script>" inside the program source must not prematurely
+      // close the <script id="fbasic-program"> tag
+      const programTagStart = html.indexOf('id="fbasic-program"')
+      const runtimeId = html.indexOf('id="fbasic-runtime"')
+      // The runtime placeholder must still be present after the program tag
+      expect(runtimeId).toBeGreaterThan(programTagStart)
+    })
+  })
+
+  // -- Runtime script placeholder ---------------------------------------------
+
+  describe('runtime script placeholder', () => {
+    it('includes a script tag with id fbasic-runtime', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toContain('id="fbasic-runtime"')
+    })
+
+    it('runtime placeholder is an empty script tag', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const runtimeMatch = html.match(
+        /<script[^>]*id="fbasic-runtime"[^>]*>\s*<\/script>/,
+      )
+      expect(runtimeMatch).not.toBeNull()
+    })
+
+    it('runtime placeholder appears after program source script', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const programIndex = html.indexOf('id="fbasic-program"')
+      const runtimeIndex = html.indexOf('id="fbasic-runtime"')
+      expect(runtimeIndex).toBeGreaterThan(programIndex)
+    })
+  })
+
+  // -- Include flags (stored as data attributes) ------------------------------
+
+  describe('export options data attributes', () => {
+    it('sets data-include-sound attribute on body', () => {
+      const html = buildExportHtml('10 PRINT "HI"', {
+        ...defaultOptions,
+        includeSound: true,
+      })
+      expect(html).toMatch(/<body[^>]*data-include-sound="true"/)
+    })
+
+    it('sets data-include-sound to false when includeSound is false', () => {
+      const html = buildExportHtml('10 PRINT "HI"', {
+        ...defaultOptions,
+        includeSound: false,
+      })
+      expect(html).toMatch(/<body[^>]*data-include-sound="false"/)
+    })
+
+    it('sets data-include-sprites attribute on body', () => {
+      const html = buildExportHtml('10 PRINT "HI"', {
+        ...defaultOptions,
+        includeSprites: true,
+      })
+      expect(html).toMatch(/<body[^>]*data-include-sprites="true"/)
+    })
+
+    it('sets data-include-sprites to false when includeSprites is false', () => {
+      const html = buildExportHtml('10 PRINT "HI"', {
+        ...defaultOptions,
+        includeSprites: false,
+      })
+      expect(html).toMatch(/<body[^>]*data-include-sprites="false"/)
+    })
+  })
+
+  // -- Valid HTML -------------------------------------------------------------
+
+  describe('valid HTML output', () => {
+    it('ends with </html>', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html.trimEnd()).toMatch(/<\/html>$/)
+    })
+
+    it('has matching head and body close tags', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      expect(html).toContain('</head>')
+      expect(html).toContain('</body>')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #772

## Changes
- Created `buildExportHtml` composable that generates a self-contained HTML document for F-BASIC program export
- HTML template includes: canvas element (256x240), inline theme CSS (dark/light), program source embedding with XSS protection, runtime script placeholder, and export option data attributes
- Updated `useHtmlExporter.ts` to use `buildExportHtml` instead of the old inline `buildMinimalHtml` stub (removed 38 lines of stub code)
- 29 new tests covering document structure, title escaping, canvas dimensions, theme CSS, program source embedding, runtime placeholder, and export options

## Test plan
- [x] 29 new unit tests pass (buildExportHtml.test.ts)
- [x] 64 total tests pass across related files
- [x] TypeScript type-check clean
- [x] ESLint clean
- [ ] CI passes