### PR TITLE
feat: resolve #878 - add success feedback to ExportHtmlDialog

### DIFF
--- a/src/features/ide/components/ExportHtmlDialog.vue
+++ b/src/features/ide/components/ExportHtmlDialog.vue
@@ -9,6 +9,7 @@
 import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { TIMING } from '@/core/constants'
 import { useHtmlExporter } from '@/features/ide/composables/useHtmlExporter'
 
 const props = defineProps<{
@@ -22,13 +23,16 @@ const emit = defineEmits<{
 const { t } = useI18n()
 
 // Composable
-const { isExporting, exportError, exportHtml } = useHtmlExporter()
+const { isExporting, exportError, exportSuccess, exportHtml } = useHtmlExporter()
 
 // Export options state
 const title = ref('')
 const theme = ref<'dark' | 'light'>('dark')
 const includeSound = ref(true)
 const includeSprites = ref(true)
+
+// Auto-close timer for success state
+let successTimer: ReturnType<typeof setTimeout> | null = null
 
 // Reset state when dialog opens
 watch(
@@ -41,6 +45,11 @@ watch(
     includeSound.value = true
     includeSprites.value = true
     exportError.value = ''
+    exportSuccess.value = false
+    if (successTimer !== null) {
+      clearTimeout(successTimer)
+      successTimer = null
+    }
   },
 )
 
@@ -69,6 +78,16 @@ async function handleExport(): Promise<void> {
     includeSound: includeSound.value,
     includeSprites: includeSprites.value,
   })
+
+  if (exportSuccess.value) {
+    if (successTimer !== null) {
+      clearTimeout(successTimer)
+    }
+    successTimer = setTimeout(() => {
+      handleClose()
+      successTimer = null
+    }, TIMING.COPIED_FEEDBACK_MS)
+  }
 }
 
 onMounted(() => {
@@ -77,6 +96,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener('keydown', handleKeydown)
+  if (successTimer !== null) {
+    clearTimeout(successTimer)
+  }
 })
 </script>
 
