### PR TITLE
test: resolve #840 - add numeric param conversion test for createI18nMock

### DIFF
--- a/test/helpers/createI18nMock.test.ts
+++ b/test/helpers/createI18nMock.test.ts
@@ -34,6 +34,11 @@ describe('createI18nMock', () => {
     )
   })
 
+  it('converts numeric params to string', () => {
+    const t = createI18nMock({ count: 'Count: {n}' })
+    expect(t('count', { n: 42 })).toEqual('Count: 42')
+  })
+
   it('replaces repeated placeholder among multiple distinct ones', () => {
     const t = createI18nMock({
       msg: '{a} and {b} and {a}',


### PR DESCRIPTION
## Summary
- Fixes #840

## Changes
- Added test case verifying numeric params are converted to strings via `String(v)` in createI18nMock

## Test plan
- [x] 7/7 createI18nMock tests pass
- [x] CI passes