### PR TITLE
feat: resolve #636 - add Export as HTML button to ProgramToolbar + i18n keys

### DIFF
--- a/src/features/ide/components/ProgramToolbar.vue
+++ b/src/features/ide/components/ProgramToolbar.vue
@@ -6,6 +6,7 @@ import { useProgramStore } from '@/features/ide/composables/useProgramStore'
 import { ConfirmDialog, GameButton, GameIconButton } from '@/shared/components/ui'
 import GameIcon from '@/shared/components/ui/GameIcon.vue'
 
+import ExportHtmlDialog from './ExportHtmlDialog.vue'
 import ShareDialog from './ShareDialog.vue'
 
 const props = withDefaults(defineProps<{ isCompact?: boolean }>(), {
@@ -17,6 +18,9 @@ const programStore = useProgramStore(t('common.defaultProgramName'))
 
 // Share dialog state
 const showShareDialog = ref(false)
+
+// Export HTML dialog state
+const showExportHtmlDialog = ref(false)
 
 // Renaming state
 const editingName = ref(false)
@@ -230,6 +234,15 @@ onUnmounted(() => {
           data-testid="ide-share-button"
           @click="showShareDialog = true"
         />
+        <GameIconButton
+          type="default"
+          icon="mdi:file-code"
+          size="small"
+          :disabled="isFileOperationPending"
+          :title="t('ide.toolbar.exportHtml')"
+          data-testid="ide-export-html-button"
+          @click="showExportHtmlDialog = true"
+        />
       </template>
       <template v-else>
         <GameButton
@@ -271,6 +284,16 @@ onUnmounted(() => {
           @click="showShareDialog = true"
         >
           {{ t('ide.share.title') }}
+        </GameButton>
+        <GameButton
+          type="default"
+          icon="mdi:file-code"
+          size="small"
+          :disabled="isFileOperationPending"
+          data-testid="ide-export-html-button"
+          @click="showExportHtmlDialog = true"
+        >
+          {{ t('ide.toolbar.exportHtml') }}
         </GameButton>
       </template>
     </div>
@@ -328,6 +351,12 @@ onUnmounted(() => {
       :source="programStore.code"
       :bg="programStore.currentProgram?.value?.bg"
       @close="showShareDialog = false"
+    />
+
+    <!-- Export HTML dialog -->
+    <ExportHtmlDialog
+      :visible="showExportHtmlDialog"
+      @close="showExportHtmlDialog = false"
     />
   </div>
 </template>

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -4,6 +4,7 @@
     "new": "New",
     "import": "Import",
     "export": "Export",
+    "exportHtml": "Export as HTML",
     "discardConfirm": "Discard unsaved changes?",
     "programNamePlaceholder": "Program name",
     "unsavedChanges": "Unsaved changes",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -4,6 +4,7 @@
     "new": "新規",
     "import": "インポート",
     "export": "エクスポート",
+    "exportHtml": "HTMLとしてエクスポート",
     "discardConfirm": "未保存の変更を破棄しますか？",
     "programNamePlaceholder": "プログラム名",
     "unsavedChanges": "未保存の変更",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -4,6 +4,7 @@
     "new": "新建",
     "import": "导入",
     "export": "导出",
+    "exportHtml": "导出为 HTML",
     "discardConfirm": "是否放弃未保存的更改？",
     "programNamePlaceholder": "程序名称",
     "unsavedChanges": "未保存的更改",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -4,6 +4,7 @@
     "new": "新建",
     "import": "匯入",
     "export": "匯出",
+    "exportHtml": "匯出為 HTML",
     "discardConfirm": "是否放棄未儲存的變更？",
     "programNamePlaceholder": "程式名稱",
     "unsavedChanges": "未儲存的變更",

--- a/test/ide/ProgramToolbar.test.ts
+++ b/test/ide/ProgramToolbar.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { defineComponent, ref } from 'vue'
 
 import ProgramToolbar from '@/features/ide/components/ProgramToolbar.vue'
 
@@ -16,6 +16,7 @@ const mockT = createI18nMock({
   'ide.toolbar.new': 'New',
   'ide.toolbar.import': 'Import',
   'ide.toolbar.export': 'Export',
+  'ide.toolbar.exportHtml': 'Export as HTML',
   'ide.toolbar.discardConfirm': 'Discard unsaved changes?',
   'ide.toolbar.programNamePlaceholder': 'Program name',
   'ide.toolbar.unsavedChanges': 'Unsaved changes',
@@ -29,6 +30,7 @@ const mockT = createI18nMock({
   'ide.share.encoding': 'Generating share URL...',
   'ide.share.encodeFailed': 'Failed to generate share URL.',
   'ide.share.tooLarge': 'This program is too large to share.',
+  'ide.exportHtml.title': 'Export as HTML',
   'common.confirmDialog.confirm': 'OK',
   'common.confirmDialog.cancel': 'Cancel',
 })
@@ -61,6 +63,23 @@ vi.mock('@/shared/utils/programCodec', () => ({
     tooLarge: false,
   }),
 }))
+
+vi.mock('@/features/ide/composables/useHtmlExporter', () => ({
+  useHtmlExporter: () => ({
+    isExporting: ref(false),
+    exportError: ref(''),
+    exportHtml: vi.fn(),
+  }),
+}))
+
+// Stub Teleport so ExportHtmlDialog content renders inline
+const teleportStub = defineComponent({
+  name: 'Teleport',
+  props: ['to'],
+  render() {
+    return this.$slots.default?.()
+  },
+})
 
 describe('ProgramToolbar', () => {
   beforeEach(() => {
@@ -332,6 +351,86 @@ describe('ProgramToolbar', () => {
 
       // No error message should be displayed
       expect(wrapper.find('.error-message').exists()).toBe(false)
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('Export as HTML button', () => {
+    const mountOptions = {
+      props: { isCompact: false },
+      global: { stubs: { Teleport: teleportStub } },
+    }
+
+    it('renders the Export as HTML button with correct text', () => {
+      const wrapper = mount(ProgramToolbar, mountOptions)
+
+      const button = wrapper.find('[data-testid="ide-export-html-button"]')
+      expect(button.exists()).toBe(true)
+      expect(button.text()).toEqual('Export as HTML')
+
+      wrapper.unmount()
+    })
+
+    it('disables Export as HTML button during file operation', async () => {
+      let resolveOpen!: () => void
+      mockOpen.mockReturnValue(
+        new Promise<boolean>((resolve) => {
+          resolveOpen = () => resolve(true)
+        }),
+      )
+
+      isDirtyRef.value = false
+      const wrapper = mount(ProgramToolbar, mountOptions)
+
+      const openButton = wrapper.find('[data-testid="ide-open-button"]')
+      await openButton.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      const exportHtmlButton = wrapper.find('[data-testid="ide-export-html-button"]')
+      expect(exportHtmlButton.attributes('disabled')).toBeDefined()
+
+      resolveOpen()
+      await wrapper.vm.$nextTick()
+
+      wrapper.unmount()
+    })
+
+    it('opens ExportHtmlDialog when Export as HTML button is clicked', async () => {
+      const wrapper = mount(ProgramToolbar, mountOptions)
+
+      // Dialog should not be visible initially
+      expect(wrapper.find('.game-dialog-overlay').exists()).toBe(false)
+
+      // Click Export as HTML button
+      const button = wrapper.find('[data-testid="ide-export-html-button"]')
+      await button.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // ExportHtmlDialog should now be visible
+      expect(wrapper.find('.game-dialog-overlay').exists()).toBe(true)
+      expect(wrapper.find('.game-dialog-title').text()).toEqual('Export as HTML')
+
+      wrapper.unmount()
+    })
+
+    it('closes ExportHtmlDialog when close is emitted', async () => {
+      const wrapper = mount(ProgramToolbar, mountOptions)
+
+      // Open dialog
+      const button = wrapper.find('[data-testid="ide-export-html-button"]')
+      await button.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.game-dialog-overlay').exists()).toBe(true)
+
+      // Click cancel button inside dialog
+      const cancelBtn = wrapper.find('[data-testid="export-html-cancel-button"]')
+      await cancelBtn.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // Dialog should be dismissed
+      expect(wrapper.find('.game-dialog-overlay').exists()).toBe(false)
 
       wrapper.unmount()
     })


### PR DESCRIPTION
## Summary
- Fixes #636 — adds "Export as HTML" button to ProgramToolbar + i18n keys (Step 7 of 7 for #538)

## Changes
- **ProgramToolbar.vue** (+29 lines): Added "Export as HTML" button in both compact and non-compact layouts. Clicking opens `ExportHtmlDialog`. Button disabled during file operations.
- **i18n** (+1 key each): Added `ide.toolbar.exportHtml` to all 4 locale files (en, ja, zh-CN, zh-TW).
- **Tests** (+4 tests): Button renders with correct text, disables during file operation, opens dialog on click, closes dialog on cancel.

## Test plan
- [x] 16/16 ProgramToolbar tests pass (4 new, 12 existing)
- [x] Type-check passes
- [x] ESLint passes
- [ ] CI passes