@@ -115,6 +137,15 @@ onUnmounted(() => {
           class="game-dialog-error"
         >
           {{ t('ide.exportHtml.exportFailed') }}
+        </div>
+
+        <!-- Success state -->
+        <div
+          v-else-if="exportSuccess"
+          data-testid="export-html-success"
+          class="game-dialog-success"
+        >
+          {{ t('ide.exportHtml.exportSuccess') }}
         </div>
 
         <!-- Form -->

--- a/src/features/ide/composables/useHtmlExporter.ts
+++ b/src/features/ide/composables/useHtmlExporter.ts
@@ -74,6 +74,7 @@ export function toExportFilename(title: string): string {
 export function useHtmlExporter() {
   const isExporting = ref(false)
   const exportError = ref('')
+  const exportSuccess = ref(false)
   const { locale } = useI18n()
   const programStore = useProgramStore()
 
@@ -87,12 +88,14 @@ export function useHtmlExporter() {
   async function exportHtml(options: HtmlExportOptions): Promise<void> {
     isExporting.value = true
     exportError.value = ''
+    exportSuccess.value = false
 
     try {
       const html = buildExportHtml(programStore.code, options, locale.value)
       const blob = new Blob([html], { type: HTML_MIME_TYPE })
       const filename = toExportFilename(options.title)
       triggerDownload(blob, filename)
+      exportSuccess.value = true
     } catch (err) {
       exportError.value = err instanceof Error ? err.message : String(err)
     } finally {
@@ -103,6 +106,7 @@ export function useHtmlExporter() {
   return {
     isExporting,
     exportError,
+    exportSuccess,
     exportHtml,
   }
 }

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -558,7 +558,8 @@
     "exportButton": "Export",
     "cancelButton": "Cancel",
     "exporting": "Exporting...",
-    "exportFailed": "Failed to export HTML file."
+    "exportFailed": "Failed to export HTML file.",
+    "exportSuccess": "Export complete! Your file has been downloaded."
   },
   "musicComposer": {
     "title": "Music Composer"

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -558,7 +558,8 @@
     "exportButton": "エクスポート",
     "cancelButton": "キャンセル",
     "exporting": "エクスポート中...",
-    "exportFailed": "HTMLファイルのエクスポートに失敗しました。"
+    "exportFailed": "HTMLファイルのエクスポートに失敗しました。",
+    "exportSuccess": "エクスポート完了！ファイルがダウンロードされました。"
   },
   "musicComposer": {
     "title": "ミュージックコンポーザー"

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -558,7 +558,8 @@
     "exportButton": "导出",
     "cancelButton": "取消",
     "exporting": "正在导出...",
-    "exportFailed": "导出 HTML 文件失败。"
+    "exportFailed": "导出 HTML 文件失败。",
+    "exportSuccess": "导出完成！文件已下载。"
   },
   "musicComposer": {
     "title": "音乐作曲器"

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -558,7 +558,8 @@
     "exportButton": "匯出",
     "cancelButton": "取消",
     "exporting": "正在匯出...",
-    "exportFailed": "匯出 HTML 檔案失敗。"
+    "exportFailed": "匯出 HTML 檔案失敗。",
+    "exportSuccess": "匯出完成！檔案已下載。"
   },
   "musicComposer": {
     "title": "音樂作曲器"

--- a/src/shared/styles/dialog.css
+++ b/src/shared/styles/dialog.css
@@ -58,6 +58,16 @@
   border-radius: 6px;
 }
 
+/* Success state message */
+.game-dialog-success {
+  padding: 0.75rem;
+  color: var(--semantic-solid-success);
+  font-size: 0.875rem;
+  background: var(--semantic-alpha-success-10);
+  border-radius: 6px;
+  text-align: center;
+}
+
 /* Action buttons row */
 .game-dialog-actions {
   display: flex;

--- a/test/ide/ExportHtmlDialog.test.ts
+++ b/test/ide/ExportHtmlDialog.test.ts
@@ -15,6 +15,7 @@ const mockT = createI18nMock({
   'ide.exportHtml.description': 'Export your program as a standalone HTML file that runs in any browser.',
   'ide.exportHtml.exporting': 'Exporting...',
   'ide.exportHtml.exportFailed': 'Failed to export HTML file.',
+  'ide.exportHtml.exportSuccess': 'Export complete! Your file has been downloaded.',
   'ide.exportHtml.titleLabel': 'Page Title',
   'ide.exportHtml.themeLabel': 'Theme',
   'ide.exportHtml.themeDark': 'Dark',
@@ -32,11 +33,13 @@ vi.mock('vue-i18n', () => ({
 const mockExportHtml = vi.fn()
 const mockIsExporting = ref(false)
 const mockExportError = ref('')
+const mockExportSuccess = ref(false)
 
 vi.mock('@/features/ide/composables/useHtmlExporter', () => ({
   useHtmlExporter: () => ({
     isExporting: mockIsExporting,
     exportError: mockExportError,
+    exportSuccess: mockExportSuccess,
     exportHtml: mockExportHtml,
   }),
 }))
@@ -76,11 +79,14 @@ function mountDialog(props: {
 describe('ExportHtmlDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.useFakeTimers()
     mockIsExporting.value = false
     mockExportError.value = ''
+    mockExportSuccess.value = false
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -264,6 +270,56 @@ describe('ExportHtmlDialog', () => {
 
     expect(wrapper.find('[data-testid="export-html-error"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="export-html-error"]').text()).toEqual('Failed to export HTML file.')
+    wrapper.unmount()
+  })
+
+  // -- Success state ---------------------------------------------------------
+  it('shows success state when export succeeds', async () => {
+    mockExportSuccess.value = true
+
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="export-html-success"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="export-html-success"]').text()).toEqual('Export complete! Your file has been downloaded.')
+    wrapper.unmount()
+  })
+
+  it('auto-closes dialog after success feedback timer', async () => {
+    mockExportHtml.mockImplementation(async () => {
+      mockExportSuccess.value = true
+    })
+
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    await wrapper.find('[data-testid="export-html-export-button"]').trigger('click')
+    await nextTick()
+
+    // Success state should be visible
+    expect(wrapper.find('[data-testid="export-html-success"]').exists()).toBe(true)
+
+    // Advance past the COPIED_FEEDBACK_MS timer (2000ms)
+    vi.advanceTimersByTime(2000)
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('does not auto-close when export fails', async () => {
+    mockExportHtml.mockResolvedValue(undefined)
+
+    const wrapper = mountDialog({ visible: true })
+    await nextTick()
+
+    await wrapper.find('[data-testid="export-html-export-button"]').trigger('click')
+    await nextTick()
+
+    vi.advanceTimersByTime(2000)
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toBeUndefined()
     wrapper.unmount()
   })
 

--- a/test/ide/ProgramToolbar.test.ts
+++ b/test/ide/ProgramToolbar.test.ts
@@ -68,6 +68,7 @@ vi.mock('@/features/ide/composables/useHtmlExporter', () => ({
   useHtmlExporter: () => ({
     isExporting: ref(false),
     exportError: ref(''),
+    exportSuccess: ref(false),
     exportHtml: vi.fn(),
   }),
 }))

--- a/test/ide/useHtmlExporter.test.ts
+++ b/test/ide/useHtmlExporter.test.ts
@@ -250,6 +250,11 @@ describe('useHtmlExporter', () => {
       expect(exportError.value).toEqual('')
     })
 
+    it('exportSuccess is false initially', () => {
+      const { exportSuccess } = mountComposable()
+      expect(exportSuccess.value).toEqual(false)
+    })
+
     it('isExporting returns to false after successful export', async () => {
       const { isExporting, exportHtml } = mountComposable()
 
@@ -263,8 +268,53 @@ describe('useHtmlExporter', () => {
       expect(isExporting.value).toEqual(false)
     })
 
+    it('sets exportSuccess to true after successful export', async () => {
+      const { exportSuccess, exportHtml } = mountComposable()
+
+      await exportHtml({
+        title: 'Test',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      expect(exportSuccess.value).toEqual(true)
+    })
+
+    it('keeps exportSuccess false when a subsequent export fails', async () => {
+      const { exportSuccess, exportHtml } = mountComposable()
+
+      // First export succeeds
+      await exportHtml({
+        title: 'Test',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+      expect(exportSuccess.value).toEqual(true)
+
+      // Second export fails — success should be reset and stay false
+      const savedBlob = globalThis.Blob
+      class FailingBlob {
+        constructor() {
+          throw new Error('Second export failed')
+        }
+      }
+      globalThis.Blob = FailingBlob as typeof Blob
+
+      await exportHtml({
+        title: 'Test2',
+        theme: 'dark',
+        includeSound: false,
+        includeSprites: false,
+      })
+
+      expect(exportSuccess.value).toEqual(false)
+      globalThis.Blob = savedBlob
+    })
+
     it('sets exportError when Blob creation fails', async () => {
-      const { exportHtml, exportError } = mountComposable()
+      const { exportHtml, exportError, exportSuccess } = mountComposable()
 
       // Mock Blob constructor to throw — must use class syntax per vitest docs
       const savedBlob = globalThis.Blob
@@ -283,6 +333,7 @@ describe('useHtmlExporter', () => {
       })
 
       expect(exportError.value).toEqual('Blob creation failed')
+      expect(exportSuccess.value).toEqual(false)
       globalThis.Blob = savedBlob
     })
 


### PR DESCRIPTION
## Summary
- Adds `exportSuccess` ref in `useHtmlExporter.ts`, set to `true` after successful download
- Adds success template block in `ExportHtmlDialog.vue` with auto-close after 2 seconds (consistent with ShareDialog's "Copied!" pattern)
- Adds `.game-dialog-success` CSS style (green variant of `.game-dialog-error`)
- Adds `exportSuccess` i18n key across all 4 locales (en, ja, zh-CN, zh-TW)

## Test plan
- [x] useHtmlExporter.test.ts: 23/23 pass (4 new tests)
- [x] ExportHtmlDialog.test.ts: 20/20 pass (3 new tests)
- [x] Type-check: clean
- [x] ESLint: clean
- [ ] CI: pending

Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)