### PR TITLE
refactor: resolve #839 - remove unused i18n mock key from IdeBottomAreaBufferTab test

### DIFF
--- a/test/ide/IdeBottomAreaBufferTab.test.ts
+++ b/test/ide/IdeBottomAreaBufferTab.test.ts
@@ -10,9 +10,7 @@ import IdeBottomArea from '@/features/ide/components/IdeBottomArea.vue'
 import { createI18nMock } from '../helpers/createI18nMock'
 import { createTestKeyboardBuffer } from './helpers/createTestKeyboardBuffer'
 
-const mockT = createI18nMock({
-  'ide.bufferInspector.title': 'Buffer Inspector',
-})
+const mockT = createI18nMock({})
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: mockT }),


### PR DESCRIPTION
## Summary
- Fixes #839

## Changes
- Removed unused `'ide.bufferInspector.title': 'Buffer Inspector'` key from `createI18nMock()` in `IdeBottomAreaBufferTab.test.ts`, leaving an empty `createI18nMock({})`. The `createI18nMock` helper already falls back to returning the raw key for unmapped keys, so all component `t()` calls continue to work correctly.

## Test plan
- [ ] 9/9 IdeBottomAreaBufferTab tests pass
- [ ] CI passes