### PR TITLE
feat: resolve #632 - build main-thread fallback runtime for export

### DIFF
--- a/src/core/devices/CanvasScreenRenderer.ts
+++ b/src/core/devices/CanvasScreenRenderer.ts
@@ -1,0 +1,132 @@
+/**
+ * CanvasScreenRenderer
+ *
+ * Renders the F-BASIC screen buffer to an HTML5 canvas element.
+ * Used by the export runtime to display program output in standalone HTML.
+ *
+ * Each character cell is rendered as a colored backdrop rectangle
+ * with the character drawn on top. The canvas uses 256x240 pixels
+ * (F-BASIC sprite screen dimensions), and each text character occupies
+ * an 8x8 pixel cell.
+ */
+
+import { SCREEN_DIMENSIONS } from '@/core/constants'
+import type { ScreenCell } from '@/core/types/execution-types'
+
+/** Default backdrop color for the canvas (black). */
+const DEFAULT_BACKDROP_COLOR = '#000000'
+
+/** Default text color for characters. */
+const DEFAULT_TEXT_COLOR = '#FFFFFF'
+
+/** Character cell dimensions in pixels. */
+const CHAR_WIDTH = 8
+const CHAR_HEIGHT = 8
+
+/**
+ * Minimal canvas context interface used by CanvasScreenRenderer.
+ * Only the methods actually called by the renderer are required.
+ * Uses (...args: unknown[]) for method signatures so that vitest
+ * mocks satisfy the interface without type assertions.
+ */
+export interface CanvasRenderContext {
+  fillStyle: string
+  font: string
+  textBaseline: string
+  fillRect(...args: unknown[]): void
+  fillText(...args: unknown[]): void
+}
+
+/**
+ * Minimal canvas interface required by CanvasScreenRenderer.
+ *
+ * HTMLCanvasElement satisfies this interface. Tests can provide
+ * a mock object implementing CanvasRenderContext without
+ * needing the full CanvasRenderingContext2D surface.
+ */
+export interface CanvasSurface {
+  readonly width: number
+  readonly height: number
+  getContext(contextId: '2d'): CanvasRenderContext | null
+}
+
+/**
+ * Renders the F-BASIC screen buffer to an HTML5 canvas.
+ *
+ * Takes a canvas element and draws the full 28x24 text screen,
+ * using 8x8 pixel cells for each character position.
+ */
+export class CanvasScreenRenderer {
+  private readonly canvas: CanvasSurface
+
+  constructor(canvas: CanvasSurface) {
+    this.canvas = canvas
+  }
+
+  /**
+   * Get the canvas surface.
+   */
+  getCanvas(): CanvasSurface {
+    return this.canvas
+  }
+
+  /**
+   * Clear the entire canvas to the default backdrop color (black).
+   */
+  clear(): void {
+    const ctx = this.getContext()
+    ctx.fillStyle = DEFAULT_BACKDROP_COLOR
+    ctx.fillRect(0, 0, this.canvas.width, this.canvas.height)
+  }
+
+  /**
+   * Render the full screen buffer to the canvas.
+   *
+   * First clears the canvas, then iterates over all 28x24 cells,
+   * drawing a backdrop rectangle and the character text for each cell.
+   *
+   * @param screenBuffer - The 28x24 screen buffer from ScreenStateManager
+   */
+  render(screenBuffer: ScreenCell[][]): void {
+    this.clear()
+
+    const ctx = this.getContext()
+    ctx.font = `${CHAR_HEIGHT}px monospace`
+    ctx.textBaseline = 'top'
+
+    const columns = SCREEN_DIMENSIONS.BACKGROUND.COLUMNS
+    const lines = SCREEN_DIMENSIONS.BACKGROUND.LINES
+
+    for (let y = 0; y < lines; y++) {
+      const row = screenBuffer[y]
+      if (!row) continue
+
+      for (let x = 0; x < columns; x++) {
+        const cell = row[x]
+        if (!cell) continue
+
+        const pixelX = x * CHAR_WIDTH
+        const pixelY = y * CHAR_HEIGHT
+
+        // Draw backdrop rectangle for each cell
+        ctx.fillStyle = DEFAULT_BACKDROP_COLOR
+        ctx.fillRect(pixelX, pixelY, CHAR_WIDTH, CHAR_HEIGHT)
+
+        // Draw the character text
+        ctx.fillStyle = DEFAULT_TEXT_COLOR
+        ctx.fillText(cell.character, pixelX, pixelY)
+      }
+    }
+  }
+
+  /**
+   * Get the 2D rendering context from the canvas.
+   */
+  private getContext(): CanvasRenderContext {
+    const ctx = this.canvas.getContext('2d')
+    if (!ctx) {
+      throw new Error('CanvasScreenRenderer: could not get 2D context from canvas')
+    }
+    return ctx
+  }
+}

