### PR TITLE
refactor: resolve #879 - split IdePage.vue and Screen.vue approaching 500-line limit

### DIFF
--- a/src/features/ide/IdePage.vue
+++ b/src/features/ide/IdePage.vue
@@ -1,20 +1,8 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, shallowRef, useTemplateRef } from 'vue'
+import { computed, onMounted, shallowRef, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
-import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
-import { SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
-import { PALETTE_DEFAULTS } from '@/core/constants'
-import type { KeyboardBufferView } from '@/core/devices'
-import {
-  createSharedKeyboardBuffer,
-  createViewsFromKeyboardBuffer,
-} from '@/core/devices'
-import type { SpriteState } from '@/core/sprite/types'
-import type { HighlighterInfo, ParserInfo, ScreenCell } from '@/core/types/execution-types'
-import type { BasicVariable } from '@/core/types/state-types'
-import type { RequestInputMessage } from '@/core/types/worker-messages'
 import { GameLayout } from '@/shared/components/ui'
 import { useContainerWidth } from '@/shared/composables/useContainerWidth'
 
@@ -27,16 +15,9 @@ import InputModal from './components/InputModal.vue'
 import SampleSelector from './components/SampleSelector.vue'
 import TutorialPanel from './components/TutorialPanel.vue'
 import type { CommandPaletteCommand } from './composables/commandPalette'
-import {
-  isEditableTarget,
-  matchesAnyShortcut,
-} from './composables/commandPalette'
-import { useBasicIde as useBasicIdeEnhanced } from './composables/useBasicIdeEnhanced'
-import type { InputMode } from './composables/useBasicIdeState'
-import { useDevApi } from './composables/useDevApi'
 import { useIdeCommandPalette } from './composables/useIdeCommandPalette'
-import { provideScreenContext } from './composables/useScreenContext'
-import { useShareRoute } from './composables/useShareRoute'
+import { useIdeGlobalHotkeys } from './composables/useIdeGlobalHotkeys'
+import { useIdePageState } from './composables/useIdePageState'
 import { useTutorialPanel } from './composables/useTutorialPanel'
 
 /**
@@ -48,118 +29,47 @@ defineOptions({
 })
 
 const { t } = useI18n()
-
-const isE2ELite =
-  typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('e2e') === 'lite'
-
 const route = useRoute()
 
-const basicIde = isE2ELite ? null : useBasicIdeEnhanced()
-
-// Share route handling
-const code = basicIde?.code ?? ref('')
-const { shareError, handleShareRoute } = useShareRoute({ code })
-
-const isRunning = basicIde?.isRunning ?? ref(false)
-const output = basicIde?.output ?? ref<string[]>([])
-const errors =
-  basicIde?.errors ??
-  ref<Array<{ line: number; message: string; type: string; stack?: string; sourceLine?: string }>>([])
-const variables = basicIde?.variables ?? ref<Record<string, BasicVariable>>({})
-const debugOutput = basicIde?.debugOutput ?? ref('')
-const debugMode = basicIde?.debugMode ?? ref(false)
-const screenBuffer = basicIde?.screenBuffer ?? ref<ScreenCell[][]>([])
-const cursorX = basicIde?.cursorX ?? ref(0)
-const cursorY = basicIde?.cursorY ?? ref(0)
-const bgPalette = basicIde?.bgPalette ?? ref(PALETTE_DEFAULTS.BG_PALETTE)
-const backdropColor = basicIde?.backdropColor ?? ref(PALETTE_DEFAULTS.BACKDROP_COLOR)
-const spritePalette = basicIde?.spritePalette ?? ref(PALETTE_DEFAULTS.SPRITE_PALETTE)
-const cgenMode = basicIde?.cgenMode ?? ref(PALETTE_DEFAULTS.CGEN_MODE)
-const spriteStates = basicIde?.spriteStates ?? ref<SpriteState[]>([])
-const spriteEnabled = basicIde?.spriteEnabled ?? ref(true)
-const movementPositionsFromBuffer =
-  basicIde?.movementPositionsFromBuffer ?? ref<Map<number, { x: number; y: number }>>(new Map())
-const frontSpriteNodes = basicIde?.frontSpriteNodes ?? ref<Map<number, unknown>>(new Map())
-const backSpriteNodes = basicIde?.backSpriteNodes ?? ref<Map<number, unknown>>(new Map())
-const inputMode = basicIde?.inputMode ?? ref<InputMode>('joystick')
-
-const runCode =
-  basicIde?.runCode ??
-  (async () => {
-    isRunning.value = true
-  })
-const stopCode =
-  basicIde?.stopCode ??
-  (() => {
-    isRunning.value = false
-  })
-const clearOutput =
-  basicIde?.clearOutput ??
-  (() => {
-    output.value = []
-    errors.value = []
-    variables.value = {}
-    debugOutput.value = ''
-  })
-const loadSampleCode = basicIde?.loadSampleCode ?? (() => false)
-const getParserCapabilities =
-  basicIde?.getParserCapabilities ??
-  (() => ({
-    name: 'E2E Lite Parser',
-    version: '0.0.0',
-    capabilities: [],
-    features: [],
-    supportedStatements: [],
-    supportedFunctions: [],
-    supportedOperators: [],
-  }))
-const getHighlighterCapabilities =
-  basicIde?.getHighlighterCapabilities ??
-  (() => ({
-    name: 'E2E Lite Highlighter',
-    version: '0.0.0',
-    features: [],
-  }))
-const toggleDebugMode =
-  basicIde?.toggleDebugMode ??
-  (() => {
-    debugMode.value = !debugMode.value
-  })
-const sendStrigEvent = basicIde?.sendStrigEvent ?? (() => {})
-const sharedDisplayBufferAccessor =
-  basicIde?.sharedDisplayBufferAccessor ?? ({} as SharedDisplayBufferAccessor)
-const sharedAnimationBuffer = basicIde?.sharedAnimationBuffer ?? ({} as SharedArrayBuffer)
-const sharedDisplayViews: SharedDisplayViews = basicIde?.sharedDisplayViews ?? {
-  buffer: {} as SharedArrayBuffer,
-  spriteView: {} as Float64Array,
-  charView: {} as Uint8Array,
-  patternView: {} as Uint8Array,
-  cursorView: {} as Uint8Array,
-  sequenceView: {} as Int32Array,
-  scalarsView: {} as Uint8Array,
-  animationSyncView: {} as Float64Array,
-}
-const sharedJoystickBuffer = basicIde?.sharedJoystickBuffer ?? ({} as SharedArrayBuffer)
-const sharedKeyboardBufferView: KeyboardBufferView =
-  basicIde?.sharedKeyboardBufferView ?? createViewsFromKeyboardBuffer(createSharedKeyboardBuffer())
-const setDecodedScreenState = basicIde?.setDecodedScreenState ?? (() => {})
-const registerCallbacks = basicIde?.registerCallbacks ?? {
-  registerScheduleRender: () => {},
-  registerInvalidateBackgroundBuffer: () => {},
-}
-const pendingInputRequest = basicIde?.pendingInputRequest ?? ref<RequestInputMessage['data'] | null>(null)
-const respondToInputRequest =
-  basicIde?.respondToInputRequest ?? ((_requestId: string, _values: string[], _cancelled: boolean) => {})
-
-// Expose DEV-only global API for headless test code injection
-useDevApi({
+// All IDE state (with E2E Lite fallbacks) + screen context provision
+const bottomAreaRef = useTemplateRef<{ updateMoveSlotsData: () => void }>('bottomAreaRef')
+const {
   code,
+  isRunning,
+  output,
+  errors,
+  variables,
+  debugOutput,
+  debugMode,
+  screenBuffer,
+  cursorX,
+  cursorY,
+  bgPalette,
+  backdropColor,
+  spritePalette,
+  cgenMode,
+  spriteStates,
+  spriteEnabled,
+  inputMode,
   runCode,
   stopCode,
+  clearOutput,
+  loadSampleCode,
+  getParserCapabilities,
+  getHighlighterCapabilities,
+  toggleDebugMode,
+  sendStrigEvent,
   pendingInputRequest,
   respondToInputRequest,
-  screenBuffer,
-})
+  sharedDisplayBufferAccessor,
+  sharedJoystickBuffer,
+  sharedKeyboardBufferView,
+  isE2ELite,
+  parserInfo,
+  highlighterInfo,
+  shareError,
+  handleShareRoute,
+} = useIdePageState(bottomAreaRef)
 
 // UI state
 const sampleSelectorOpen = shallowRef(false)
@@ -175,34 +85,40 @@ const tutorialPanel = useTutorialPanel()
 const editorPanelRef = useTemplateRef<HTMLDivElement>('editorPanelRef')
 const isToolbarCompact = useContainerWidth(editorPanelRef, 900)
 
-// IdeBottomArea ref for animation loop to call updateMoveSlotsData
-const bottomAreaRef = useTemplateRef<{ updateMoveSlotsData: () => void }>('bottomAreaRef')
-
-// Provide screen context so ScreenTab/Screen can inject instead of prop drilling
-if (!isE2ELite && sharedDisplayViews && sharedDisplayBufferAccessor && sharedAnimationBuffer && sharedJoystickBuffer) {
-  provideScreenContext({
-    screenBuffer,
-    cursorX,
-    cursorY,
-    bgPalette,
-    backdropColor,
-    spritePalette,
-    cgenMode,
-    spriteStates,
-    spriteEnabled,
-    movementPositionsFromBuffer,
-    externalFrontSpriteNodes: frontSpriteNodes,
-    externalBackSpriteNodes: backSpriteNodes,
-    sharedDisplayViews: ref(sharedDisplayViews),
-    sharedDisplayBufferAccessor,
-    sharedAnimationBuffer: ref(sharedAnimationBuffer),
-    sharedJoystickBuffer: ref(sharedJoystickBuffer),
-    setDecodedScreenState,
-    registerCallbacks,
-    // Callback for animation loop to update inspector MOVE tab data
-    updateInspectorMoveSlots: () => bottomAreaRef.value?.updateMoveSlotsData(),
-  })
+// Toggle input mode between joystick and keyboard
+function toggleInputMode() {
+  inputMode.value = inputMode.value === 'joystick' ? 'keyboard' : 'joystick'
 }
+
+// Command palette commands
+const { commands: commandPaletteCommands } = useIdeCommandPalette({
+  isRunning,
+  runCode,
+  stopCode,
+  clearOutput,
+  toggleDebugMode,
+  toggleInputMode,
+  sampleSelectorOpen,
+  logLevelPanelOpen,
+  editorView,
+})
+
+function openCommandPalette() {
+  commandPaletteOpen.value = true
+}
+
+function closeCommandPalette() {
+  commandPaletteOpen.value = false
+}
+
+async function handleExecuteCommandFromPalette(command: CommandPaletteCommand) {
+  closeCommandPalette()
+  await command.execute()
+}
+
+// Computed properties for backward compatibility
+const canRun = computed(() => !isRunning.value)
+const canStop = isRunning
 
 // Input modal response handler
 function handleInputResponse(
@@ -224,50 +140,14 @@ function handleLoadSample(sampleType: string) {
   }
 }
 
-function openCommandPalette() {
-  commandPaletteOpen.value = true
+function dismissShareError() {
+  shareError.value = ''
 }
-
-function closeCommandPalette() {
-  commandPaletteOpen.value = false
-}
-
-async function restartCode() {
-  stopCode()
-  await runCode()
-}
-
-// Command palette commands
-const { commands: commandPaletteCommands } = useIdeCommandPalette({
-  isRunning,
-  runCode,
-  stopCode,
-  clearOutput,
-  toggleDebugMode,
-  toggleInputMode,
-  sampleSelectorOpen,
-  logLevelPanelOpen,
-  editorView,
-})
-
-async function handleExecuteCommandFromPalette(command: CommandPaletteCommand) {
-  closeCommandPalette()
-  await command.execute()
-}
-
-// Computed properties for backward compatibility
-const canRun = computed(() => !isRunning.value)
-const canStop = isRunning
-
-// Parser capabilities for display
-const parserInfo = shallowRef<ParserInfo | null>(null)
-const highlighterInfo = shallowRef<HighlighterInfo | null>(null)
 
 // Initialize parser info and handle share route
 onMounted(() => {
   parserInfo.value = getParserCapabilities()
   highlighterInfo.value = getHighlighterCapabilities()
-  window.addEventListener('keydown', handleGlobalKeydown)
 
   // If we arrived via a share link, decode and load the program
   if (route.name === 'Share') {
@@ -275,49 +155,14 @@ onMounted(() => {
   }
 })
 
-onUnmounted(() => {
-  window.removeEventListener('keydown', handleGlobalKeydown)
+// Register global keyboard shortcuts (command palette, run/stop/restart, F9)
+useIdeGlobalHotkeys({
+  commandPaletteOpen,
+  inputMode,
+  runCode,
+  stopCode,
+  openCommandPalette,
 })
-
-// Global hotkey handler
-function handleGlobalKeydown(e: KeyboardEvent) {
-  if (matchesAnyShortcut(e, ['Ctrl+Shift+P', 'Meta+Shift+P'])) {
-    e.preventDefault()
-    openCommandPalette()
-    return
-  }
-
-  if (commandPaletteOpen.value || isEditableTarget(e.target)) return
-
-  if (matchesAnyShortcut(e, ['Ctrl+Enter', 'Meta+Enter'])) {
-    e.preventDefault()
-    void runCode()
-    return
-  }
-
-  if (matchesAnyShortcut(e, ['Ctrl+Shift+Enter', 'Meta+Shift+Enter'])) {
-    e.preventDefault()
-    stopCode()
-    return
-  }
-
-  if (matchesAnyShortcut(e, ['Ctrl+Shift+R', 'Meta+Shift+R'])) {
-    e.preventDefault()
-    void restartCode()
-    return
-  }
-
-  // F9: Toggle input mode (joystick/keyboard)
-  if (e.key === 'F9') {
-    e.preventDefault()
-    toggleInputMode()
-  }
-}
-
-// Toggle input mode between joystick and keyboard
-function toggleInputMode() {
-  inputMode.value = inputMode.value === 'joystick' ? 'keyboard' : 'joystick'
-}
 </script>
 
 <template>
@@ -398,7 +243,7 @@ function toggleInputMode() {
           <span class="share-error-text">{{ t('ide.share.loadFailed') }}: {{ shareError }}</span>
           <button
             class="share-error-dismiss"
-            @click="shareError = ''"
+            @click="dismissShareError"
           >
             &times;
           </button>

--- a/src/features/ide/components/Screen.vue
+++ b/src/features/ide/components/Screen.vue
@@ -1,25 +1,18 @@
 <script setup lang="ts">
-import Konva from 'konva'
-import { computed, onDeactivated, onUnmounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 
-import type { ScreenCell } from '@/core/types/execution-types'
-import { useAnimationWorker } from '@/features/ide/composables/useAnimationWorker'
-import { preInitializeBackgroundTiles, renderBackgroundToCanvas, renderBackgroundToCanvasDirty } from '@/features/ide/composables/useCanvasBackgroundRenderer'
-import { initializeKonvaLayers, type KonvaScreenLayers, renderAllScreenLayers } from '@/features/ide/composables/useKonvaScreenRenderer'
-import { useScreenAnimationLoopRenderOnly } from '@/features/ide/composables/useScreenAnimationLoopRenderOnly'
 import { useScreenContext } from '@/features/ide/composables/useScreenContext'
 import { useScreenDebug } from '@/features/ide/composables/useScreenDebug'
 import { useScreenFilter } from '@/features/ide/composables/useScreenFilter'
-import { useScreenZoom } from '@/features/ide/composables/useScreenZoom'
+import { useScreenRenderPipeline } from '@/features/ide/composables/useScreenRenderPipeline'
 import { COLORS } from '@/shared/data/palette'
-import { logScreen } from '@/shared/logger'
 import type { VueKonvaStageInstance } from '@/types/vue-konva'
 
 import DebugGridOverlay from './DebugGridOverlay.vue'
 
 /**
  * Screen - CRT-style display for F-BASIC: backdrop, character grid, sprites.
- * Reads state from useScreenContext; runs Konva render loop and animation loop.
+ * Reads state from useScreenContext; delegates rendering to useScreenRenderPipeline.
  */
 defineOptions({
   name: 'Screen',
@@ -28,25 +21,14 @@ defineOptions({
 // Screen data from context (provided by IdePage); no props
 const ctx = useScreenContext()
 
-/** Deep copy of screen buffer for dirty diff (last rendered state) */
-function deepCopyBuffer(buf: ScreenCell[][]): ScreenCell[][] {
-  return buf.map(row => row.map(c => ({ ...c })))
-}
-
-// Konva Stage reference
-const stageRef = useTemplateRef<VueKonvaStageInstance>('stageRef')
-
-// Use bgPalette from context
-const paletteCode = computed(() => ctx.bgPalette.value ?? 1)
-
 // Computed backdrop color hex
 const backdropColorHex = computed(() => {
   const colorCode = ctx.backdropColor.value ?? 0
   return COLORS[colorCode] ?? COLORS[0] ?? '#000000'
 })
 
-// Use shared zoom state composable
-const { zoomLevel } = useScreenZoom()
+// Use bgPalette from context
+const paletteCode = computed(() => ctx.bgPalette.value ?? 1)
 
 // Use debug settings composable
 const { showGrid } = useScreenDebug()
@@ -54,390 +36,15 @@ const { showGrid } = useScreenDebug()
 // Use screen filter composable for CRT scanline toggle
 const { filterEnabled } = useScreenFilter()
 
-// Base screen dimensions (full backdrop/sprite screen: 256×240)
-const BASE_WIDTH = 256
-const BASE_HEIGHT = 240
+// Konva Stage reference
+const stageRef = useTemplateRef<VueKonvaStageInstance>('stageRef')
 
-// Offscreen Canvas2D for background rendering (much faster than Konva for text)
-// Rendered to Konva.Image to participate in layer stacking
-const backgroundCanvas = document.createElement('canvas')
-backgroundCanvas.width = BASE_WIDTH
-backgroundCanvas.height = BASE_HEIGHT
-
-// Computed stage display dimensions based on zoom (for CSS scaling)
-const stageDisplayWidth = computed(() => BASE_WIDTH * zoomLevel.value)
-const stageDisplayHeight = computed(() => BASE_HEIGHT * zoomLevel.value)
-
-// Konva layers (background populated from offscreen Canvas2D for performance)
-// Use shallowRef since the layers object is replaced, not mutated
-const layers = shallowRef<KonvaScreenLayers>({
-  backdropLayer: null,
-  spriteBackLayer: null,
-  backgroundLayer: null, // Populated with Konva.Image from offscreen Canvas2D
-  spriteFrontLayer: null,
-})
-
-// Sprite node maps for animated sprite updates
-// Use shallowRef since the Map objects are replaced, not mutated
-const frontSpriteNodes = shallowRef<Map<number, Konva.Image>>(new Map())
-const backSpriteNodes = shallowRef<Map<number, Konva.Image>>(new Map())
-
-// Last rendered buffer for dirty diff (Canvas2D rendering)
-// Use shallowRef since the buffer array is replaced, not mutated
-const lastBackgroundBufferRef = shallowRef<ScreenCell[][] | null>(null)
-
-// Last backdrop color used for canvas rendering (to detect backdrop changes for dirty render)
-const lastBackdropColorRef = ref<number | null>(null)
-
-// Shared buffer path: last sequence and last decoded buffer (so we only decode when sequence changes)
-// Use shallowRef since the buffer array is replaced, not mutated
-const lastSequenceRef = ref(-1)
-const lastDecodedBufferRef = shallowRef<ScreenCell[][] | null>(null)
-
-// Render reason: bufferOnly = only screenBuffer changed (PRINT); full = sprite/palette/backdrop/etc
-type RenderReason = 'full' | 'bufferOnly'
-const pendingRenderReasonRef = ref<RenderReason>('full')
-
-// When animation is active: static render is deferred to end of frame (animation first)
-const pendingStaticRenderRef = ref(false)
-
-// Track if a render is in progress to prevent overlapping renders
-let renderInProgress = false
-
-/**
- * Initialize Konva Stage and layers
- */
-async function initializeKonva(): Promise<void> {
-  if (!stageRef.value) return
-
-  // Get the Konva stage node from vue-konva ref
-  const stageNode = stageRef.value?.getNode() ?? stageRef.value?.getStage?.() ?? null
-  if (!stageNode) {
-    logScreen.error('Failed to get Konva stage node')
-    return
-  }
-
-  // Pre-initialize background tile images in the background (non-blocking)
-  // This ensures all tile images are ready before rendering
-  // Start immediately but don't wait - images will be created on-demand if not ready
-  void preInitializeBackgroundTiles().catch(err => {
-    logScreen.warn('Background tile pre-initialization failed:', err)
-  })
-
-  // Initialize layers (backdrop is managed by vue-konva template, so we don't need to access it)
-  layers.value = initializeKonvaLayers(stageNode)
-  // Backdrop layer is managed by template, so we leave it as null
-  layers.value.backdropLayer = null
-
-  // Initial render
-  await scheduleRender()
-}
-
-/**
- * Render all screen layers using Konva
- */
-async function render(): Promise<void> {
-  if (!stageRef.value || renderInProgress) return
-
-  renderInProgress = true
-  try {
-    // Shared buffer path: read sequence; if changed (or first run), decode and update parent refs
-    const accessor = ctx.sharedDisplayBufferAccessor
-    let bufferToRender: ScreenCell[][] = ctx.screenBuffer.value ?? []
-    if (accessor) {
-      const seq = accessor.readSequence()
-      if (seq !== lastSequenceRef.value || lastDecodedBufferRef.value === null) {
-        const decoded = accessor.readScreenState()
-        ctx.setDecodedScreenState(decoded)
-        lastSequenceRef.value = seq
-        lastDecodedBufferRef.value = decoded.buffer
-      }
-      bufferToRender = lastDecodedBufferRef.value ?? (ctx.screenBuffer.value ?? [])
-    }
-
-    // Render background using Canvas2D to offscreen canvas (much faster than Konva for text grid)
-    const lastBuffer = lastBackgroundBufferRef.value
-    const currentBackdropColor = ctx.backdropColor.value ?? 0
-    if (lastBuffer && pendingRenderReasonRef.value === 'bufferOnly') {
-      // Dirty render: only changed cells (falls back to full if backdrop changed)
-      renderBackgroundToCanvasDirty(
-        backgroundCanvas,
-        bufferToRender,
-        lastBuffer,
-        paletteCode.value,
-        currentBackdropColor,
-        lastBackdropColorRef.value
-      )
-    } else {
-      // Full render
-      renderBackgroundToCanvas(backgroundCanvas, bufferToRender, paletteCode.value, currentBackdropColor)
-    }
-    lastBackdropColorRef.value = currentBackdropColor
-
-    // Create/update Konva.Image from Canvas2D content to participate in layer stacking
-    if (layers.value.backgroundLayer) {
-      // Clear existing background
-      layers.value.backgroundLayer.destroyChildren()
-
-      // Create Konva.Image from offscreen canvas
-      const backgroundImage = new Konva.Image({
-        x: 0,
-        y: 0,
-        image: backgroundCanvas,
-        listening: false, // Don't need events on background
-      })
-
-      layers.value.backgroundLayer.add(backgroundImage)
-      layers.value.backgroundLayer.batchDraw()
-    }
-
-    // Render sprites using Konva
-    const layersToRender: KonvaScreenLayers = {
-      backdropLayer: null, // Backdrop is managed by vue-konva template
-      spriteBackLayer: layers.value.spriteBackLayer as Konva.Layer | null,
-      backgroundLayer: layers.value.backgroundLayer as Konva.Layer | null, // Now populated from Canvas2D
-      spriteFrontLayer: layers.value.spriteFrontLayer as Konva.Layer | null,
-    }
-
-    // Read movement states from shared buffer (DEF MOVE definitions are stored there)
-    // This is the source of truth for which sprites should be rendered
-    const movementsFromBuffer = ctx.sharedDisplayBufferAccessor?.readAllMovementStates() ?? []
-    const movementCount = movementsFromBuffer.length
-    const spriteNodeCount = frontSpriteNodes.value.size + backSpriteNodes.value.size
-    const needSpriteBuild =
-      movementCount > 0 && (spriteNodeCount === 0 || spriteNodeCount < movementCount)
-    // When Clear: 0 movements, nodes still exist — must run sprite layers to clear Konva nodes
-    const needSpriteClear =
-      movementCount === 0 && spriteNodeCount > 0
-    const backgroundOnly =
-      !needSpriteBuild &&
-      !needSpriteClear &&
-      pendingRenderReasonRef.value === 'bufferOnly'
-
-    if (needSpriteBuild || needSpriteClear || !backgroundOnly) {
-      const movementsDebug = movementsFromBuffer.map(m => ({
-        actionNumber: m.actionNumber,
-        characterType: m.definition.characterType,
-      }))
-      logScreen.debug('render', {
-        movementCount,
-        spriteNodeCount,
-        needSpriteBuild,
-        needSpriteClear,
-        backgroundOnly,
-        reason: pendingRenderReasonRef.value,
-        movementsFromBuffer: movementsDebug,
-      })
-    }
-
-    // Pass lastBackgroundBuffer for sprite rendering context (background uses Canvas2D now)
-    const lastBackgroundBuffer = lastBackgroundBufferRef.value
-    const { frontSpriteNodes: frontNodes, backSpriteNodes: backNodes } =
-      await renderAllScreenLayers(
-        layersToRender,
-        bufferToRender,
-        ctx.spriteStates.value ?? [],
-        paletteCode.value,
-        ctx.spritePalette.value ?? 1,
-        ctx.backdropColor.value ?? 0,
-        ctx.spriteEnabled.value ?? false,
-        ctx.sharedDisplayBufferAccessor,
-        true,
-        frontSpriteNodes.value as Map<number, Konva.Image>,
-        backSpriteNodes.value as Map<number, Konva.Image>,
-        {
-          backgroundOnly,
-          lastBackgroundBuffer,
-        }
-      )
-
-    // After background render, store buffer for next dirty diff
-    lastBackgroundBufferRef.value = deepCopyBuffer(bufferToRender)
-
-    if (!backgroundOnly) {
-      frontSpriteNodes.value = frontNodes as Map<number, Konva.Image>
-      backSpriteNodes.value = backNodes as Map<number, Konva.Image>
-      const extFront = ctx.externalFrontSpriteNodes.value
-      if (extFront) {
-        extFront.clear()
-        for (const [key, value] of frontNodes.entries()) {
-          extFront.set(key, value)
-        }
-      }
-      const extBack = ctx.externalBackSpriteNodes.value
-      if (extBack) {
-        extBack.clear()
-        for (const [key, value] of backNodes.entries()) {
-          extBack.set(key, value)
-        }
-      }
-    }
-  } catch (error) {
-    logScreen.error('Error rendering screen layers:', error)
-  } finally {
-    renderInProgress = false
-  }
-}
-
-// Pure Buffer Read: movement states are read directly from shared buffer (DEF MOVE definitions are stored there)
-// When new MOVE commands are added, Animation Worker writes to buffer, triggering watcher below
-
-// Watch paletteCode, backdropColor, spritePalette, sprite states, and sprite enabled to trigger re-render
-// These are STATIC rendering changes (CGSET, COLOR, SPRITE, etc.) - render immediately
-// Combined watcher for better performance (Vue 3 best practice)
-// Use computed to extract sprite state fingerprint for efficient change detection
-const spriteStateFingerprint = computed(() => {
-  const states = ctx.spriteStates.value
-  if (!states || states.length === 0) return ''
-  return states.map(s => `${s.spriteNumber}:${s.x},${s.y},${s.visible ? '1' : '0'},${s.priority}`).join('|')
-})
-
-watch(
-  [
-    paletteCode,
-    () => ctx.backdropColor.value,
-    () => ctx.spritePalette.value,
-    spriteStateFingerprint,
-    () => ctx.spriteEnabled.value,
-    zoomLevel,
-  ],
-  () => {
-    pendingRenderReasonRef.value = 'full'
-    scheduleRender()
-  }
-)
-
-// Render queue: when animation is active, sets pending static render so animation loop runs render at end of frame
-function scheduleRender() {
-  // Check if there are active movements - Pure Buffer Read
-  const hasActiveMovements = (() => {
-    if (!ctx.sharedDisplayBufferAccessor) return false
-    for (let actionNumber = 0; actionNumber < 8; actionNumber++) {
-      if (ctx.sharedDisplayBufferAccessor.readSpriteIsActive(actionNumber)) {
-        return true
-      }
-    }
-    return false
-  })()
-
-  if (hasActiveMovements) {
-    // Animation is active, set pending flag
-    pendingStaticRenderRef.value = true
-  } else {
-    // No active animation, render immediately
-    render()
-  }
-}
-
-function cleanupRenderQueue() {
-  // No-op - pendingStaticRenderRef will be cleared on unmount
-}
-
-// Register scheduleRender with parent so SCREEN_CHANGED can trigger a redraw (shared buffer path)
-watch(
-  () => ctx.registerCallbacks.registerScheduleRender,
-  fn => {
-    if (fn) fn(scheduleRender)
-  },
-  { immediate: true }
-)
-
-// Register buffer invalidation callback for palette changes (PALETB etc.)
-// Nullifying lastBackgroundBufferRef forces the dirty renderer to do a full redraw
-// since renderBackgroundToCanvasDirty falls back to full render when lastBuffer is null.
-// Also nullify lastBackdropColorRef so backdrop fill is always applied on invalidation.
-watch(
-  () => ctx.registerCallbacks.registerInvalidateBackgroundBuffer,
-  fn => {
-    if (fn) fn(() => {
-      lastBackgroundBufferRef.value = null
-      lastBackdropColorRef.value = null
-    })
-  },
-  { immediate: true }
-)
-
-// Watch screenBuffer and render when it changes (PRINT). Use full when movements > nodes.
-// When using shared buffer, SCREEN_CHANGED triggers scheduleRender; this watch still runs for ref updates.
-watch(
-  () => ctx.screenBuffer.value,
-  () => {
-    const movementCount = ctx.movementStates?.value?.length ?? 0
-    const spriteNodeCount = frontSpriteNodes.value.size + backSpriteNodes.value.size
-    const useFull = movementCount > spriteNodeCount
-    if (useFull) {
-      logScreen.debug(
-        'screenBuffer watch → full',
-        'movementCount=',
-        movementCount,
-        'spriteNodeCount=',
-        spriteNodeCount
-      )
-    }
-    pendingRenderReasonRef.value = useFull ? 'full' : 'bufferOnly'
-    scheduleRender()
-  },
-  { immediate: true, deep: true, flush: 'post' }
-)
-
-// Backdrop is managed by vue-konva template via backdropColorHex computed property
-
-// Initialize Animation Worker (single writer to shared buffer)
-const { initialize: initializeAnimationWorker, terminate: terminateAnimationWorker } =
-  useAnimationWorker({
-    sharedAnimationBuffer: computed(() => ctx.sharedAnimationBuffer.value ?? null),
-    onReady: () => {
-      logScreen.debug('[Screen] Animation Worker ready')
-    },
-    onError: (error) => {
-      logScreen.error('[Screen] Animation Worker error:', error)
-    },
-  })
-
-// Initial render when stage becomes available
-watch(
+// Delegate render pipeline to composable
+const { stageDisplayWidth, stageDisplayHeight, baseWidth, baseHeight } = useScreenRenderPipeline({
+  ctx,
   stageRef,
-  async stage => {
-    if (stage) {
-      await initializeKonva()
-      // Initialize Animation Worker when stage is ready
-      await initializeAnimationWorker()
-    }
-  },
-  { immediate: true }
-)
-
-// Setup render-only animation loop - READS from shared buffer (Animation Worker is the single writer)
-// Runs continuously at 60fps, detecting missing sprite nodes and triggering render as needed
-const stopAnimationLoop = useScreenAnimationLoopRenderOnly({
-  layers,
-  frontSpriteNodes,
-  backSpriteNodes,
-  spritePalette: computed(() => ctx.spritePalette.value ?? 1),
-  sharedDisplayBufferAccessor: ctx.sharedDisplayBufferAccessor,
-  setMovementPositionsFromBuffer: (positions) => {
-    ctx.movementPositionsFromBuffer.value = positions
-  },
-  updateInspectorMoveSlots: ctx.updateInspectorMoveSlots,
-  getPendingStaticRender: () => pendingStaticRenderRef.value,
-  onRunPendingStaticRender: async () => {
-    await render()
-    pendingStaticRenderRef.value = false
-  },
-  onRenderNeeded: () => {
-    pendingRenderReasonRef.value = 'full'
-    scheduleRender()
-  },
+  paletteCode,
 })
-
-// Stop animation loop and cancel pending renders (unmount and keep-alive deactivation)
-function cleanupScreen() {
-  stopAnimationLoop()
-  cleanupRenderQueue()
-  terminateAnimationWorker()
-}
-onUnmounted(cleanupScreen)
-onDeactivated(cleanupScreen)
 </script>
 
 <template>
@@ -460,22 +67,22 @@ onDeactivated(cleanupScreen)
             ref="stageRef"
             class="screen-stage"
             :config="{
-              width: BASE_WIDTH,
-              height: BASE_HEIGHT,
+              width: baseWidth,
+              height: baseHeight,
             }"
             :style="{
-              transform: `scale(${zoomLevel})`,
+              transform: `scale(${stageDisplayWidth / baseWidth})`,
               transformOrigin: 'top left',
             }"
           >
           <v-layer>
-            <!-- Backdrop Screen (F-Basic layer 1: furthest back, 32×30 chars = 256×240 px) -->
+            <!-- Backdrop Screen (F-Basic layer 1: furthest back, 32x30 chars = 256x240 px) -->
             <v-rect
               :config="{
                 x: 0,
                 y: 0,
-                width: BASE_WIDTH,
-                height: BASE_HEIGHT,
+                width: baseWidth,
+                height: baseHeight,
                 fill: backdropColorHex,
               }"
             />
@@ -483,7 +90,7 @@ onDeactivated(cleanupScreen)
           </v-layer>
           </v-stage>
           <!-- Debug Grid Overlay -->
-          <DebugGridOverlay v-if="showGrid" :zoom="zoomLevel" />
+          <DebugGridOverlay v-if="showGrid" :zoom="stageDisplayWidth / baseWidth" />
         </div>
         <div class="crt-reflection"></div>
       </div>

--- a/src/features/ide/composables/useIdeGlobalHotkeys.ts
+++ b/src/features/ide/composables/useIdeGlobalHotkeys.ts
@@ -1,0 +1,76 @@
+/**
+ * useIdeGlobalHotkeys composable
+ *
+ * Manages global keyboard shortcuts for the IDE page.
+ * Handles command palette toggle, run/stop/restart, and input mode switching.
+ * Registers on mount, unregisters on unmount.
+ */
+
+import { onMounted, onUnmounted, type Ref, type ShallowRef } from 'vue'
+
+import { isEditableTarget, matchesAnyShortcut } from './commandPalette'
+import type { InputMode } from './useBasicIdeState'
+
+interface IdeGlobalHotkeysDeps {
+  commandPaletteOpen: ShallowRef<boolean>
+  inputMode: Ref<InputMode>
+  runCode: () => Promise<void>
+  stopCode: () => void
+  openCommandPalette: () => void
+}
+
+/**
+ * Register global keyboard shortcuts for the IDE.
+ *
+ * Shortcuts handled:
+ * - Ctrl/Cmd+Shift+P: Open command palette
+ * - Ctrl/Cmd+Enter: Run code
+ * - Ctrl/Cmd+Shift+Enter: Stop code
+ * - Ctrl/Cmd+Shift+R: Restart code
+ * - F9: Toggle input mode (joystick/keyboard)
+ */
+export function useIdeGlobalHotkeys(deps: IdeGlobalHotkeysDeps): void {
+  function handleGlobalKeydown(e: KeyboardEvent) {
+    if (matchesAnyShortcut(e, ['Ctrl+Shift+P', 'Meta+Shift+P'])) {
+      e.preventDefault()
+      deps.openCommandPalette()
+      return
+    }
+
+    if (deps.commandPaletteOpen.value || isEditableTarget(e.target)) return
+
+    if (matchesAnyShortcut(e, ['Ctrl+Enter', 'Meta+Enter'])) {
+      e.preventDefault()
+      void deps.runCode()
+      return
+    }
+
+    if (matchesAnyShortcut(e, ['Ctrl+Shift+Enter', 'Meta+Shift+Enter'])) {
+      e.preventDefault()
+      deps.stopCode()
+      return
+    }
+
+    if (matchesAnyShortcut(e, ['Ctrl+Shift+R', 'Meta+Shift+R'])) {
+      e.preventDefault()
+      // Stop then restart
+      deps.stopCode()
+      void deps.runCode()
+      return
+    }
+
+    // F9: Toggle input mode (joystick/keyboard)
+    if (e.key === 'F9') {
+      e.preventDefault()
+      deps.inputMode.value = deps.inputMode.value === 'joystick' ? 'keyboard' : 'joystick'
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener('keydown', handleGlobalKeydown)
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('keydown', handleGlobalKeydown)
+  })
+}

--- a/src/features/ide/composables/useIdePageState.ts
+++ b/src/features/ide/composables/useIdePageState.ts
@@ -1,0 +1,286 @@
+/**
+ * useIdePageState composable
+ *
+ * Aggregates all IDE state from useBasicIdeEnhanced, with E2E Lite fallbacks.
+ * When running in E2E Lite mode (URL param ?e2e=lite), provides stub refs
+ * so the IDE page can render without a full parser/worker stack.
+ * Also provides screen context and exposes the DEV API.
+ */
+
+import { type Ref, ref, type ShallowRef, shallowRef } from 'vue'
+
+import type { SharedDisplayViews } from '@/core/animation/sharedDisplayBuffer'
+import type { DecodedScreenState, SharedDisplayBufferAccessor } from '@/core/animation/sharedDisplayBufferAccessor'
+import { PALETTE_DEFAULTS } from '@/core/constants'
+import type { KeyboardBufferView } from '@/core/devices'
+import {
+  createSharedKeyboardBuffer,
+  createViewsFromKeyboardBuffer,
+} from '@/core/devices'
+import type { SpriteState } from '@/core/sprite/types'
+import type { HighlighterInfo, ParserInfo, ScreenCell } from '@/core/types/execution-types'
+import type { BasicVariable } from '@/core/types/state-types'
+import type { RequestInputMessage } from '@/core/types/worker-messages'
+
+import { useBasicIde as useBasicIdeEnhanced } from './useBasicIdeEnhanced'
+import type { InputMode } from './useBasicIdeState'
+import { useDevApi } from './useDevApi'
+import { provideScreenContext } from './useScreenContext'
+import { useShareRoute } from './useShareRoute'
+
+export interface IdePageState {
+  // Code & execution
+  code: Ref<string>
+  isRunning: Ref<boolean>
+  output: Ref<string[]>
+  errors: Ref<Array<{ line: number; message: string; type: string; stack?: string; sourceLine?: string }>>
+  variables: Ref<Record<string, BasicVariable>>
+  debugOutput: Ref<string>
+  debugMode: Ref<boolean>
+
+  // Screen state
+  screenBuffer: Ref<ScreenCell[][]>
+  cursorX: Ref<number>
+  cursorY: Ref<number>
+  bgPalette: Ref<number>
+  backdropColor: Ref<number>
+  spritePalette: Ref<number>
+  cgenMode: Ref<number>
+  spriteStates: Ref<SpriteState[]>
+  spriteEnabled: Ref<boolean>
+  movementPositionsFromBuffer: Ref<Map<number, { x: number; y: number }>>
+  frontSpriteNodes: Ref<Map<number, unknown>>
+  backSpriteNodes: Ref<Map<number, unknown>>
+  inputMode: Ref<InputMode>
+
+  // Methods
+  runCode: () => Promise<void>
+  stopCode: () => void
+  clearOutput: () => void
+  loadSampleCode: (sampleType: string, displayName: string) => boolean
+  getParserCapabilities: () => ParserInfo
+  getHighlighterCapabilities: () => HighlighterInfo
+  toggleDebugMode: () => void
+  sendStrigEvent: (joystickId: number, state: number) => void
+  setDecodedScreenState: (decoded: DecodedScreenState) => void
+  pendingInputRequest: Ref<RequestInputMessage['data'] | null>
+  respondToInputRequest: (requestId: string, values: string[], cancelled: boolean) => void
+
+  // Shared buffers
+  sharedDisplayBufferAccessor: SharedDisplayBufferAccessor
+  sharedAnimationBuffer: SharedArrayBuffer
+  sharedDisplayViews: SharedDisplayViews
+  sharedJoystickBuffer: SharedArrayBuffer
+  sharedKeyboardBufferView: KeyboardBufferView
+  registerCallbacks: {
+    registerScheduleRender: (fn: () => void) => void
+    registerInvalidateBackgroundBuffer: (fn: () => void) => void
+  }
+
+  // E2E mode flag
+  isE2ELite: boolean
+
+  // Parser info (for editor display)
+  parserInfo: ShallowRef<ParserInfo | null>
+  highlighterInfo: ShallowRef<HighlighterInfo | null>
+
+  // Share route
+  shareError: Ref<string>
+  handleShareRoute: () => Promise<void>
+}
+
+/**
+ * Create aggregated IDE page state with E2E Lite fallbacks.
+ *
+ * @param bottomAreaRef - Template ref to IdeBottomArea for inspector MOVE tab callback
+ */
+export function useIdePageState(
+  bottomAreaRef: ShallowRef<{ updateMoveSlotsData: () => void } | null>
+): IdePageState {
+  const isE2ELite =
+    typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('e2e') === 'lite'
+
+  const basicIde = isE2ELite ? null : useBasicIdeEnhanced()
+
+  // Share route handling
+  const code = basicIde?.code ?? ref('')
+  const { shareError, handleShareRoute } = useShareRoute({ code })
+
+  const isRunning = basicIde?.isRunning ?? ref(false)
+  const output = basicIde?.output ?? ref<string[]>([])
+  const errors =
+    basicIde?.errors ??
+    ref<Array<{ line: number; message: string; type: string; stack?: string; sourceLine?: string }>>([])
+  const variables = basicIde?.variables ?? ref<Record<string, BasicVariable>>({})
+  const debugOutput = basicIde?.debugOutput ?? ref('')
+  const debugMode = basicIde?.debugMode ?? ref(false)
+  const screenBuffer = basicIde?.screenBuffer ?? ref<ScreenCell[][]>([])
+  const cursorX = basicIde?.cursorX ?? ref(0)
+  const cursorY = basicIde?.cursorY ?? ref(0)
+  const bgPalette = basicIde?.bgPalette ?? ref(PALETTE_DEFAULTS.BG_PALETTE)
+  const backdropColor = basicIde?.backdropColor ?? ref(PALETTE_DEFAULTS.BACKDROP_COLOR)
+  const spritePalette = basicIde?.spritePalette ?? ref(PALETTE_DEFAULTS.SPRITE_PALETTE)
+  const cgenMode = basicIde?.cgenMode ?? ref(PALETTE_DEFAULTS.CGEN_MODE)
+  const spriteStates = basicIde?.spriteStates ?? ref<SpriteState[]>([])
+  const spriteEnabled = basicIde?.spriteEnabled ?? ref(true)
+  const movementPositionsFromBuffer =
+    basicIde?.movementPositionsFromBuffer ?? ref<Map<number, { x: number; y: number }>>(new Map())
+  const frontSpriteNodes = basicIde?.frontSpriteNodes ?? ref<Map<number, unknown>>(new Map())
+  const backSpriteNodes = basicIde?.backSpriteNodes ?? ref<Map<number, unknown>>(new Map())
+  const inputMode = basicIde?.inputMode ?? ref<InputMode>('joystick')
+
+  const runCode =
+    basicIde?.runCode ??
+    (async () => {
+      isRunning.value = true
+    })
+  const stopCode =
+    basicIde?.stopCode ??
+    (() => {
+      isRunning.value = false
+    })
+  const clearOutput =
+    basicIde?.clearOutput ??
+    (() => {
+      output.value = []
+      errors.value = []
+      variables.value = {}
+      debugOutput.value = ''
+    })
+  const loadSampleCode = basicIde?.loadSampleCode ?? (() => false)
+  const getParserCapabilities =
+    basicIde?.getParserCapabilities ??
+    (() => ({
+      name: 'E2E Lite Parser',
+      version: '0.0.0',
+      capabilities: [],
+      features: [],
+      supportedStatements: [],
+      supportedFunctions: [],
+      supportedOperators: [],
+    }))
+  const getHighlighterCapabilities =
+    basicIde?.getHighlighterCapabilities ??
+    (() => ({
+      name: 'E2E Lite Highlighter',
+      version: '0.0.0',
+      features: [],
+    }))
+  const toggleDebugMode =
+    basicIde?.toggleDebugMode ??
+    (() => {
+      debugMode.value = !debugMode.value
+    })
+  const sendStrigEvent = basicIde?.sendStrigEvent ?? ((_joystickId: number, _state: number) => {})
+  const sharedDisplayBufferAccessor =
+    basicIde?.sharedDisplayBufferAccessor ?? ({} as SharedDisplayBufferAccessor)
+  const sharedAnimationBuffer = basicIde?.sharedAnimationBuffer ?? ({} as SharedArrayBuffer)
+  const sharedDisplayViews: SharedDisplayViews = basicIde?.sharedDisplayViews ?? {
+    buffer: {} as SharedArrayBuffer,
+    spriteView: {} as Float64Array,
+    charView: {} as Uint8Array,
+    patternView: {} as Uint8Array,
+    cursorView: {} as Uint8Array,
+    sequenceView: {} as Int32Array,
+    scalarsView: {} as Uint8Array,
+    animationSyncView: {} as Float64Array,
+  }
+  const sharedJoystickBuffer = basicIde?.sharedJoystickBuffer ?? ({} as SharedArrayBuffer)
+  const sharedKeyboardBufferView: KeyboardBufferView =
+    basicIde?.sharedKeyboardBufferView ?? createViewsFromKeyboardBuffer(createSharedKeyboardBuffer())
+  const setDecodedScreenState = basicIde?.setDecodedScreenState ?? ((_decoded: DecodedScreenState) => {})
+  const registerCallbacks = basicIde?.registerCallbacks ?? {
+    registerScheduleRender: () => {},
+    registerInvalidateBackgroundBuffer: () => {},
+  }
+  const pendingInputRequest = basicIde?.pendingInputRequest ?? ref<RequestInputMessage['data'] | null>(null)
+  const respondToInputRequest =
+    basicIde?.respondToInputRequest ?? ((_requestId: string, _values: string[], _cancelled: boolean) => {})
+
+  // Expose DEV-only global API for headless test code injection
+  useDevApi({
+    code,
+    runCode,
+    stopCode,
+    pendingInputRequest,
+    respondToInputRequest,
+    screenBuffer,
+  })
+
+  // Provide screen context so ScreenTab/Screen can inject instead of prop drilling
+  const hasAllBuffers = sharedDisplayViews && sharedDisplayBufferAccessor
+    && sharedAnimationBuffer && sharedJoystickBuffer
+  if (!isE2ELite && hasAllBuffers) {
+    provideScreenContext({
+      screenBuffer,
+      cursorX,
+      cursorY,
+      bgPalette,
+      backdropColor,
+      spritePalette,
+      cgenMode,
+      spriteStates,
+      spriteEnabled,
+      movementPositionsFromBuffer,
+      externalFrontSpriteNodes: frontSpriteNodes,
+      externalBackSpriteNodes: backSpriteNodes,
+      sharedDisplayViews: ref(sharedDisplayViews),
+      sharedDisplayBufferAccessor,
+      sharedAnimationBuffer: ref(sharedAnimationBuffer),
+      sharedJoystickBuffer: ref(sharedJoystickBuffer),
+      setDecodedScreenState,
+      registerCallbacks,
+      // Callback for animation loop to update inspector MOVE tab data
+      updateInspectorMoveSlots: () => bottomAreaRef.value?.updateMoveSlotsData(),
+    })
+  }
+
+  // Parser capabilities for display
+  const parserInfo = shallowRef<ParserInfo | null>(null)
+  const highlighterInfo = shallowRef<HighlighterInfo | null>(null)
+
+  return {
+    code,
+    isRunning,
+    output,
+    errors,
+    variables,
+    debugOutput,
+    debugMode,
+    screenBuffer,
+    cursorX,
+    cursorY,
+    bgPalette,
+    backdropColor,
+    spritePalette,
+    cgenMode,
+    spriteStates,
+    spriteEnabled,
+    movementPositionsFromBuffer,
+    frontSpriteNodes,
+    backSpriteNodes,
+    inputMode,
+    runCode,
+    stopCode,
+    clearOutput,
+    loadSampleCode,
+    getParserCapabilities,
+    getHighlighterCapabilities,
+    toggleDebugMode,
+    sendStrigEvent,
+    setDecodedScreenState,
+    pendingInputRequest,
+    respondToInputRequest,
+    sharedDisplayBufferAccessor,
+    sharedAnimationBuffer,
+    sharedDisplayViews,
+    sharedJoystickBuffer,
+    sharedKeyboardBufferView,
+    registerCallbacks,
+    isE2ELite,
+    parserInfo,
+    highlighterInfo,
+    shareError,
+    handleShareRoute,
+  }
+}

--- a/src/features/ide/composables/useScreenRenderPipeline.ts
+++ b/src/features/ide/composables/useScreenRenderPipeline.ts
@@ -1,0 +1,416 @@
+/**
+ * useScreenRenderPipeline composable
+ *
+ * Manages the Konva render lifecycle for the Screen component.
+ * Owns: Konva initialization, render function, dirty buffer tracking,
+ * watcher setup, render scheduling, animation loop integration, and cleanup.
+ *
+ * This is the core rendering responsibility of Screen.vue -- the component
+ * itself should be thin: template + composable wiring.
+ */
+
+import Konva from 'konva'
+import { computed, onDeactivated, onUnmounted, type Ref, ref, type ShallowRef, shallowRef, watch } from 'vue'
+
+import type { ScreenCell } from '@/core/types/execution-types'
+import { logScreen } from '@/shared/logger'
+import type { VueKonvaStageInstance } from '@/types/vue-konva'
+
+import { useAnimationWorker } from './useAnimationWorker'
+import { preInitializeBackgroundTiles, renderBackgroundToCanvas, renderBackgroundToCanvasDirty } from './useCanvasBackgroundRenderer'
+import { initializeKonvaLayers, type KonvaScreenLayers, renderAllScreenLayers } from './useKonvaScreenRenderer'
+import { useScreenAnimationLoopRenderOnly } from './useScreenAnimationLoopRenderOnly'
+import type { ScreenContextValue } from './useScreenContext'
+import { useScreenZoom } from './useScreenZoom'
+
+// Base screen dimensions (full backdrop/sprite screen: 256x240)
+const BASE_WIDTH = 256
+const BASE_HEIGHT = 240
+
+/** Deep copy of screen buffer for dirty diff (last rendered state) */
+function deepCopyBuffer(buf: ScreenCell[][]): ScreenCell[][] {
+  return buf.map(row => row.map(c => ({ ...c })))
+}
+
+// Render reason: bufferOnly = only screenBuffer changed (PRINT); full = sprite/palette/backdrop/etc
+type RenderReason = 'full' | 'bufferOnly'
+
+export interface ScreenRenderPipelineOptions {
+  /** Screen context (provided by IdePage) */
+  ctx: ScreenContextValue
+  /** Template ref to the Konva stage element */
+  stageRef: ShallowRef<VueKonvaStageInstance | null>
+  /** Computed palette code from context */
+  paletteCode: Ref<number>
+}
+
+export interface ScreenRenderPipelineResult {
+  /** Computed stage display width based on zoom */
+  stageDisplayWidth: Readonly<Ref<number>>
+  /** Computed stage display height based on zoom */
+  stageDisplayHeight: Readonly<Ref<number>>
+  /** Base screen width constant */
+  baseWidth: number
+  /** Base screen height constant */
+  baseHeight: number
+}
+
+/**
+ * Setup the complete screen render pipeline.
+ *
+ * Initializes Konva, sets up watchers for reactive state changes,
+ * manages render scheduling (immediate vs deferred to animation frame),
+ * and integrates with the animation loop for sprite updates.
+ */
+export function useScreenRenderPipeline(options: ScreenRenderPipelineOptions): ScreenRenderPipelineResult {
+  const { ctx, stageRef, paletteCode } = options
+
+  // Offscreen Canvas2D for background rendering (much faster than Konva for text)
+  // Rendered to Konva.Image to participate in layer stacking
+  const backgroundCanvas = document.createElement('canvas')
+  backgroundCanvas.width = BASE_WIDTH
+  backgroundCanvas.height = BASE_HEIGHT
+
+  // Konva layers (background populated from offscreen Canvas2D for performance)
+  const layers = shallowRef<KonvaScreenLayers>({
+    backdropLayer: null,
+    spriteBackLayer: null,
+    backgroundLayer: null,
+    spriteFrontLayer: null,
+  })
+
+  // Sprite node maps for animated sprite updates
+  const frontSpriteNodes = shallowRef<Map<number, Konva.Image>>(new Map())
+  const backSpriteNodes = shallowRef<Map<number, Konva.Image>>(new Map())
+
+  // Last rendered buffer for dirty diff (Canvas2D rendering)
+  const lastBackgroundBufferRef = shallowRef<ScreenCell[][] | null>(null)
+
+  // Last backdrop color used for canvas rendering (to detect backdrop changes for dirty render)
+  const lastBackdropColorRef = ref<number | null>(null)
+
+  // Shared buffer path: last sequence and last decoded buffer (so we only decode when sequence changes)
+  const lastSequenceRef = ref(-1)
+  const lastDecodedBufferRef = shallowRef<ScreenCell[][] | null>(null)
+
+  // Render scheduling state
+  const pendingRenderReasonRef = ref<RenderReason>('full')
+  const pendingStaticRenderRef = ref(false)
+  let renderInProgress = false
+
+  /**
+   * Initialize Konva Stage and layers
+   */
+  async function initializeKonva(): Promise<void> {
+    if (!stageRef.value) return
+
+    const stageNode = stageRef.value?.getNode() ?? stageRef.value?.getStage?.() ?? null
+    if (!stageNode) {
+      logScreen.error('Failed to get Konva stage node')
+      return
+    }
+
+    // Pre-initialize background tile images in the background (non-blocking)
+    void preInitializeBackgroundTiles().catch(err => {
+      logScreen.warn('Background tile pre-initialization failed:', err)
+    })
+
+    // Initialize layers (backdrop is managed by vue-konva template)
+    layers.value = initializeKonvaLayers(stageNode)
+    layers.value.backdropLayer = null
+
+    // Initial render
+    scheduleRender()
+  }
+
+  /**
+   * Render all screen layers using Konva
+   */
+  async function render(): Promise<void> {
+    if (!stageRef.value || renderInProgress) return
+
+    renderInProgress = true
+    try {
+      // Shared buffer path: read sequence; if changed (or first run), decode and update parent refs
+      const accessor = ctx.sharedDisplayBufferAccessor
+      let bufferToRender: ScreenCell[][] = ctx.screenBuffer.value ?? []
+      if (accessor) {
+        const seq = accessor.readSequence()
+        if (seq !== lastSequenceRef.value || lastDecodedBufferRef.value === null) {
+          const decoded = accessor.readScreenState()
+          ctx.setDecodedScreenState(decoded)
+          lastSequenceRef.value = seq
+          lastDecodedBufferRef.value = decoded.buffer
+        }
+        bufferToRender = lastDecodedBufferRef.value ?? (ctx.screenBuffer.value ?? [])
+      }
+
+      // Render background using Canvas2D to offscreen canvas
+      const lastBuffer = lastBackgroundBufferRef.value
+      const currentBackdropColor = ctx.backdropColor.value ?? 0
+      if (lastBuffer && pendingRenderReasonRef.value === 'bufferOnly') {
+        renderBackgroundToCanvasDirty(
+          backgroundCanvas,
+          bufferToRender,
+          lastBuffer,
+          paletteCode.value,
+          currentBackdropColor,
+          lastBackdropColorRef.value
+        )
+      } else {
+        renderBackgroundToCanvas(backgroundCanvas, bufferToRender, paletteCode.value, currentBackdropColor)
+      }
+      lastBackdropColorRef.value = currentBackdropColor
+
+      // Create/update Konva.Image from Canvas2D content
+      if (layers.value.backgroundLayer) {
+        layers.value.backgroundLayer.destroyChildren()
+
+        const backgroundImage = new Konva.Image({
+          x: 0,
+          y: 0,
+          image: backgroundCanvas,
+          listening: false,
+        })
+
+        layers.value.backgroundLayer.add(backgroundImage)
+        layers.value.backgroundLayer.batchDraw()
+      }
+
+      // Render sprites using Konva
+      const layersToRender: KonvaScreenLayers = {
+        backdropLayer: null,
+        spriteBackLayer: layers.value.spriteBackLayer,
+        backgroundLayer: layers.value.backgroundLayer,
+        spriteFrontLayer: layers.value.spriteFrontLayer,
+      }
+
+      const movementsFromBuffer = ctx.sharedDisplayBufferAccessor?.readAllMovementStates() ?? []
+      const movementCount = movementsFromBuffer.length
+      const spriteNodeCount = frontSpriteNodes.value.size + backSpriteNodes.value.size
+      const needSpriteBuild =
+        movementCount > 0 && (spriteNodeCount === 0 || spriteNodeCount < movementCount)
+      const needSpriteClear =
+        movementCount === 0 && spriteNodeCount > 0
+      const backgroundOnly =
+        !needSpriteBuild &&
+        !needSpriteClear &&
+        pendingRenderReasonRef.value === 'bufferOnly'
+
+      if (needSpriteBuild || needSpriteClear || !backgroundOnly) {
+        const movementsDebug = movementsFromBuffer.map(m => ({
+          actionNumber: m.actionNumber,
+          characterType: m.definition.characterType,
+        }))
+        logScreen.debug('render', {
+          movementCount,
+          spriteNodeCount,
+          needSpriteBuild,
+          needSpriteClear,
+          backgroundOnly,
+          reason: pendingRenderReasonRef.value,
+          movementsFromBuffer: movementsDebug,
+        })
+      }
+
+      const lastBackgroundBuffer = lastBackgroundBufferRef.value
+      const { frontSpriteNodes: frontNodes, backSpriteNodes: backNodes } =
+        await renderAllScreenLayers(
+          layersToRender,
+          bufferToRender,
+          ctx.spriteStates.value ?? [],
+          paletteCode.value,
+          ctx.spritePalette.value ?? 1,
+          ctx.backdropColor.value ?? 0,
+          ctx.spriteEnabled.value ?? false,
+          ctx.sharedDisplayBufferAccessor,
+          true,
+          frontSpriteNodes.value,
+          backSpriteNodes.value,
+          {
+            backgroundOnly,
+            lastBackgroundBuffer,
+          }
+        )
+
+      // After background render, store buffer for next dirty diff
+      lastBackgroundBufferRef.value = deepCopyBuffer(bufferToRender)
+
+      if (!backgroundOnly) {
+        frontSpriteNodes.value = frontNodes
+        backSpriteNodes.value = backNodes
+        const extFront = ctx.externalFrontSpriteNodes.value
+        if (extFront) {
+          extFront.clear()
+          for (const [key, value] of frontNodes.entries()) {
+            extFront.set(key, value)
+          }
+        }
+        const extBack = ctx.externalBackSpriteNodes.value
+        if (extBack) {
+          extBack.clear()
+          for (const [key, value] of backNodes.entries()) {
+            extBack.set(key, value)
+          }
+        }
+      }
+    } catch (error) {
+      logScreen.error('Error rendering screen layers:', error)
+    } finally {
+      renderInProgress = false
+    }
+  }
+
+  // Sprite state fingerprint for efficient change detection
+  const spriteStateFingerprint = computed(() => {
+    const states = ctx.spriteStates.value
+    if (!states || states.length === 0) return ''
+    return states.map(s => `${s.spriteNumber}:${s.x},${s.y},${s.visible ? '1' : '0'},${s.priority}`).join('|')
+  })
+
+  // Use shared zoom state composable for stage display dimensions
+  const { zoomLevel } = useScreenZoom()
+
+  // Computed stage display dimensions based on zoom (for CSS scaling)
+  const stageDisplayWidth = computed(() => BASE_WIDTH * zoomLevel.value)
+  const stageDisplayHeight = computed(() => BASE_HEIGHT * zoomLevel.value)
+
+  // Watch paletteCode, backdropColor, spritePalette, sprite states, and sprite enabled to trigger re-render
+  watch(
+    [
+      paletteCode,
+      () => ctx.backdropColor.value,
+      () => ctx.spritePalette.value,
+      spriteStateFingerprint,
+      () => ctx.spriteEnabled.value,
+      zoomLevel,
+    ],
+    () => {
+      pendingRenderReasonRef.value = 'full'
+      scheduleRender()
+    }
+  )
+
+  // Render queue: when animation is active, sets pending static render so animation loop runs render at end of frame
+  function scheduleRender() {
+    const hasActiveMovements = (() => {
+      if (!ctx.sharedDisplayBufferAccessor) return false
+      for (let actionNumber = 0; actionNumber < 8; actionNumber++) {
+        if (ctx.sharedDisplayBufferAccessor.readSpriteIsActive(actionNumber)) {
+          return true
+        }
+      }
+      return false
+    })()
+
+    if (hasActiveMovements) {
+      pendingStaticRenderRef.value = true
+    } else {
+      void render()
+    }
+  }
+
+  // Register scheduleRender with parent so SCREEN_CHANGED can trigger a redraw
+  watch(
+    () => ctx.registerCallbacks.registerScheduleRender,
+    fn => {
+      if (fn) fn(scheduleRender)
+    },
+    { immediate: true }
+  )
+
+  // Register buffer invalidation callback for palette changes (PALETB etc.)
+  watch(
+    () => ctx.registerCallbacks.registerInvalidateBackgroundBuffer,
+    fn => {
+      if (fn) fn(() => {
+        lastBackgroundBufferRef.value = null
+        lastBackdropColorRef.value = null
+      })
+    },
+    { immediate: true }
+  )
+
+  // Watch screenBuffer and render when it changes (PRINT)
+  watch(
+    () => ctx.screenBuffer.value,
+    () => {
+      const movementCount = ctx.movementStates?.value?.length ?? 0
+      const spriteNodeCount = frontSpriteNodes.value.size + backSpriteNodes.value.size
+      const useFull = movementCount > spriteNodeCount
+      if (useFull) {
+        logScreen.debug(
+          'screenBuffer watch → full',
+          'movementCount=',
+          movementCount,
+          'spriteNodeCount=',
+          spriteNodeCount
+        )
+      }
+      pendingRenderReasonRef.value = useFull ? 'full' : 'bufferOnly'
+      scheduleRender()
+    },
+    { immediate: true, deep: true, flush: 'post' }
+  )
+
+  // Initialize Animation Worker (single writer to shared buffer)
+  const { initialize: initializeAnimationWorker, terminate: terminateAnimationWorker } =
+    useAnimationWorker({
+      sharedAnimationBuffer: computed(() => ctx.sharedAnimationBuffer.value ?? null),
+      onReady: () => {
+        logScreen.debug('[Screen] Animation Worker ready')
+      },
+      onError: (error) => {
+        logScreen.error('[Screen] Animation Worker error:', error)
+      },
+    })
+
+  // Initial render when stage becomes available
+  watch(
+    stageRef,
+    async stage => {
+      if (stage) {
+        await initializeKonva()
+        await initializeAnimationWorker()
+      }
+    },
+    { immediate: true }
+  )
+
+  // Setup render-only animation loop
+  const stopAnimationLoop = useScreenAnimationLoopRenderOnly({
+    layers,
+    frontSpriteNodes,
+    backSpriteNodes,
+    spritePalette: computed(() => ctx.spritePalette.value ?? 1),
+    sharedDisplayBufferAccessor: ctx.sharedDisplayBufferAccessor,
+    setMovementPositionsFromBuffer: (positions) => {
+      ctx.movementPositionsFromBuffer.value = positions
+    },
+    updateInspectorMoveSlots: ctx.updateInspectorMoveSlots,
+    getPendingStaticRender: () => pendingStaticRenderRef.value,
+    onRunPendingStaticRender: async () => {
+      await render()
+      pendingStaticRenderRef.value = false
+    },
+    onRenderNeeded: () => {
+      pendingRenderReasonRef.value = 'full'
+      scheduleRender()
+    },
+  })
+
+  // Stop animation loop and cancel pending renders
+  function cleanupScreen() {
+    stopAnimationLoop()
+    terminateAnimationWorker()
+  }
+  onUnmounted(cleanupScreen)
+  onDeactivated(cleanupScreen)
+
+  return {
+    stageDisplayWidth,
+    stageDisplayHeight,
+    baseWidth: BASE_WIDTH,
+    baseHeight: BASE_HEIGHT,
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts 3 composables from IdePage.vue (498→343) and Screen.vue (496→103) by responsibility
- `useIdePageState.ts` (286 lines): E2E Lite fallbacks, state aggregation, screen context provision
- `useIdeGlobalHotkeys.ts` (76 lines): global keyboard shortcut handling
- `useScreenRenderPipeline.ts` (416 lines): Konva render lifecycle, watchers, animation integration
- Pure refactor — no behavior changes, all existing consumers preserved

## Test plan
- [x] Screen.test.ts: 12/12 pass (before and after)
- [x] Type-check: clean
- [x] ESLint: clean
- [x] E2E selectors preserved (data-testid="ide-screen-stage", etc.)
- [ ] CI: pending

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)