### PR TITLE
refactor: resolve #849 - centralize export HTML theme color constants

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -315,3 +315,11 @@ export const SYNTAX_COLORS = {
   LINE_NUMBER: '#666666',
   VARIABLE: '#9900cc',
 } as const
+
+// Export HTML theme colors (used by buildExportHtml for standalone HTML output)
+export const EXPORT_THEME_COLORS = {
+  DARK_BG: '#000',
+  LIGHT_BG: '#fff',
+  DARK_TEXT: '#e0e0e0',
+  LIGHT_TEXT: '#1a1a1a',
+} as const

--- a/src/features/ide/composables/buildExportHtml.ts
+++ b/src/features/ide/composables/buildExportHtml.ts
@@ -11,32 +11,20 @@
  * by the build step (#635) or a dedicated wiring step.
  */
 
-import { SCREEN_DIMENSIONS } from '@/core/constants'
+import { EXPORT_THEME_COLORS, SCREEN_DIMENSIONS } from '@/core/constants'
 import type { HtmlExportOptions } from '@/features/ide/composables/useHtmlExporter'
 
 /** Canvas width and height matching F-BASIC sprite screen dimensions. */
 const CANVAS_WIDTH = SCREEN_DIMENSIONS.SPRITE.WIDTH
 const CANVAS_HEIGHT = SCREEN_DIMENSIONS.SPRITE.HEIGHT
 
-/** CSS background color for dark theme. */
-const DARK_BG = '#000'
-
-/** CSS background color for light theme. */
-const LIGHT_BG = '#fff'
-
-/** CSS text color for dark theme (off-white for readability). */
-const DARK_TEXT = '#e0e0e0'
-
-/** CSS text color for light theme (near-black for readability). */
-const LIGHT_TEXT = '#1a1a1a'
-
 /**
  * Returns the CSS color values for the given theme.
  */
 function getThemeColors(theme: 'dark' | 'light'): { bg: string; text: string } {
   return theme === 'dark'
-    ? { bg: DARK_BG, text: DARK_TEXT }
-    : { bg: LIGHT_BG, text: LIGHT_TEXT }
+    ? { bg: EXPORT_THEME_COLORS.DARK_BG, text: EXPORT_THEME_COLORS.DARK_TEXT }
+    : { bg: EXPORT_THEME_COLORS.LIGHT_BG, text: EXPORT_THEME_COLORS.LIGHT_TEXT }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes #849

## Changes
- Moved 4 hardcoded theme color hex constants (`DARK_BG`, `LIGHT_BG`, `DARK_TEXT`, `LIGHT_TEXT`) from `buildExportHtml.ts` into a new `EXPORT_THEME_COLORS` object in `src/core/constants.ts`
- Updated `getThemeColors()` in `buildExportHtml.ts` to reference `EXPORT_THEME_COLORS.*`

## Test plan
- [x] 29/29 buildExportHtml tests pass
- [x] TypeScript type-check clean
- [x] ESLint clean
- [x] CI passes