--- a/src/core/devices/MainThreadDeviceAdapter.ts
+++ b/src/core/devices/MainThreadDeviceAdapter.ts
@@ -1,0 +1,178 @@
+/**
+ * MainThreadDeviceAdapter
+ *
+ * A BasicDeviceAdapter implementation for the export runtime that renders
+ * directly to an HTML5 canvas on the main thread, without web workers
+ * or SharedArrayBuffer.
+ *
+ * Screen operations are delegated to:
+ * - {@link ScreenStateManager} for screen buffer state management
+ * - {@link CanvasScreenRenderer} for drawing the buffer to the canvas
+ *
+ * Sound, sprites, and input dialogs are stubbed for future steps.
+ */
+
+import type { BasicDeviceAdapter } from '@/core/types/device-types'
+
+import type { CanvasSurface } from './CanvasScreenRenderer'
+import { CanvasScreenRenderer } from './CanvasScreenRenderer'
+import { ScreenStateManager } from './ScreenStateManager'
+
+/** Configuration for creating a MainThreadDeviceAdapter. */
+export interface MainThreadDeviceAdapterOptions {
+  /** The canvas surface to render the screen buffer to. */
+  canvas: CanvasSurface
+}
+
+/**
+ * Device adapter for the export runtime.
+ *
+ * Runs on the main thread and renders to a canvas. Used by standalone
+ * exported HTML files that cannot use web workers or SharedArrayBuffer.
+ *
+ * Implements all required methods from BasicDeviceAdapter. Sound,
+ * sprite, and input dialog methods are stubbed no-ops pending
+ * future implementation steps (#633, #634).
+ */
+export class MainThreadDeviceAdapter implements BasicDeviceAdapter {
+  private readonly screenState: ScreenStateManager
+  private readonly renderer: CanvasScreenRenderer
+
+  // === KEYBOARD INPUT STATE ===
+
+  private currentKey: string = ''
+
+  constructor(options: MainThreadDeviceAdapterOptions) {
+    this.screenState = new ScreenStateManager()
+    this.renderer = new CanvasScreenRenderer(options.canvas)
+  }
+
+  // === JOYSTICK INPUT (stubbed — no joystick support in export) ===
+
+  getJoystickCount(): number {
+    return 0
+  }
+
+  getStickState(_joystickId: number): number {
+    return 0
+  }
+
+  setStickState(_joystickId: number, _state: number): void {
+    // No-op: joystick not supported in export
+  }
+
+  pushStrigState(_joystickId: number, _state: number): void {
+    // No-op: joystick not supported in export
+  }
+
+  consumeStrigState(_joystickId: number): number {
+    return 0
+  }
+
+  // === KEYBOARD INPUT (INKEY$) ===
+
+  getInkeyState(): string {
+    return this.currentKey
+  }
+
+  setInkeyState(keyChar: string): void {
+    this.currentKey = keyChar
+  }
+
+  clearInkeyState(): void {
+    this.currentKey = ''
+  }
+
+  // === SPRITE POSITION (stubbed — sprites in future step #634) ===
+
+  getSpritePosition(_actionNumber: number): { x: number; y: number } | null {
+    return null
+  }
+
+  // === TEXT OUTPUT ===
+
+  printOutput(output: string): void {
+    this.writeToScreen(output)
+  }
+
+  debugOutput(output: string): void {
+    this.writeToScreen(output)
+  }
+
+  errorOutput(output: string): void {
+    this.writeToScreen(output)
+  }
+
+  clearScreen(): void {
+    this.screenState.initializeScreen()
+    this.renderer.clear()
+  }
+
+  setCursorPosition(x: number, y: number): void {
+    this.screenState.setCursorPosition(x, y)
+  }
+
+  getCursorPosition(): { x: number; y: number } {
+    return this.screenState.getCursorPosition()
+  }
+
+  getScreenCell(x: number, y: number, colorSwitch?: number): string | number {
+    return this.screenState.getScreenCell(x, y, colorSwitch)
+  }
+
+  setColorPattern(x: number, y: number, pattern: number): void {
+    this.screenState.setColorPattern(x, y, pattern)
+  }
+
+  setColorPalette(bgPalette: number, spritePalette: number): void {
+    this.screenState.setColorPalette(bgPalette, spritePalette)
+  }
+
+  setPaletteCombination(
+    target: 'B' | 'S',
+    combination: number,
+    c1: number,
+    c2: number,
+    c3: number,
+    c4: number,
+  ): void {
+    this.screenState.setPaletteCombination(target, combination, [c1, c2, c3, c4])
+  }
+
+  setBackdropColor(colorCode: number): void {
+    this.screenState.setBackdropColor(colorCode)
+  }
+
+  setCharacterGeneratorMode(mode: number): void {
+    this.screenState.setCharacterGeneratorMode(mode)
+  }
+
+  getCharacterGeneratorMode(): number {
+    return this.screenState.getCgenMode()
+  }
+
+  // === RESET ===
+
+  /**
+   * Reset all screen state and re-render.
+   * Called when starting a new program execution.
+   */
+  resetState(): void {
+    this.screenState.resetState()
+    this.renderer.render(this.screenState.getScreenBuffer())
+  }
+
+  // === PRIVATE HELPERS ===
+
+  /**
+   * Write a string to the screen buffer and trigger canvas rendering.
+   * Handles each character individually to properly manage cursor
+   * position (newlines, scrolling, line wrapping).
+   */
+  private writeToScreen(output: string): void {
+    for (const char of output) {
+      this.screenState.writeCharacter(char)
+    }
+    this.renderer.render(this.screenState.getScreenBuffer())
+  }
+}

