### PR TITLE
feat: resolve #773 - wire source gathering from editor store to useHtmlExporter

### DIFF
--- a/src/features/ide/components/ExportHtmlDialog.vue
+++ b/src/features/ide/components/ExportHtmlDialog.vue
@@ -6,19 +6,14 @@
  * Uses the useHtmlExporter composable to trigger the actual export.
  */
 
-import { onMounted, onUnmounted, ref, toRef, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import type { CompactBg } from '@/core/types/program-types'
 import { useHtmlExporter } from '@/features/ide/composables/useHtmlExporter'
 
-const props = withDefaults(defineProps<{
+const props = defineProps<{
   visible: boolean
-  source: string
-  bg?: CompactBg
-}>(), {
-  bg: undefined,
-})
+}>()
 
 const emit = defineEmits<{
   (e: 'close'): void
@@ -27,10 +22,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 
 // Composable
-const { isExporting, exportError, exportHtml } = useHtmlExporter(
-  toRef(props, 'source'),
-  toRef(props, 'bg'),
-)
+const { isExporting, exportError, exportHtml } = useHtmlExporter()
 
 // Export options state
 const title = ref('')

--- a/src/features/ide/composables/useHtmlExporter.ts
+++ b/src/features/ide/composables/useHtmlExporter.ts
@@ -9,8 +9,8 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import type { CompactBg } from '@/core/types/program-types'
 import { buildExportHtml } from '@/features/ide/composables/buildExportHtml'
+import { useProgramStore } from '@/features/ide/composables/useProgramStore'
 
 /** Default filename used when the export title is empty or whitespace-only. */
 export const DEFAULT_EXPORT_FILENAME = 'program.html'
@@ -67,17 +67,15 @@ export function toExportFilename(title: string): string {
 /**
  * Composable for exporting an F-BASIC program as a standalone HTML file.
  *
- * @param source - The F-BASIC program source code
- * @param _bg - Optional BG data (reserved for future use)
+ * Reads the current program source from the program store.
+ *
  * @returns Reactive export state and the exportHtml function
  */
-export function useHtmlExporter(
-  source: { value: string },
-  _bg?: { value: CompactBg | undefined },
-) {
+export function useHtmlExporter() {
   const isExporting = ref(false)
   const exportError = ref('')
   const { locale } = useI18n()
+  const programStore = useProgramStore()
 
   /**
    * Triggers the HTML export with the given options.
@@ -91,7 +89,7 @@ export function useHtmlExporter(
     exportError.value = ''
 
     try {
-      const html = buildExportHtml(source.value, options, locale.value)
+      const html = buildExportHtml(programStore.code, options, locale.value)
       const blob = new Blob([html], { type: HTML_MIME_TYPE })
       const filename = toExportFilename(options.title)
       triggerDownload(blob, filename)

--- a/test/ide/ExportHtmlDialog.test.ts
+++ b/test/ide/ExportHtmlDialog.test.ts
@@ -3,7 +3,6 @@ import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
 
-import type { CompactBg } from '@/core/types/program-types'
 import ExportHtmlDialog from '@/features/ide/components/ExportHtmlDialog.vue'
 
 // ---------------------------------------------------------------------------
@@ -58,13 +57,10 @@ const teleportStub = defineComponent({
 
 function mountDialog(props: {
   visible?: boolean
-  source?: string
-  bg?: CompactBg
 } = {}) {
   return mount(ExportHtmlDialog, {
     props: {
       visible: false,
-      source: '10 PRINT "HELLO"',
       ...props,
     },
     global: {

--- a/test/ide/useHtmlExporter.test.ts
+++ b/test/ide/useHtmlExporter.test.ts
@@ -4,7 +4,8 @@
  *
  * Covers: file download mechanism including Blob creation,
  * URL.createObjectURL / revokeObjectURL lifecycle,
- * temporary anchor element creation and click trigger.
+ * temporary anchor element creation and click trigger,
+ * and program store integration.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -22,18 +23,26 @@ vi.mock('vue-i18n', () => ({
   }),
 }))
 
+// -- Program store mock -------------------------------------------------------
+
+const mockCode = ref('10 PRINT "HELLO"')
+
+vi.mock('@/features/ide/composables/useProgramStore', () => ({
+  useProgramStore: () => ({
+    get code() {
+      return mockCode.value
+    },
+  }),
+}))
+
 const MOCK_BLOB_URL = 'blob:mock-url'
 
 // ============================================================================
 // Helpers
 // ============================================================================
 
-function createSourceRef(code: string) {
-  return ref(code)
-}
-
-function mountComposable(code = '10 PRINT "HELLO"') {
-  return useHtmlExporter(createSourceRef(code))
+function mountComposable() {
+  return useHtmlExporter()
 }
 
 // ============================================================================
@@ -132,7 +141,7 @@ describe('useHtmlExporter', () => {
 
   describe('download mechanism', () => {
     it('creates a Blob with HTML content type when exportHtml is called', async () => {
-      const { exportHtml } = mountComposable('10 PRINT "HELLO"')
+      const { exportHtml } = mountComposable()
 
       const blobSpy = vi.spyOn(globalThis, 'Blob')
 
@@ -154,7 +163,7 @@ describe('useHtmlExporter', () => {
     })
 
     it('calls URL.createObjectURL with the blob', async () => {
-      const { exportHtml } = mountComposable('10 CLS')
+      const { exportHtml } = mountComposable()
 
       await exportHtml({
         title: 'My Program',
@@ -169,7 +178,7 @@ describe('useHtmlExporter', () => {
     })
 
     it('creates a temporary anchor element with download attribute set to filename', async () => {
-      const { exportHtml } = mountComposable('10 PRINT "HI"')
+      const { exportHtml } = mountComposable()
 
       await exportHtml({
         title: 'My Program',
@@ -185,7 +194,7 @@ describe('useHtmlExporter', () => {
     })
 
     it('triggers click on the anchor element', async () => {
-      const { exportHtml } = mountComposable('10 PRINT "HI"')
+      const { exportHtml } = mountComposable()
 
       await exportHtml({
         title: 'My Program',
@@ -200,7 +209,7 @@ describe('useHtmlExporter', () => {
     })
 
     it('calls URL.revokeObjectURL for cleanup after download', async () => {
-      const { exportHtml } = mountComposable('10 PRINT "HI"')
+      const { exportHtml } = mountComposable()
 
       await exportHtml({
         title: 'My Program',
@@ -214,7 +223,7 @@ describe('useHtmlExporter', () => {
     })
 
     it('removes the anchor element from the DOM after download', async () => {
-      const { exportHtml } = mountComposable('10 PRINT "HI"')
+      const { exportHtml } = mountComposable()
 
       await exportHtml({
         title: 'My Program',
@@ -303,6 +312,43 @@ describe('useHtmlExporter', () => {
 
       const anchor = capturedAnchors[0]!
       expect(anchor.getAttribute('download')).toEqual(DEFAULT_EXPORT_FILENAME)
+    })
+  })
+
+  // -- Program store integration ----------------------------------------------
+
+  describe('program store integration', () => {
+    it('reads program source from useProgramStore', async () => {
+      const { exportHtml } = mountComposable()
+
+      const blobSpy = vi.spyOn(globalThis, 'Blob')
+      await exportHtml({
+        title: 'Test',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      const [content] = blobSpy.mock.calls[0]!
+      expect((content as string[])[0]).toContain('10 PRINT "HELLO"')
+      blobSpy.mockRestore()
+    })
+
+    it('exports the current store code without requiring a source parameter', async () => {
+      mockCode.value = '20 GOTO 10'
+      const { exportHtml } = mountComposable()
+
+      const blobSpy = vi.spyOn(globalThis, 'Blob')
+      await exportHtml({
+        title: 'Test',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      const [content] = blobSpy.mock.calls[0]!
+      expect((content as string[])[0]).toContain('20 GOTO 10')
+      blobSpy.mockRestore()
     })
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #773 — wires `useHtmlExporter` to read program source from `useProgramStore` instead of accepting it as a parameter

## Changes
- `useHtmlExporter.ts`: Removed `source` and `_bg` parameters, added `useProgramStore` import, reads `code` directly from the store
- `ExportHtmlDialog.vue`: Removed `source` and `bg` props, simplified composable call to `useHtmlExporter()`
- `useHtmlExporter.test.ts`: Added `useProgramStore` mock with reactive `code` getter, 2 new integration tests, updated existing tests to use no-arg `mountComposable()`
- `ExportHtmlDialog.test.ts`: Removed `source`/`bg` props from `mountDialog` helper and `CompactBg` import

## Test plan
- [x] 37 targeted tests pass (20 useHtmlExporter + 17 ExportHtmlDialog)
- [x] TypeScript type-check passes
- [x] ESLint passes (no errors)
- [ ] CI passes