### PR TITLE
refactor: resolve #881 - remove dead code: unused statement lookup functions

### DIFF
--- a/src/core/execution/statement-expander.ts
+++ b/src/core/execution/statement-expander.ts
@@ -150,17 +150,3 @@ export function expandStatements(statementsCst: CstNode[]): {
   }
 }
 
-/**
- * Find statement indices by line number
- */
-export function findStatementIndicesByLine(labelMap: Map<number, number[]>, lineNumber: number): number[] {
-  return labelMap.get(lineNumber) ?? []
-}
-
-/**
- * Get the first statement index for a line number (for GOTO/GOSUB)
- */
-export function getFirstStatementIndexByLine(labelMap: Map<number, number[]>, lineNumber: number): number | undefined {
-  const indices = labelMap.get(lineNumber)
-  return indices && indices.length > 0 ? indices[0] : undefined
-}

--- a/src/core/state/ExecutionContext.ts
+++ b/src/core/state/ExecutionContext.ts
@@ -197,13 +197,6 @@ export class ExecutionContext {
   }
 
   /**
-   * Find statement indices by line number
-   */
-  findStatementIndicesByLine(lineNumber: number): number[] {
-    return this.labelMap.get(lineNumber) ?? []
-  }
-
-  /**
    * Find first statement index by line number (for GOTO/GOSUB)
    */
   findStatementIndexByLine(lineNumber: number): number {

--- a/test/core/execution/statement-expander.test.ts
+++ b/test/core/execution/statement-expander.test.ts
@@ -1,8 +1,8 @@
 /**
  * Statement Expander Tests
  *
- * Unit tests for statement-expander.ts — expandStatements(), findStatementIndicesByLine(),
- * getFirstStatementIndexByLine(). Handles GOTO/GOSUB statement expansion and label mapping.
+ * Unit tests for statement-expander.ts — expandStatements().
+ * Handles GOTO/GOSUB statement expansion and label mapping.
  */
 
 import type { CstElement, CstNode, IToken } from 'chevrotain'
@@ -10,8 +10,6 @@ import { describe, expect, it } from 'vitest'
 
 import {
   expandStatements,
-  findStatementIndicesByLine,
-  getFirstStatementIndexByLine,
 } from '@/core/execution/statement-expander'
 
 // ---------------------------------------------------------------------------
@@ -402,80 +400,5 @@ describe('expandStatements', () => {
       // Line 30 PRINT "D": no IF scope
       expect(result.statements[3]!.ifScopeEndIndex).toBeUndefined()
     })
-  })
-})
-
-// ---------------------------------------------------------------------------
-// findStatementIndicesByLine
-// ---------------------------------------------------------------------------
-
-describe('findStatementIndicesByLine', () => {
-  it('should return indices for an existing line number', () => {
-    const labelMap = new Map<number, number[]>([
-      [10, [0]],
-      [20, [1, 2]],
-    ])
-
-    expect(findStatementIndicesByLine(labelMap, 10)).toEqual([0])
-    expect(findStatementIndicesByLine(labelMap, 20)).toEqual([1, 2])
-  })
-
-  it('should return empty array for a non-existent line number', () => {
-    const labelMap = new Map<number, number[]>([
-      [10, [0]],
-    ])
-
-    expect(findStatementIndicesByLine(labelMap, 999)).toEqual([])
-  })
-
-  it('should return empty array for an empty label map', () => {
-    const labelMap = new Map<number, number[]>()
-
-    expect(findStatementIndicesByLine(labelMap, 10)).toEqual([])
-  })
-})
-
-// ---------------------------------------------------------------------------
-// getFirstStatementIndexByLine
-// ---------------------------------------------------------------------------
-
-describe('getFirstStatementIndexByLine', () => {
-  it('should return the first index for a line with multiple commands', () => {
-    const labelMap = new Map<number, number[]>([
-      [20, [1, 2, 3]],
-    ])
-
-    expect(getFirstStatementIndexByLine(labelMap, 20)).toBe(1)
-  })
-
-  it('should return the index for a line with a single command', () => {
-    const labelMap = new Map<number, number[]>([
-      [10, [0]],
-    ])
-
-    expect(getFirstStatementIndexByLine(labelMap, 10)).toBe(0)
-  })
-
-  it('should return undefined for a non-existent line number', () => {
-    const labelMap = new Map<number, number[]>([
-      [10, [0]],
-    ])
-
-    expect(getFirstStatementIndexByLine(labelMap, 999)).toBeUndefined()
-  })
-
-  it('should return undefined for an empty label map', () => {
-    const labelMap = new Map<number, number[]>()
-
-    expect(getFirstStatementIndexByLine(labelMap, 10)).toBeUndefined()
-  })
-
-  it('should return undefined when line maps to empty array', () => {
-    // Edge case: a line number maps to an empty indices array
-    const labelMap = new Map<number, number[]>([
-      [10, []],
-    ])
-
-    expect(getFirstStatementIndexByLine(labelMap, 10)).toBeUndefined()
   })
 })

--- a/test/core/state/ExecutionContext.test.ts
+++ b/test/core/state/ExecutionContext.test.ts
@@ -343,23 +343,6 @@ describe('ExecutionContext', () => {
     })
   })
 
-  describe('findStatementIndicesByLine', () => {
-    it('should return indices for a mapped line number', () => {
-      const ctx = new ExecutionContext(createConfig())
-      ctx.labelMap.set(10, [0, 1])
-      ctx.labelMap.set(20, [2])
-
-      expect(ctx.findStatementIndicesByLine(10)).toEqual([0, 1])
-      expect(ctx.findStatementIndicesByLine(20)).toEqual([2])
-    })
-
-    it('should return empty array for unmapped line number', () => {
-      const ctx = new ExecutionContext(createConfig())
-
-      expect(ctx.findStatementIndicesByLine(999)).toEqual([])
-    })
-  })
-
   describe('findStatementIndexByLine', () => {
     it('should return first index for a mapped line number', () => {
       const ctx = new ExecutionContext(createConfig())


### PR DESCRIPTION
## Summary
- Removes 3 dead functions: `findStatementIndicesByLine()` (plural) from ExecutionContext.ts and statement-expander.ts, plus `getFirstStatementIndexByLine()` from statement-expander.ts
- These are leftovers never called in production — the singular `findStatementIndexByLine()` is the standard method used by all GOTO/GOSUB/ON/RETURN routing
- Removes 10 associated tests (no longer testing deleted functions)
- Net -115 lines. Pure refactor, no behavior changes.

## Test plan
- [x] ExecutionContext.test.ts: 42/42 pass
- [x] statement-expander.test.ts: 20/20 pass
- [x] Type-check: clean
- [x] ESLint: clean
- [ ] CI: pending

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)