### PR TITLE
refactor: resolve #863 - extract shared sprite test helpers from CanvasSpriteRenderer and MainThreadDeviceAdapter tests

### DIFF
--- a/test/devices/CanvasSpriteRenderer.test.ts
+++ b/test/devices/CanvasSpriteRenderer.test.ts
@@ -11,9 +11,13 @@ import { describe, expect, it, type MockedFunction, vi } from 'vitest'
 import { SCREEN_DIMENSIONS } from '@/core/constants'
 import type { CanvasSurface } from '@/core/devices/CanvasScreenRenderer'
 import { CanvasSpriteRenderer } from '@/core/devices/CanvasSpriteRenderer'
-import type { DefSpriteDefinition, SpriteState } from '@/core/sprite/types'
 import type { Tile } from '@/shared/data/types'
 
+import {
+  createSolidTile,
+  createSpriteDefinition,
+  createSpriteState,
+} from '../helpers/spriteTestFixtures'
 // ============================================================================
 // Mock Canvas Types & Factory
 // ============================================================================
@@ -54,48 +58,11 @@ function createMockContext(): { ctx: MockCtx; canvas: CanvasSurface } {
 // Helpers
 // ============================================================================
 
-/** Creates a minimal 8x8 tile with the given color index. */
-function createSolidTile(colorIndex: number): Tile {
-  return Array.from({ length: 8 }, () => Array.from({ length: 8 }, () => colorIndex))
-}
-
 /** Creates a tile with a specific pattern (checkerboard of 0 and 1). */
 function createCheckerTile(): Tile {
   return Array.from({ length: 8 }, (_, y) =>
     Array.from({ length: 8 }, (_, x) => (x + y) % 2),
   )
-}
-
-/** Creates a minimal DefSpriteDefinition for testing. */
-function createSpriteDefinition(
-  overrides: Partial<DefSpriteDefinition> = {},
-): DefSpriteDefinition {
-  return {
-    spriteNumber: 0,
-    colorCombination: 0,
-    size: 0,
-    priority: 0,
-    invertX: 0,
-    invertY: 0,
-    characterSet: '@',
-    tiles: [createSolidTile(1)],
-    ...overrides,
-  }
-}
-
-/** Creates a SpriteState for testing. */
-function createSpriteState(
-  overrides: Partial<SpriteState> = {},
-): SpriteState {
-  return {
-    spriteNumber: 0,
-    x: 0,
-    y: 0,
-    visible: true,
-    priority: 0,
-    definition: createSpriteDefinition(),
-    ...overrides,
-  }
 }
 
 // ============================================================================

--- a/test/devices/MainThreadDeviceAdapter.test.ts
+++ b/test/devices/MainThreadDeviceAdapter.test.ts
@@ -11,8 +11,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { SCREEN_DIMENSIONS } from '@/core/constants'
 import type { CanvasSurface } from '@/core/devices/CanvasScreenRenderer'
 import { MainThreadDeviceAdapter } from '@/core/devices/MainThreadDeviceAdapter'
-import type { DefSpriteDefinition, SpriteState } from '@/core/sprite/types'
-import type { Tile } from '@/shared/data/types'
+
+import {
+  createSpriteDefinition,
+  createSpriteState,
+} from '../helpers/spriteTestFixtures'
 
 // ============================================================================
 // Mock Canvas Factory
@@ -36,47 +39,6 @@ function createMockContext() {
   }
 
   return { ctx, canvas }
-}
-
-// ============================================================================
-// Sprite Test Helpers
-// ============================================================================
-
-/** Creates a minimal 8x8 tile with the given color index. */
-function createSolidTile(colorIndex: number): Tile {
-  return Array.from({ length: 8 }, () => Array.from({ length: 8 }, () => colorIndex))
-}
-
-/** Creates a minimal DefSpriteDefinition for testing. */
-function createSpriteDefinition(
-  overrides: Partial<DefSpriteDefinition> = {},
-): DefSpriteDefinition {
-  return {
-    spriteNumber: 0,
-    colorCombination: 0,
-    size: 0,
-    priority: 0,
-    invertX: 0,
-    invertY: 0,
-    characterSet: '@',
-    tiles: [createSolidTile(1)],
-    ...overrides,
-  }
-}
-
-/** Creates a SpriteState for testing. */
-function createSpriteState(
-  overrides: Partial<SpriteState> = {},
-): SpriteState {
-  return {
-    spriteNumber: 0,
-    x: 0,
-    y: 0,
-    visible: true,
-    priority: 0,
-    definition: createSpriteDefinition(),
-    ...overrides,
-  }
 }
 
 // ============================================================================

--- a/test/helpers/spriteTestFixtures.ts
+++ b/test/helpers/spriteTestFixtures.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared test fixtures for sprite-related tests.
+ *
+ * Provides factory helpers for creating sprite tiles, definitions, and states
+ * used by both CanvasSpriteRenderer and MainThreadDeviceAdapter tests.
+ */
+
+import type { DefSpriteDefinition, SpriteState } from '@/core/sprite/types'
+import type { Tile } from '@/shared/data/types'
+
+/** Creates a minimal 8x8 tile with the given color index. */
+export function createSolidTile(colorIndex: number): Tile {
+  return Array.from({ length: 8 }, () => Array.from({ length: 8 }, () => colorIndex))
+}
+
+/** Creates a minimal DefSpriteDefinition for testing. */
+export function createSpriteDefinition(
+  overrides: Partial<DefSpriteDefinition> = {},
+): DefSpriteDefinition {
+  return {
+    spriteNumber: 0,
+    colorCombination: 0,
+    size: 0,
+    priority: 0,
+    invertX: 0,
+    invertY: 0,
+    characterSet: '@',
+    tiles: [createSolidTile(1)],
+    ...overrides,
+  }
+}
+
+/** Creates a SpriteState for testing. */
+export function createSpriteState(
+  overrides: Partial<SpriteState> = {},
+): SpriteState {
+  return {
+    spriteNumber: 0,
+    x: 0,
+    y: 0,
+    visible: true,
+    priority: 0,
+    definition: createSpriteDefinition(),
+    ...overrides,
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #863 — extracts duplicated test helpers to shared module

## Changes
- Created `test/helpers/spriteTestFixtures.ts` (46 lines) with shared `createSolidTile`, `createSpriteDefinition`, `createSpriteState` helpers
- Updated `CanvasSpriteRenderer.test.ts` (354→322 lines, -32) — removed local helpers, imports from shared module
- Updated `MainThreadDeviceAdapter.test.ts` (416→377 lines, -39) — removed local helpers and unused type imports, imports from shared module

## Test plan
- [x] 49 device tests pass (16 + 33)
- [x] Type-check clean
- [x] ESLint clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)