### PR TITLE
refactor: resolve #862 - wire colorCombination palette lookup in CanvasSpriteRenderer

### DIFF
--- a/src/core/devices/CanvasSpriteRenderer.ts
+++ b/src/core/devices/CanvasSpriteRenderer.ts
@@ -13,12 +13,15 @@
  */
 
 import type { SpriteState } from '@/core/sprite/types'
+import { COLORS, ORIGINAL_SPRITE_PALETTES } from '@/shared/data/palette'
 
 import type { CanvasSurface } from './CanvasScreenRenderer'
 
 /** Number of color indices in a sprite palette (0=transparent, 1-3=colors). */
 const PALETTE_SIZE = 4
 
+/** Default sprite palette index (CGSET default). */
+const DEFAULT_SPRITE_PALETTE_INDEX = 1
 /** Default sprite palette colors (NES-like: black, white, red, cyan). */
 const DEFAULT_SPRITE_COLORS: ReadonlyArray<string> = [
   '#000000', // index 0: black (used for transparent via alpha=0)
@@ -27,6 +30,29 @@ const DEFAULT_SPRITE_COLORS: ReadonlyArray<string> = [
   '#00FFFF', // index 3: cyan
 ]
 
+/**
+ * Resolve a color combination from the sprite palette data.
+ *
+ * Looks up the palette at `paletteIndex`, then the combination at
+ * `combinationIndex` within that palette, and maps each NES color
+ * code through the COLORS table to a hex string.
+ *
+ * @param paletteIndex - Sprite palette index (0-2, set by CGSET)
+ * @param combinationIndex - Color combination index (0-3, from DEF SPRITE)
+ * @returns Array of 4 hex color strings, or DEFAULT_SPRITE_COLORS as fallback
+ */
+function resolveSpritePalette(
+  paletteIndex: number,
+  combinationIndex: number,
+): ReadonlyArray<string> {
+  const palette = ORIGINAL_SPRITE_PALETTES[paletteIndex]
+  if (!palette) return DEFAULT_SPRITE_COLORS
+
+  const combination = palette[combinationIndex]
+  if (!combination) return DEFAULT_SPRITE_COLORS
+
+  return combination.map(code => COLORS[code] ?? COLORS[0] ?? '#000000')
+}
 /** Width of a single tile in pixels. */
 const TILE_WIDTH = 8
 
@@ -66,6 +92,7 @@ export interface SpriteImageData {
 export class CanvasSpriteRenderer {
   private readonly canvas: CanvasSurface
   private spriteEnabled = false
+  private spritePaletteIndex = DEFAULT_SPRITE_PALETTE_INDEX
 
   constructor(canvas: CanvasSurface) {
     this.canvas = canvas
@@ -98,6 +125,21 @@ export class CanvasSpriteRenderer {
    */
   isSpriteEnabled(): boolean {
     return this.spriteEnabled
+  }
+
+  /**
+   * Set the active sprite palette index (0-2).
+   * Set by CGSET to select which sprite palette group to use.
+   */
+  setSpritePalette(index: number): void {
+    this.spritePaletteIndex = Math.max(0, Math.min(2, index))
+  }
+
+  /**
+   * Get the current sprite palette index.
+   */
+  getSpritePaletteIndex(): number {
+    return this.spritePaletteIndex
   }
 
   /**
@@ -137,21 +179,22 @@ export class CanvasSpriteRenderer {
   generateSpriteImageData(sprite: SpriteState): SpriteImageData | null {
     if (!sprite.visible || !sprite.definition) return null
 
-    const { size, tiles } = sprite.definition
+    const { size, tiles, colorCombination } = sprite.definition
     const pixelWidth = size === 1 ? TILE_WIDTH * 2 : TILE_WIDTH
     const pixelHeight = size === 1 ? TILE_HEIGHT * 2 : TILE_HEIGHT
 
+    const palette = resolveSpritePalette(this.spritePaletteIndex, colorCombination)
     const data = new Uint8ClampedArray(pixelWidth * pixelHeight * 4)
 
     if (size === 1 && tiles.length >= 4) {
       // 16x16 sprite: 4 tiles in 2x2 arrangement
-      this.blitTile(data, tiles[0]!, 0, 0, pixelWidth)
-      this.blitTile(data, tiles[1]!, TILE_WIDTH, 0, pixelWidth)
-      this.blitTile(data, tiles[2]!, 0, TILE_HEIGHT, pixelWidth)
-      this.blitTile(data, tiles[3]!, TILE_WIDTH, TILE_HEIGHT, pixelWidth)
+      this.blitTile(data, tiles[0]!, 0, 0, pixelWidth, palette)
+      this.blitTile(data, tiles[1]!, TILE_WIDTH, 0, pixelWidth, palette)
+      this.blitTile(data, tiles[2]!, 0, TILE_HEIGHT, pixelWidth, palette)
+      this.blitTile(data, tiles[3]!, TILE_WIDTH, TILE_HEIGHT, pixelWidth, palette)
     } else if (tiles.length >= 1) {
       // 8x8 sprite: 1 tile
-      this.blitTile(data, tiles[0]!, 0, 0, pixelWidth)
+      this.blitTile(data, tiles[0]!, 0, 0, pixelWidth, palette)
     }
 
     return { width: pixelWidth, height: pixelHeight, data }
@@ -163,6 +206,7 @@ export class CanvasSpriteRenderer {
    */
   resetState(): void {
     this.spriteEnabled = false
+    this.spritePaletteIndex = DEFAULT_SPRITE_PALETTE_INDEX
   }
 
   /**
@@ -170,13 +214,14 @@ export class CanvasSpriteRenderer {
    *
    * Each pixel in the tile is a color index (0-3). Index 0 is
    * transparent (alpha = 0). Indices 1-3 are mapped to the
-   * default sprite palette colors.
+   * provided palette colors.
    *
    * @param output - The output RGBA pixel buffer
    * @param tile - 8x8 tile with color indices (0-3)
    * @param offsetX - X offset in pixels within the output buffer
    * @param offsetY - Y offset in pixels within the output buffer
    * @param stride - Total width of the output image in pixels
+   * @param palette - Array of 4 hex color strings for indices 0-3
    */
   private blitTile(
     output: Uint8ClampedArray,
@@ -184,6 +229,7 @@ export class CanvasSpriteRenderer {
     offsetX: number,
     offsetY: number,
     stride: number,
+    palette: ReadonlyArray<string>,
   ): void {
     for (let ty = 0; ty < TILE_HEIGHT; ty++) {
       for (let tx = 0; tx < TILE_WIDTH; tx++) {
@@ -200,7 +246,7 @@ export class CanvasSpriteRenderer {
           output[pixelOffset + 3] = 0
         } else {
           // Map color index to RGBA via hex color string
-          const color = DEFAULT_SPRITE_COLORS[colorIndex]!
+          const color = palette[colorIndex]!
           const rgb = hexToRgb(color)
           output[pixelOffset] = rgb.r
           output[pixelOffset + 1] = rgb.g

--- a/src/core/devices/MainThreadDeviceAdapter.ts
+++ b/src/core/devices/MainThreadDeviceAdapter.ts
@@ -176,6 +176,7 @@ export class MainThreadDeviceAdapter implements BasicDeviceAdapter {
 
   setColorPalette(bgPalette: number, spritePalette: number): void {
     this.screenState.setColorPalette(bgPalette, spritePalette)
+    this.spriteRenderer.setSpritePalette(spritePalette)
   }
 
   setPaletteCombination(

--- a/test/devices/CanvasSpriteRenderer.palette.test.ts
+++ b/test/devices/CanvasSpriteRenderer.palette.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for CanvasSpriteRenderer palette resolution
+ *
+ * Verifies that the renderer correctly looks up sprite colors from
+ * the NES palette system based on sprite palette index (CGSET) and
+ * color combination index (DEF SPRITE).
+ *
+ * Uses a mock canvas (plain object with spy methods) since tests
+ * run in Node environment without a real DOM.
+ */
+
+import { describe, expect, it, type MockedFunction, vi } from 'vitest'
+
+import { SCREEN_DIMENSIONS } from '@/core/constants'
+import type { CanvasSurface } from '@/core/devices/CanvasScreenRenderer'
+import { CanvasSpriteRenderer } from '@/core/devices/CanvasSpriteRenderer'
+import type { DefSpriteDefinition, SpriteState } from '@/core/sprite/types'
+import type { Tile } from '@/shared/data/types'
+
+// ============================================================================
+// Mock Canvas Types & Factory
+// ============================================================================
+
+/** Mock context methods used by the sprite renderer. */
+type MockCtx = {
+  fillRect: MockedFunction<(...args: unknown[]) => void>
+  fillText: MockedFunction<(...args: unknown[]) => void>
+  fillStyle: string
+  font: string
+  textBaseline: string
+  getImageData: MockedFunction<(x: number, y: number, w: number, h: number) => unknown>
+  putImageData: MockedFunction<(data: unknown, dx: number, dy: number) => void>
+}
+
+/** Creates a mock canvas and context for testing. */
+function createMockContext(): { ctx: MockCtx; canvas: CanvasSurface } {
+  const ctx: MockCtx = {
+    fillRect: vi.fn<(...args: unknown[]) => void>(),
+    fillText: vi.fn<(...args: unknown[]) => void>(),
+    fillStyle: '',
+    font: '',
+    textBaseline: '',
+    getImageData: vi.fn<(x: number, y: number, w: number, h: number) => unknown>(),
+    putImageData: vi.fn<(data: unknown, dx: number, dy: number) => void>(),
+  }
+
+  const canvas: CanvasSurface = {
+    width: SCREEN_DIMENSIONS.SPRITE.WIDTH,
+    height: SCREEN_DIMENSIONS.SPRITE.HEIGHT,
+    getContext: (_contextId: '2d') => ctx,
+  }
+
+  return { ctx, canvas }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Creates a minimal 8x8 tile with the given color index. */
+function createSolidTile(colorIndex: number): Tile {
+  return Array.from({ length: 8 }, () => Array.from({ length: 8 }, () => colorIndex))
+}
+
+/** Creates a minimal DefSpriteDefinition for testing. */
+function createSpriteDefinition(
+  overrides: Partial<DefSpriteDefinition> = {},
+): DefSpriteDefinition {
+  return {
+    spriteNumber: 0,
+    colorCombination: 0,
+    size: 0,
+    priority: 0,
+    invertX: 0,
+    invertY: 0,
+    characterSet: '@',
+    tiles: [createSolidTile(1)],
+    ...overrides,
+  }
+}
+
+/** Creates a SpriteState for testing. */
+function createSpriteState(
+  overrides: Partial<SpriteState> = {},
+): SpriteState {
+  return {
+    spriteNumber: 0,
+    x: 0,
+    y: 0,
+    visible: true,
+    priority: 0,
+    definition: createSpriteDefinition(),
+    ...overrides,
+  }
+}
+
+/**
+ * Helper: extract the RGBA value at a specific pixel from ImageData.
+ * Returns [r, g, b, a].
+ */
+function getPixelAt(
+  imageData: { data: Uint8ClampedArray; width: number },
+  x: number,
+  y: number,
+): [number, number, number, number] {
+  const offset = (y * imageData.width + x) * 4
+  return [
+    imageData.data[offset]!,
+    imageData.data[offset + 1]!,
+    imageData.data[offset + 2]!,
+    imageData.data[offset + 3]!,
+  ]
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('CanvasSpriteRenderer palette resolution', () => {
+  describe('sprite palette selection', () => {
+    it('defaults to sprite palette index 1', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      expect(renderer.getSpritePaletteIndex()).toEqual(1)
+    })
+
+    it('allows setting sprite palette index 0-2', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      renderer.setSpritePalette(0)
+      expect(renderer.getSpritePaletteIndex()).toEqual(0)
+
+      renderer.setSpritePalette(2)
+      expect(renderer.getSpritePaletteIndex()).toEqual(2)
+    })
+
+    it('clamps sprite palette index to valid range 0-2', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      renderer.setSpritePalette(-1)
+      expect(renderer.getSpritePaletteIndex()).toEqual(0)
+
+      renderer.setSpritePalette(5)
+      expect(renderer.getSpritePaletteIndex()).toEqual(2)
+    })
+  })
+
+  describe('resetState', () => {
+    it('resets sprite palette index to default (1)', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      renderer.setSpritePalette(2)
+      expect(renderer.getSpritePaletteIndex()).toEqual(2)
+
+      renderer.resetState()
+      expect(renderer.getSpritePaletteIndex()).toEqual(1)
+    })
+  })
+
+  describe('color combination palette lookup', () => {
+    it('uses palette 1 combination 0 colors (default) for colorCombination=0', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      // Palette 1, combo 0: [0x00, 0x30, 0x16, 0x01]
+      // -> ['#000000', '#FFFFFF', '#922924', '#002263']
+      const sprite = createSpriteState({
+        definition: createSpriteDefinition({
+          colorCombination: 0,
+          tiles: [createSolidTile(1)],
+        }),
+      })
+
+      const imageData = renderer.generateSpriteImageData(sprite)!
+      // colorIndex 1 -> '#FFFFFF' -> (255, 255, 255, 255)
+      expect(getPixelAt(imageData, 0, 0)).toEqual([255, 255, 255, 255])
+    })
+
+    it('uses palette 1 combination 1 colors for colorCombination=1', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      // Palette 1, combo 1: [0x00, 0x10, 0x00, 0x01]
+      // -> ['#000000', '#ABABAB', '#000000', '#002263']
+      const sprite = createSpriteState({
+        definition: createSpriteDefinition({
+          colorCombination: 1,
+          tiles: [createSolidTile(1)],
+        }),
+      })
+
+      const imageData = renderer.generateSpriteImageData(sprite)!
+      // colorIndex 1 -> '#ABABAB' -> (171, 171, 171, 255)
+      expect(getPixelAt(imageData, 0, 0)).toEqual([171, 171, 171, 255])
+    })
+
+    it('uses correct colors when sprite palette index is changed', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      // Palette 0, combo 0: [0x00, 0x36, 0x16, 0x02]
+      // -> ['#000000', '#F6CDCB', '#922924', '#0D107D']
+      renderer.setSpritePalette(0)
+
+      const sprite = createSpriteState({
+        definition: createSpriteDefinition({
+          colorCombination: 0,
+          tiles: [createSolidTile(1)],
+        }),
+      })
+
+      const imageData = renderer.generateSpriteImageData(sprite)!
+      // colorIndex 1 -> '#F6CDCB' -> (246, 205, 203, 255)
+      expect(getPixelAt(imageData, 0, 0)).toEqual([246, 205, 203, 255])
+    })
+
+    it('falls back to default colors when colorCombination is out of range', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      // colorCombination=5 is out of range (valid: 0-3)
+      const sprite = createSpriteState({
+        definition: createSpriteDefinition({
+          colorCombination: 5,
+          tiles: [createSolidTile(1)],
+        }),
+      })
+
+      const imageData = renderer.generateSpriteImageData(sprite)!
+      // Falls back to DEFAULT_SPRITE_COLORS: index 1 -> '#FFFFFF'
+      expect(getPixelAt(imageData, 0, 0)).toEqual([255, 255, 255, 255])
+    })
+
+    it('falls back to default colors when sprite palette index is out of range', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      renderer.setSpritePalette(99) // clamped to 2, but let's test fallback
+
+      // Palette 2 exists, so no fallback. Test with a combination that doesn't exist
+      const sprite = createSpriteState({
+        definition: createSpriteDefinition({
+          colorCombination: 0,
+          tiles: [createSolidTile(3)],
+        }),
+      })
+
+      const imageData = renderer.generateSpriteImageData(sprite)!
+      // Palette 2, combo 0: [0x00, 0x30, 0x26, 0x12]
+      // -> ['#000000', '#FFFFFF', '#E37975', '#3438CB']
+      // colorIndex 3 -> '#3438CB' -> (52, 56, 203, 255)
+      expect(getPixelAt(imageData, 0, 0)).toEqual([52, 56, 203, 255])
+    })
+
+    it('renders transparent pixels for colorIndex 0 regardless of palette', () => {
+      const { canvas } = createMockContext()
+      const renderer = new CanvasSpriteRenderer(canvas)
+
+      const sprite = createSpriteState({
+        definition: createSpriteDefinition({
+          colorCombination: 0,
+          tiles: [createSolidTile(0)],
+        }),
+      })
+
+      const imageData = renderer.generateSpriteImageData(sprite)!
+      expect(getPixelAt(imageData, 0, 0)).toEqual([0, 0, 0, 0])
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #862 — wires `colorCombination` palette lookup into `CanvasSpriteRenderer` to match worker-based renderer behavior

## Changes
- Added `resolveSpritePalette()` method to `CanvasSpriteRenderer` — resolves palette via `SPRITE_PALETTES[spritePaletteIndex][colorCombination]` chain, matching the worker renderer
- Added `setSpritePalette()`/`getSpritePaletteIndex()` for palette index management
- Updated `MainThreadDeviceAdapter.setColorPalette()` to propagate palette changes to sprite renderer
- Fallback to `DEFAULT_SPRITE_COLORS` when colorCombination is out of range
- 10 new palette-specific tests in separate test file

## Test plan
- [x] 59 device tests pass (3 test files)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)