--- a/src/core/devices/index.ts
+++ b/src/core/devices/index.ts
@@ -5,6 +5,7 @@
  */
 
 // Device implementations
+export * from './MainThreadDeviceAdapter'
 export * from './TestDeviceAdapter'
 export * from './WebWorkerDeviceAdapter'
 

--- a/test/devices/CanvasScreenRenderer.test.ts
+++ b/test/devices/CanvasScreenRenderer.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for CanvasScreenRenderer
+ *
+ * Verifies canvas-based screen rendering for the export runtime.
+ * Uses a mock canvas (plain object with spy methods) since tests
+ * run in Node environment without a real DOM.
+ */
+
+import { describe, expect, it, type MockedFunction, vi } from 'vitest'
+
+import { SCREEN_DIMENSIONS } from '@/core/constants'
+import type { CanvasSurface } from '@/core/devices/CanvasScreenRenderer'
+import { CanvasScreenRenderer } from '@/core/devices/CanvasScreenRenderer'
+import type { ScreenCell } from '@/core/types/execution-types'
+
+// ============================================================================
+// Mock Canvas Types & Factory
+// ============================================================================
+
+/** Mock context methods used by the renderer. */
+type MockCtx = {
+  fillRect: MockedFunction<(...args: unknown[]) => void>
+  fillText: MockedFunction<(...args: unknown[]) => void>
+  measureText: MockedFunction<(...args: unknown[]) => { width: number }>
+  fillStyle: string
+  font: string
+  textBaseline: string
+}
+
+/** Creates a mock canvas and context for testing. */
+function createMockContext(): { ctx: MockCtx; canvas: CanvasSurface } {
+  const ctx: MockCtx = {
+    fillRect: vi.fn<(...args: unknown[]) => void>(),
+    fillText: vi.fn<(...args: unknown[]) => void>(),
+    measureText: vi.fn<(...args: unknown[]) => { width: number }>(() => ({ width: 8 })),
+    fillStyle: '',
+    font: '',
+    textBaseline: '',
+  }
+
+  const canvas: CanvasSurface = {
+    width: SCREEN_DIMENSIONS.SPRITE.WIDTH,
+    height: SCREEN_DIMENSIONS.SPRITE.HEIGHT,
+    getContext: (_contextId: '2d') => ctx,
+  }
+
+  return { ctx, canvas }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Creates a 28x24 screen buffer filled with spaces. */
+function createEmptyBuffer(): ScreenCell[][] {
+  const buffer: ScreenCell[][] = []
+  for (let y = 0; y < SCREEN_DIMENSIONS.BACKGROUND.LINES; y++) {
+    const row: ScreenCell[] = []
+    for (let x = 0; x < SCREEN_DIMENSIONS.BACKGROUND.COLUMNS; x++) {
+      row.push({ character: ' ', colorPattern: 0, x, y })
+    }
+    buffer.push(row)
+  }
+  return buffer
+}
+
+/** Sets a character at a specific position in the buffer. */
+function setChar(
+  buffer: ScreenCell[][],
+  x: number,
+  y: number,
+  char: string,
+  colorPattern = 0,
+): void {
+  if (buffer[y]?.[x]) {
+    buffer[y][x].character = char
+    buffer[y][x].colorPattern = colorPattern
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('CanvasScreenRenderer', () => {
+  describe('constructor', () => {
+    it('stores a reference to the canvas element', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+      expect(renderer.getCanvas()).toEqual(canvas)
+    })
+  })
+
+  describe('clear', () => {
+    it('fills the entire canvas with black', () => {
+      const { ctx, canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+
+      renderer.clear()
+
+      expect(ctx.fillStyle).toEqual('#000000')
+      expect(ctx.fillRect).toHaveBeenCalledWith(
+        0,
+        0,
+        SCREEN_DIMENSIONS.SPRITE.WIDTH,
+        SCREEN_DIMENSIONS.SPRITE.HEIGHT,
+      )
+    })
+  })
+
+  describe('render', () => {
+    it('sets the font to an 8px monospace font', () => {
+      const { ctx, canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+      const buffer = createEmptyBuffer()
+
+      renderer.render(buffer)
+
+      expect(ctx.font).toEqual('8px monospace')
+    })
+
+    it('draws each character in the screen buffer using fillText', () => {
+      const { ctx, canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+      const buffer = createEmptyBuffer()
+      setChar(buffer, 0, 0, 'H')
+      setChar(buffer, 1, 0, 'I')
+
+      renderer.render(buffer)
+
+      // Each character is 8px wide; textBaseline is 'top' so y = row * 8
+      expect(ctx.fillText).toHaveBeenCalledWith('H', 0, 0)
+      expect(ctx.fillText).toHaveBeenCalledWith('I', 8, 0)
+    })
+
+    it('positions characters at correct pixel coordinates based on grid position', () => {
+      const { ctx, canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+      const buffer = createEmptyBuffer()
+      setChar(buffer, 5, 3, 'X')
+
+      renderer.render(buffer)
+
+      // Column 5 * 8px = 40px x, Row 3 * 8px = 24px y (textBaseline 'top')
+      expect(ctx.fillText).toHaveBeenCalledWith('X', 40, 24)
+    })
+
+    it('draws a backdrop rectangle for non-space characters', () => {
+      const { ctx, canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+      const buffer = createEmptyBuffer()
+      setChar(buffer, 2, 1, 'A')
+
+      renderer.render(buffer)
+
+      // Backdrop rectangle at position (2*8, 1*8) with size 8x8
+      expect(ctx.fillRect).toHaveBeenCalledWith(16, 8, 8, 8)
+    })
+
+    it('uses white color for the character text by default', () => {
+      const { ctx, canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+      const buffer = createEmptyBuffer()
+      setChar(buffer, 0, 0, 'T')
+
+      renderer.render(buffer)
+
+      // fillText for 'T' is called at (0, 0) with textBaseline 'top'
+      expect(ctx.fillText).toHaveBeenCalledWith('T', 0, 0)
+    })
+
+    it('renders all 28x24 cells including empty ones', () => {
+      const { ctx, canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+      const buffer = createEmptyBuffer()
+
+      renderer.render(buffer)
+
+      // 28 columns * 24 rows = 672 fillText calls (even for spaces)
+      const textCalls = ctx.fillText.mock.calls.filter(
+        (call: unknown[]) => typeof call[0] === 'string',
+      )
+      expect(textCalls).toHaveLength(672)
+    })
+
+    it('clears the canvas before rendering', () => {
+      const { ctx, canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+      const buffer = createEmptyBuffer()
+
+      renderer.render(buffer)
+
+      // The first fillRect should be the full-canvas clear (black fill)
+      expect(ctx.fillRect).toHaveBeenNthCalledWith(
+        1,
+        0,
+        0,
+        SCREEN_DIMENSIONS.SPRITE.WIDTH,
+        SCREEN_DIMENSIONS.SPRITE.HEIGHT,
+      )
+    })
+  })
+
+  describe('getCanvas', () => {
+    it('returns the canvas element passed to the constructor', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasScreenRenderer(canvas)
+      expect(renderer.getCanvas()).toEqual(canvas)
+    })
+  })
+})

--- a/test/devices/MainThreadDeviceAdapter.test.ts
+++ b/test/devices/MainThreadDeviceAdapter.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for MainThreadDeviceAdapter
+ *
+ * Verifies the main-thread device adapter used by the export runtime.
+ * Tests screen delegation, input handling, and stub methods for features
+ * not yet supported in the export (sound, sprites, input dialog).
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { SCREEN_DIMENSIONS } from '@/core/constants'
+import type { CanvasSurface } from '@/core/devices/CanvasScreenRenderer'
+import { MainThreadDeviceAdapter } from '@/core/devices/MainThreadDeviceAdapter'
+
+// ============================================================================
+// Mock Canvas Factory
+// ============================================================================
+
+function createMockContext() {
+  const ctx = {
+    fillRect: vi.fn<(...args: unknown[]) => void>(),
+    fillText: vi.fn<(...args: unknown[]) => void>(),
+    measureText: vi.fn<(...args: unknown[]) => { width: number }>(() => ({ width: 8 })),
+    fillStyle: '',
+    font: '',
+    textBaseline: '',
+  }
+
+  const canvas: CanvasSurface = {
+    width: SCREEN_DIMENSIONS.SPRITE.WIDTH,
+    height: SCREEN_DIMENSIONS.SPRITE.HEIGHT,
+    getContext: (_contextId: '2d') => ctx,
+  }
+
+  return { ctx, canvas }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('MainThreadDeviceAdapter', () => {
+  describe('constructor', () => {
+    it('creates an adapter with a canvas', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      expect(adapter).toBeDefined()
+    })
+  })
+
+  describe('joystick methods (stubbed)', () => {
+    it('getJoystickCount returns 0', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      expect(adapter.getJoystickCount()).toEqual(0)
+    })
+
+    it('getStickState returns 0', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      expect(adapter.getStickState(0)).toEqual(0)
+    })
+
+    it('setStickState does not throw', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      expect(() => adapter.setStickState(0, 1)).not.toThrow()
+    })
+
+    it('pushStrigState does not throw', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      expect(() => adapter.pushStrigState(0, 1)).not.toThrow()
+    })
+
+    it('consumeStrigState returns 0', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      expect(adapter.consumeStrigState(0)).toEqual(0)
+    })
+  })
+
+  describe('keyboard input (INKEY$)', () => {
+    it('getInkeyState returns empty string by default', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      expect(adapter.getInkeyState()).toEqual('')
+    })
+
+    it('setInkeyState stores the key character', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      adapter.setInkeyState('A')
+      expect(adapter.getInkeyState()).toEqual('A')
+    })
+
+    it('clearInkeyState clears the stored key', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      adapter.setInkeyState('A')
+      adapter.clearInkeyState()
+      expect(adapter.getInkeyState()).toEqual('')
+    })
+  })
+
+  describe('sprite methods (stubbed)', () => {
+    it('getSpritePosition returns null', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+      expect(adapter.getSpritePosition(0)).toBeNull()
+    })
+  })
+
+  describe('text output delegation', () => {
+    it('printOutput writes characters to screen buffer', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      adapter.printOutput('A')
+
+      // The character 'A' should be at position (0, 0) in the screen buffer
+      expect(adapter.getScreenCell(0, 0)).toEqual('A')
+    })
+
+    it('printOutput triggers canvas render', () => {
+      const { ctx, canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      adapter.printOutput('X')
+
+      // Canvas should have been rendered (fillText called for 'X')
+      expect(ctx.fillText).toHaveBeenCalledWith('X', 0, 0)
+    })
+
+    it('debugOutput delegates to same screen buffer', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      adapter.debugOutput('D')
+
+      expect(adapter.getScreenCell(0, 0)).toEqual('D')
+    })
+
+    it('errorOutput delegates to same screen buffer', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      adapter.errorOutput('E')
+
+      expect(adapter.getScreenCell(0, 0)).toEqual('E')
+    })
+
+    it('clearScreen resets screen buffer and clears canvas', () => {
+      const { ctx, canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      adapter.printOutput('A')
+      adapter.clearScreen()
+
+      // Screen buffer should be cleared (all spaces)
+      expect(adapter.getScreenCell(0, 0)).toEqual(' ')
+
+      // Canvas should be cleared
+      expect(ctx.fillRect).toHaveBeenCalledWith(
+        0,
+        0,
+        SCREEN_DIMENSIONS.SPRITE.WIDTH,
+        SCREEN_DIMENSIONS.SPRITE.HEIGHT,
+      )
+    })
+
+    it('setCursorPosition and getCursorPosition work', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      adapter.setCursorPosition(5, 10)
+      expect(adapter.getCursorPosition()).toEqual({ x: 5, y: 10 })
+    })
+
+    it('getScreenCell returns space for empty cell', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      expect(adapter.getScreenCell(0, 0)).toEqual(' ')
+    })
+
+    it('getScreenCell with colorSwitch returns 0 for empty cell', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      expect(adapter.getScreenCell(0, 0, 1)).toEqual(0)
+    })
+  })
+
+  describe('palette methods delegation', () => {
+    it('setColorPalette delegates to screen state', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      expect(() => adapter.setColorPalette(0, 1)).not.toThrow()
+    })
+
+    it('setBackdropColor delegates to screen state', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      expect(() => adapter.setBackdropColor(5)).not.toThrow()
+    })
+
+    it('setCharacterGeneratorMode delegates to screen state', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      expect(() => adapter.setCharacterGeneratorMode(1)).not.toThrow()
+    })
+
+    it('getCharacterGeneratorMode returns default value', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      expect(adapter.getCharacterGeneratorMode()).toEqual(2)
+    })
+
+    it('setColorPattern delegates to screen state', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      expect(() => adapter.setColorPattern(0, 0, 1)).not.toThrow()
+    })
+  })
+
+  describe('resetState', () => {
+    it('clears screen buffer and re-renders', () => {
+      const { canvas } = createMockContext()
+      const adapter = new MainThreadDeviceAdapter({ canvas })
+
+      adapter.printOutput('A')
+      adapter.resetState()
+
+      expect(adapter.getScreenCell(0, 0)).toEqual(' ')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #632 — Step 3 of 7 for #538 (export programs as standalone HTML files)

## Changes
- Added `CanvasScreenRenderer` — lightweight canvas-based screen renderer with `CanvasSurface`/`CanvasRenderContext` interfaces for testability without DOM dependency
- Added `MainThreadDeviceAdapter` — implements `BasicDeviceAdapter` for main-thread execution, delegates screen ops to `ScreenStateManager` + `CanvasScreenRenderer`, stubs joystick/sprites/sound for future steps
- Updated `src/core/devices/index.ts` barrel export

## Test plan
- [ ] 34 new tests pass (10 CanvasScreenRenderer + 24 MainThreadDeviceAdapter)
- [ ] 64 total device tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)