### PR TITLE
refactor: resolve #850 - use locale-aware lang attribute in exported HTML

### DIFF
--- a/src/features/ide/composables/buildExportHtml.ts
+++ b/src/features/ide/composables/buildExportHtml.ts
@@ -98,11 +98,13 @@ function buildThemeCss(theme: 'dark' | 'light'): string {
  *
  * @param source - The F-BASIC program source code
  * @param options - Export configuration options
+ * @param locale - The user's current locale for the HTML lang attribute
  * @returns A complete HTML document string
  */
 export function buildExportHtml(
   source: string,
   options: HtmlExportOptions,
+  locale: string,
 ): string {
   const css = buildThemeCss(options.theme)
   const escapedTitle = escapeHtml(options.title)
@@ -110,7 +112,7 @@ export function buildExportHtml(
 
   return [
     '<!DOCTYPE html>',
-    '<html lang="en">',
+    `<html lang="${locale}">`,
     '<head>',
     '  <meta charset="UTF-8">',
     '  <meta name="viewport" content="width=device-width, initial-scale=1.0">',

--- a/src/features/ide/composables/useHtmlExporter.ts
+++ b/src/features/ide/composables/useHtmlExporter.ts
@@ -7,6 +7,7 @@
  */
 
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import type { CompactBg } from '@/core/types/program-types'
 import { buildExportHtml } from '@/features/ide/composables/buildExportHtml'
@@ -76,6 +77,7 @@ export function useHtmlExporter(
 ) {
   const isExporting = ref(false)
   const exportError = ref('')
+  const { locale } = useI18n()
 
   /**
    * Triggers the HTML export with the given options.
@@ -89,7 +91,7 @@ export function useHtmlExporter(
     exportError.value = ''
 
     try {
-      const html = buildExportHtml(source.value, options)
+      const html = buildExportHtml(source.value, options, locale.value)
       const blob = new Blob([html], { type: HTML_MIME_TYPE })
       const filename = toExportFilename(options.title)
       triggerDownload(blob, filename)

--- a/test/ide/buildExportHtml.test.ts
+++ b/test/ide/buildExportHtml.test.ts
@@ -27,39 +27,53 @@ const defaultOptions: HtmlExportOptions = {
 // ============================================================================
 
 describe('buildExportHtml', () => {
+  // -- Locale -----------------------------------------------------------------
+
+  describe('locale', () => {
+    it('uses the provided locale in the HTML lang attribute', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
+      expect(html).toContain('<html lang="en">')
+    })
+
+    it('reflects a non-English locale in the HTML lang attribute', () => {
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'ja')
+      expect(html).toContain('<html lang="ja">')
+    })
+  })
+
   // -- Document structure -----------------------------------------------------
 
   describe('document structure', () => {
     it('returns a string starting with <!DOCTYPE html>', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html.startsWith('<!DOCTYPE html>')).toBe(true)
     })
 
     it('contains exactly one <html> element', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       const matches = html.match(/<html[^>]*>/g)
       expect(matches).toHaveLength(1)
     })
 
     it('contains exactly one <head> element', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       const matches = html.match(/<head>/g)
       expect(matches).toHaveLength(1)
     })
 
     it('contains exactly one <body> element', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       const matches = html.match(/<body[^>]*>/g)
       expect(matches).toHaveLength(1)
     })
 
     it('contains charset meta tag with UTF-8', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toContain('charset="UTF-8"')
     })
 
     it('contains viewport meta tag', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toContain('viewport')
     })
   })
@@ -71,7 +85,7 @@ describe('buildExportHtml', () => {
       const html = buildExportHtml('10 PRINT "HI"', {
         ...defaultOptions,
         title: 'My Game',
-      })
+      }, 'en')
       expect(html).toContain('<title>My Game</title>')
     })
 
@@ -79,7 +93,7 @@ describe('buildExportHtml', () => {
       const html = buildExportHtml('10 PRINT "HI"', {
         ...defaultOptions,
         title: '<script>alert("xss")</script>',
-      })
+      }, 'en')
       expect(html).not.toContain('<script>alert("xss")</script>')
       expect(html).toContain('&lt;script&gt;')
     })
@@ -89,22 +103,22 @@ describe('buildExportHtml', () => {
 
   describe('canvas element', () => {
     it('contains a canvas element', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toMatch(/<canvas/)
     })
 
     it('canvas has id "fbasic-screen"', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toContain('id="fbasic-screen"')
     })
 
     it('canvas has width 256', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toMatch(/<canvas[^>]*width="256"/)
     })
 
     it('canvas has height 240', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toMatch(/<canvas[^>]*height="240"/)
     })
   })
@@ -113,7 +127,7 @@ describe('buildExportHtml', () => {
 
   describe('theme CSS', () => {
     it('includes inline CSS in a <style> tag', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toMatch(/<style[^>]*>/)
     })
 
@@ -121,7 +135,7 @@ describe('buildExportHtml', () => {
       const html = buildExportHtml('10 PRINT "HI"', {
         ...defaultOptions,
         theme: 'dark',
-      })
+      }, 'en')
       // Dark theme should have a dark background color (near-black)
       expect(html).toContain('background-color:#000')
     })
@@ -130,13 +144,13 @@ describe('buildExportHtml', () => {
       const html = buildExportHtml('10 PRINT "HI"', {
         ...defaultOptions,
         theme: 'light',
-      })
+      }, 'en')
       // Light theme should have a light background color (near-white)
       expect(html).toContain('background-color:#fff')
     })
 
     it('centers the canvas using flexbox', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toContain('display:flex')
       expect(html).toContain('justify-content:center')
     })
@@ -146,21 +160,21 @@ describe('buildExportHtml', () => {
 
   describe('program source embedding', () => {
     it('embeds program source in a script tag with id fbasic-program', () => {
-      const html = buildExportHtml('10 PRINT "HELLO"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HELLO"', defaultOptions, 'en')
       expect(html).toContain('id="fbasic-program"')
       expect(html).toContain('10 PRINT "HELLO"')
     })
 
     it('preserves multi-line program source', () => {
       const source = '10 PRINT "LINE1"\n20 PRINT "LINE2"\n30 END'
-      const html = buildExportHtml(source, defaultOptions)
+      const html = buildExportHtml(source, defaultOptions, 'en')
       expect(html).toContain('10 PRINT "LINE1"')
       expect(html).toContain('20 PRINT "LINE2"')
       expect(html).toContain('30 END')
     })
 
     it('escapes HTML entities in program source', () => {
-      const html = buildExportHtml('<div>test</div>', defaultOptions)
+      const html = buildExportHtml('<div>test</div>', defaultOptions, 'en')
       // Inside a <script> tag, < and > don't need escaping,
       // but the </script> sequence must be broken to avoid closing the tag
       expect(html).not.toContain('</script></script>')
@@ -168,7 +182,7 @@ describe('buildExportHtml', () => {
 
     it('escapes the closing script tag sequence in program source', () => {
       const source = '10 PRINT "</script>"'
-      const html = buildExportHtml(source, defaultOptions)
+      const html = buildExportHtml(source, defaultOptions, 'en')
       // The literal "</script>" inside the program source must not prematurely
       // close the <script id="fbasic-program"> tag
       const programTagStart = html.indexOf('id="fbasic-program"')
@@ -182,12 +196,12 @@ describe('buildExportHtml', () => {
 
   describe('runtime script placeholder', () => {
     it('includes a script tag with id fbasic-runtime', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toContain('id="fbasic-runtime"')
     })
 
     it('runtime placeholder is an empty script tag', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       const runtimeMatch = html.match(
         /<script[^>]*id="fbasic-runtime"[^>]*>\s*<\/script>/,
       )
@@ -195,7 +209,7 @@ describe('buildExportHtml', () => {
     })
 
     it('runtime placeholder appears after program source script', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       const programIndex = html.indexOf('id="fbasic-program"')
       const runtimeIndex = html.indexOf('id="fbasic-runtime"')
       expect(runtimeIndex).toBeGreaterThan(programIndex)
@@ -209,7 +223,7 @@ describe('buildExportHtml', () => {
       const html = buildExportHtml('10 PRINT "HI"', {
         ...defaultOptions,
         includeSound: true,
-      })
+      }, 'en')
       expect(html).toMatch(/<body[^>]*data-include-sound="true"/)
     })
 
@@ -217,7 +231,7 @@ describe('buildExportHtml', () => {
       const html = buildExportHtml('10 PRINT "HI"', {
         ...defaultOptions,
         includeSound: false,
-      })
+      }, 'en')
       expect(html).toMatch(/<body[^>]*data-include-sound="false"/)
     })
 
@@ -225,7 +239,7 @@ describe('buildExportHtml', () => {
       const html = buildExportHtml('10 PRINT "HI"', {
         ...defaultOptions,
         includeSprites: true,
-      })
+      }, 'en')
       expect(html).toMatch(/<body[^>]*data-include-sprites="true"/)
     })
 
@@ -233,7 +247,7 @@ describe('buildExportHtml', () => {
       const html = buildExportHtml('10 PRINT "HI"', {
         ...defaultOptions,
         includeSprites: false,
-      })
+      }, 'en')
       expect(html).toMatch(/<body[^>]*data-include-sprites="false"/)
     })
   })
@@ -242,12 +256,12 @@ describe('buildExportHtml', () => {
 
   describe('valid HTML output', () => {
     it('ends with </html>', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html.trimEnd()).toMatch(/<\/html>$/)
     })
 
     it('has matching head and body close tags', () => {
-      const html = buildExportHtml('10 PRINT "HI"', defaultOptions)
+      const html = buildExportHtml('10 PRINT "HI"', defaultOptions, 'en')
       expect(html).toContain('</head>')
       expect(html).toContain('</body>')
     })

--- a/test/ide/useHtmlExporter.test.ts
+++ b/test/ide/useHtmlExporter.test.ts
@@ -16,6 +16,12 @@ import {
   useHtmlExporter,
 } from '@/features/ide/composables/useHtmlExporter'
 
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    locale: ref('en'),
+  }),
+}))
+
 const MOCK_BLOB_URL = 'blob:mock-url'
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Fixes #850

## Changes
- Added `locale: string` parameter to `buildExportHtml()` in `buildExportHtml.ts`
- Changed hardcoded `<html lang="en">` to `<html lang="${locale}">`
- `useHtmlExporter.ts` now reads locale from `useI18n()` and passes it to `buildExportHtml()`
- Added 2 tests verifying locale is correctly reflected in HTML lang attribute (en and ja)

## Test plan
- [x] 49/49 targeted tests pass (31 buildExportHtml + 18 useHtmlExporter)
- [x] Type-check clean
- [x] ESLint clean