### PR TITLE
test: resolve #883 - add tests for musicValidation.ts and noteFrequency.ts

### DIFF
--- a/test/sound/musicValidation.test.ts
+++ b/test/sound/musicValidation.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Unit tests for validateMusicString()
+ *
+ * Directly tests the PLAY command music string validator from musicValidation.ts.
+ * Covers all validation rules: invalid characters, command range checks,
+ * sharp note validation, rest/note parsing, and edge cases.
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import { validateMusicString } from '@/core/sound/musicValidation'
+
+// ============================================================================
+// Valid strings - should not throw
+// ============================================================================
+
+describe('validateMusicString - valid strings', () => {
+  test('accepts empty string', () => {
+    expect(() => validateMusicString('')).not.toThrow()
+  })
+
+  test('accepts whitespace-only string', () => {
+    expect(() => validateMusicString('   ')).not.toThrow()
+  })
+
+  test('accepts single natural note', () => {
+    expect(() => validateMusicString('C')).not.toThrow()
+  })
+
+  test('accepts all natural notes', () => {
+    expect(() => validateMusicString('CDEFGAB')).not.toThrow()
+  })
+
+  test('accepts notes with length codes', () => {
+    expect(() => validateMusicString('C1D2E4G8')).not.toThrow()
+  })
+
+  test('accepts rest without length', () => {
+    expect(() => validateMusicString('R')).not.toThrow()
+  })
+
+  test('accepts rest with length codes', () => {
+    expect(() => validateMusicString('R1R4R9')).not.toThrow()
+  })
+
+  test('accepts spaces between notes', () => {
+    expect(() => validateMusicString('C D E F G')).not.toThrow()
+  })
+
+  test('accepts colon channel separator', () => {
+    expect(() => validateMusicString('C:E:G')).not.toThrow()
+  })
+
+  test('accepts sharp before valid notes', () => {
+    expect(() => validateMusicString('#C#D#E#F#G#A#B')).not.toThrow()
+  })
+
+  test('accepts sharp note with length code', () => {
+    expect(() => validateMusicString('#C4')).not.toThrow()
+  })
+
+  test('accepts all commands in sequence', () => {
+    expect(() => validateMusicString('T3O2Y2M0V15CDEFG')).not.toThrow()
+  })
+
+  test('normalizes lowercase to uppercase', () => {
+    expect(() => validateMusicString('cde')).not.toThrow()
+  })
+
+  test('accepts note after command', () => {
+    expect(() => validateMusicString('T4C')).not.toThrow()
+    expect(() => validateMusicString('O3G')).not.toThrow()
+    expect(() => validateMusicString('V10A')).not.toThrow()
+  })
+})
+
+// ============================================================================
+// Invalid characters
+// ============================================================================
+
+describe('validateMusicString - invalid characters', () => {
+  test('rejects letter Z', () => {
+    expect(() => validateMusicString('AZ')).toThrow(
+      "Invalid character 'Z' in PLAY string at position 2"
+    )
+  })
+
+  test('rejects letter X', () => {
+    expect(() => validateMusicString('CX')).toThrow(
+      "Invalid character 'X' in PLAY string at position 2"
+    )
+  })
+
+  test('rejects letter P', () => {
+    expect(() => validateMusicString('P')).toThrow(
+      "Invalid character 'P' in PLAY string at position 1"
+    )
+  })
+
+  test('rejects special character @', () => {
+    expect(() => validateMusicString('C@D')).toThrow(
+      "Invalid character '@' in PLAY string at position 2"
+    )
+  })
+
+  test('rejects special character !', () => {
+    expect(() => validateMusicString('!')).toThrow(
+      "Invalid character '!' in PLAY string at position 1"
+    )
+  })
+
+  test('rejects special character -', () => {
+    expect(() => validateMusicString('C-D')).toThrow(
+      "Invalid character '-' in PLAY string at position 2"
+    )
+  })
+
+  test('rejects lowercase invalid character (normalized before check)', () => {
+    expect(() => validateMusicString('aaaz')).toThrow(
+      "Invalid character 'Z' in PLAY string at position 4"
+    )
+  })
+})
+
+// ============================================================================
+// Tempo validation (T1-T8)
+// ============================================================================
+
+describe('validateMusicString - tempo (T)', () => {
+  test('accepts lower boundary T1', () => {
+    expect(() => validateMusicString('T1C')).not.toThrow()
+  })
+
+  test('accepts upper boundary T8', () => {
+    expect(() => validateMusicString('T8C')).not.toThrow()
+  })
+
+  test('accepts mid-range T4', () => {
+    expect(() => validateMusicString('T4C')).not.toThrow()
+  })
+
+  test('rejects T0 (below range)', () => {
+    expect(() => validateMusicString('T0C')).toThrow('Invalid tempo T0: must be 1-8')
+  })
+
+  test('rejects T9 (above range)', () => {
+    expect(() => validateMusicString('T9C')).toThrow('Invalid tempo T9: must be 1-8')
+  })
+
+  test('rejects T99 (well above range)', () => {
+    expect(() => validateMusicString('T99C')).toThrow('Invalid tempo T99: must be 1-8')
+  })
+
+  test('rejects T without following digit', () => {
+    expect(() => validateMusicString('TC')).toThrow('Tempo value required after T at position 2')
+  })
+
+  test('rejects T at end of string', () => {
+    expect(() => validateMusicString('CT')).toThrow('Tempo value required after T at position 3')
+  })
+
+  test('accepts multi-digit tempo T12 parsed as value 12', () => {
+    // T12 parses as value 12 (two digits), which is > 8
+    expect(() => validateMusicString('T12C')).toThrow('Invalid tempo T12: must be 1-8')
+  })
+})
+
+// ============================================================================
+// Octave validation (O0-O5)
+// ============================================================================
+
+describe('validateMusicString - octave (O)', () => {
+  test('accepts lower boundary O0', () => {
+    expect(() => validateMusicString('O0C')).not.toThrow()
+  })
+
+  test('accepts upper boundary O5', () => {
+    expect(() => validateMusicString('O5C')).not.toThrow()
+  })
+
+  test('accepts mid-range O2', () => {
+    expect(() => validateMusicString('O2C')).not.toThrow()
+  })
+
+  test('rejects O6 (above range)', () => {
+    expect(() => validateMusicString('O6C')).toThrow('Invalid octave O6: must be 0-5')
+  })
+
+  test('rejects O9 (well above range)', () => {
+    expect(() => validateMusicString('O9C')).toThrow('Invalid octave O9: must be 0-5')
+  })
+
+  test('rejects O without following digit', () => {
+    expect(() => validateMusicString('OC')).toThrow('Octave value required after O at position 2')
+  })
+
+  test('rejects O at end of string', () => {
+    expect(() => validateMusicString('CO')).toThrow('Octave value required after O at position 3')
+  })
+})
+
+// ============================================================================
+// Duty validation (Y0-Y3)
+// ============================================================================
+
+describe('validateMusicString - duty (Y)', () => {
+  test('accepts lower boundary Y0', () => {
+    expect(() => validateMusicString('Y0C')).not.toThrow()
+  })
+
+  test('accepts upper boundary Y3', () => {
+    expect(() => validateMusicString('Y3C')).not.toThrow()
+  })
+
+  test('rejects Y4 (above range)', () => {
+    expect(() => validateMusicString('Y4C')).toThrow('Invalid duty Y4: must be 0-3')
+  })
+
+  test('rejects Y9 (well above range)', () => {
+    expect(() => validateMusicString('Y9C')).toThrow('Invalid duty Y9: must be 0-3')
+  })
+
+  test('rejects Y without following digit', () => {
+    expect(() => validateMusicString('YC')).toThrow('Duty value required after Y at position 2')
+  })
+
+  test('rejects Y at end of string', () => {
+    expect(() => validateMusicString('CY')).toThrow('Duty value required after Y at position 3')
+  })
+})
+
+// ============================================================================
+// Envelope validation (M0-M1)
+// ============================================================================
+
+describe('validateMusicString - envelope (M)', () => {
+  test('accepts M0', () => {
+    expect(() => validateMusicString('M0C')).not.toThrow()
+  })
+
+  test('accepts M1', () => {
+    expect(() => validateMusicString('M1C')).not.toThrow()
+  })
+
+  test('rejects M2 (above range)', () => {
+    expect(() => validateMusicString('M2C')).toThrow('Invalid envelope M2: must be 0-1')
+  })
+
+  test('rejects M9 (well above range)', () => {
+    expect(() => validateMusicString('M9C')).toThrow('Invalid envelope M9: must be 0-1')
+  })
+
+  test('rejects M without following digit', () => {
+    expect(() => validateMusicString('MC')).toThrow('Envelope value required after M at position 2')
+  })
+
+  test('rejects M at end of string', () => {
+    expect(() => validateMusicString('CM')).toThrow('Envelope value required after M at position 3')
+  })
+})
+
+// ============================================================================
+// Volume validation (V0-V15)
+// ============================================================================
+
+describe('validateMusicString - volume (V)', () => {
+  test('accepts lower boundary V0', () => {
+    expect(() => validateMusicString('V0C')).not.toThrow()
+  })
+
+  test('accepts upper boundary V15', () => {
+    expect(() => validateMusicString('V15C')).not.toThrow()
+  })
+
+  test('accepts mid-range V7', () => {
+    expect(() => validateMusicString('V7C')).not.toThrow()
+  })
+
+  test('rejects V16 (above range)', () => {
+    expect(() => validateMusicString('V16C')).toThrow('Invalid volume V16: must be 0-15')
+  })
+
+  test('rejects V99 (well above range)', () => {
+    expect(() => validateMusicString('V99C')).toThrow('Invalid volume V99: must be 0-15')
+  })
+
+  test('rejects V without following digit', () => {
+    expect(() => validateMusicString('VC')).toThrow('Volume value required after V at position 2')
+  })
+
+  test('rejects V at end of string', () => {
+    expect(() => validateMusicString('CV')).toThrow('Volume value required after V at position 3')
+  })
+})
+
+// ============================================================================
+// Sharp note validation
+// ============================================================================
+
+describe('validateMusicString - sharp (#)', () => {
+  test('accepts #C', () => {
+    expect(() => validateMusicString('#C')).not.toThrow()
+  })
+
+  test('accepts #D', () => {
+    expect(() => validateMusicString('#D')).not.toThrow()
+  })
+
+  test('accepts #E (E sharp = F)', () => {
+    expect(() => validateMusicString('#E')).not.toThrow()
+  })
+
+  test('accepts #F', () => {
+    expect(() => validateMusicString('#F')).not.toThrow()
+  })
+
+  test('accepts #G', () => {
+    expect(() => validateMusicString('#G')).not.toThrow()
+  })
+
+  test('accepts #A', () => {
+    expect(() => validateMusicString('#A')).not.toThrow()
+  })
+
+  test('accepts #B (B sharp = C)', () => {
+    expect(() => validateMusicString('#B')).not.toThrow()
+  })
+
+  test('rejects #H (invalid note)', () => {
+    expect(() => validateMusicString('#H')).toThrow(
+      'Invalid sharp #H at position 1: # must be followed by a note (C, D, E, F, G, A, B)'
+    )
+  })
+
+  test('rejects #0 (digit after sharp)', () => {
+    expect(() => validateMusicString('#0')).toThrow(
+      'Invalid sharp #0 at position 1: # must be followed by a note (C, D, E, F, G, A, B)'
+    )
+  })
+
+  test('rejects # at end of string', () => {
+    expect(() => validateMusicString('C#')).toThrow('Sharp (#) at position 2 must be followed by a note')
+  })
+
+  test('accepts sharp note followed by length digit', () => {
+    expect(() => validateMusicString('#C4')).not.toThrow()
+  })
+
+  test('accepts sharp note at end of string after note', () => {
+    expect(() => validateMusicString('C#C')).not.toThrow()
+  })
+})
+
+// ============================================================================
+// Rest validation
+// ============================================================================
+
+describe('validateMusicString - rest (R)', () => {
+  test('accepts R without length', () => {
+    expect(() => validateMusicString('R')).not.toThrow()
+  })
+
+  test('accepts R with length 1', () => {
+    expect(() => validateMusicString('R1')).not.toThrow()
+  })
+
+  test('accepts R with length 9', () => {
+    expect(() => validateMusicString('R9')).not.toThrow()
+  })
+
+  test('accepts multiple rests', () => {
+    expect(() => validateMusicString('RRR')).not.toThrow()
+  })
+})
+
+// ============================================================================
+// Natural notes with optional length
+// ============================================================================
+
+describe('validateMusicString - natural notes', () => {
+  for (const note of ['C', 'D', 'E', 'F', 'G', 'A', 'B'] as const) {
+    test(`accepts note ${note} without length`, () => {
+      expect(() => validateMusicString(note)).not.toThrow()
+    })
+
+    test(`accepts note ${note} with length 1`, () => {
+      expect(() => validateMusicString(`${note}1`)).not.toThrow()
+    })
+
+    test(`accepts note ${note} with length 9`, () => {
+      expect(() => validateMusicString(`${note}9`)).not.toThrow()
+    })
+  }
+})
+
+// ============================================================================
+// Channel separator (colon)
+// ============================================================================
+
+describe('validateMusicString - channel separator', () => {
+  test('accepts colon between notes', () => {
+    expect(() => validateMusicString('C:E:G')).not.toThrow()
+  })
+
+  test('accepts multiple colons', () => {
+    expect(() => validateMusicString(':::')).not.toThrow()
+  })
+
+  test('accepts colon at start', () => {
+    expect(() => validateMusicString(':CDE')).not.toThrow()
+  })
+
+  test('accepts colon at end', () => {
+    expect(() => validateMusicString('CDE:')).not.toThrow()
+  })
+})
+
+// ============================================================================
+// Standalone digits (must not appear outside commands/notes)
+// ============================================================================
+
+describe('validateMusicString - standalone digits', () => {
+  test('rejects standalone digit at start', () => {
+    expect(() => validateMusicString('5C')).toThrow(
+      "Unexpected digit '5' at position 0: digits must follow a command or note"
+    )
+  })
+
+  test('rejects standalone digit after rest (no double length)', () => {
+    // R1 consumes 1 as length, then 5 is standalone
+    expect(() => validateMusicString('R15C')).toThrow(
+      "Unexpected digit '5' at position 2: digits must follow a command or note"
+    )
+  })
+
+  test('rejects standalone digit after sharp note with length', () => {
+    // #C4 consumes #C then 4 as length, then 5 is standalone
+    expect(() => validateMusicString('#C45D')).toThrow(
+      "Unexpected digit '5' at position 3: digits must follow a command or note"
+    )
+  })
+})
+
+// ============================================================================
+// Complex / real-world strings
+// ============================================================================
+
+describe('validateMusicString - complex strings', () => {
+  test('accepts typical song fragment', () => {
+    expect(() => validateMusicString('T4O3C4D4E4F4G4A4B4')).not.toThrow()
+  })
+
+  test('accepts song with sharps and rests', () => {
+    expect(() => validateMusicString('T4O3#C4D4R4E4#F4G4')).not.toThrow()
+  })
+
+  test('accepts multi-channel song', () => {
+    expect(() => validateMusicString('T4O3C4E4G4:O3C4E4G4:O3C4E4G4')).not.toThrow()
+  })
+
+  test('accepts all settings before notes', () => {
+    expect(() =>
+      validateMusicString('T4O2Y1M0V12C D E F G A B R')
+    ).not.toThrow()
+  })
+})

--- a/test/sound/noteFrequency.test.ts
+++ b/test/sound/noteFrequency.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for calculateNoteFrequency() and NOTE_SEMITONES
+ *
+ * Directly tests the note-to-frequency conversion from noteFrequency.ts.
+ * Covers known reference frequencies, all natural notes, sharp variants,
+ * octave boundaries, and error handling for invalid note names.
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import { calculateNoteFrequency, NOTE_SEMITONES } from '@/core/sound/noteFrequency'
+
+// ============================================================================
+// NOTE_SEMITONES constant
+// ============================================================================
+
+describe('NOTE_SEMITONES', () => {
+  test('maps C to 0', () => {
+    expect(NOTE_SEMITONES['C']).toEqual(0)
+  })
+
+  test('maps D to 2', () => {
+    expect(NOTE_SEMITONES['D']).toEqual(2)
+  })
+
+  test('maps E to 4', () => {
+    expect(NOTE_SEMITONES['E']).toEqual(4)
+  })
+
+  test('maps F to 5', () => {
+    expect(NOTE_SEMITONES['F']).toEqual(5)
+  })
+
+  test('maps G to 7', () => {
+    expect(NOTE_SEMITONES['G']).toEqual(7)
+  })
+
+  test('maps A to 9', () => {
+    expect(NOTE_SEMITONES['A']).toEqual(9)
+  })
+
+  test('maps B to 11', () => {
+    expect(NOTE_SEMITONES['B']).toEqual(11)
+  })
+
+  test('has exactly 7 entries', () => {
+    expect(Object.keys(NOTE_SEMITONES).length).toEqual(7)
+  })
+
+  test('contains all natural note names', () => {
+    const notes = ['C', 'D', 'E', 'F', 'G', 'A', 'B']
+    for (const note of notes) {
+      expect(NOTE_SEMITONES[note]).toBeDefined()
+    }
+  })
+})
+
+// ============================================================================
+// Known reference frequencies (A4 = 440 Hz tuning)
+// ============================================================================
+
+describe('calculateNoteFrequency - reference frequencies', () => {
+  test('A4 (F-BASIC octave 2, no sharp) = 440 Hz', () => {
+    // F-BASIC octave 2 = standard octave 4, A is semitone 9
+    // midiNote = (2+2)*12 + 9 + 12 = 69
+    // 440 * 2^((69-69)/12) = 440
+    const result = calculateNoteFrequency('A', 2, false)
+    expect(result).toBeCloseTo(440, 2)
+  })
+
+  test('C4 (F-BASIC octave 2) = 261.63 Hz', () => {
+    // midiNote = (2+2)*12 + 0 + 12 = 60
+    // 440 * 2^((60-69)/12) = 261.63
+    const result = calculateNoteFrequency('C', 2, false)
+    expect(result).toBeCloseTo(261.63, 2)
+  })
+
+  test('A5 (F-BASIC octave 3) = 880 Hz', () => {
+    // midiNote = (3+2)*12 + 9 + 12 = 81
+    // 440 * 2^((81-69)/12) = 880
+    const result = calculateNoteFrequency('A', 3, false)
+    expect(result).toBeCloseTo(880, 2)
+  })
+
+  test('C5 (F-BASIC octave 3) = 523.25 Hz', () => {
+    // midiNote = (3+2)*12 + 0 + 12 = 72
+    // 440 * 2^((72-69)/12) = 523.25
+    const result = calculateNoteFrequency('C', 3, false)
+    expect(result).toBeCloseTo(523.25, 2)
+  })
+})
+
+// ============================================================================
+// All 7 natural notes in F-BASIC octave 2 (standard octave 4)
+// ============================================================================
+
+describe('calculateNoteFrequency - all natural notes in octave 2', () => {
+  test('C = 261.63 Hz', () => {
+    expect(calculateNoteFrequency('C', 2, false)).toBeCloseTo(261.63, 2)
+  })
+
+  test('D = 293.66 Hz', () => {
+    expect(calculateNoteFrequency('D', 2, false)).toBeCloseTo(293.66, 2)
+  })
+
+  test('E = 329.63 Hz', () => {
+    expect(calculateNoteFrequency('E', 2, false)).toBeCloseTo(329.63, 2)
+  })
+
+  test('F = 349.23 Hz', () => {
+    expect(calculateNoteFrequency('F', 2, false)).toBeCloseTo(349.23, 2)
+  })
+
+  test('G = 392.00 Hz', () => {
+    expect(calculateNoteFrequency('G', 2, false)).toBeCloseTo(392.0, 2)
+  })
+
+  test('A = 440.00 Hz', () => {
+    expect(calculateNoteFrequency('A', 2, false)).toBeCloseTo(440.0, 2)
+  })
+
+  test('B = 493.88 Hz', () => {
+    expect(calculateNoteFrequency('B', 2, false)).toBeCloseTo(493.88, 2)
+  })
+})
+
+// ============================================================================
+// Sharp variants
+// ============================================================================
+
+describe('calculateNoteFrequency - sharp notes', () => {
+  test('C#4 (F-BASIC octave 2) = 277.18 Hz', () => {
+    // midiNote = (2+2)*12 + 0 + 1 + 12 = 61
+    expect(calculateNoteFrequency('C', 2, true)).toBeCloseTo(277.18, 2)
+  })
+
+  test('D#4 (F-BASIC octave 2) = 311.13 Hz', () => {
+    expect(calculateNoteFrequency('D', 2, true)).toBeCloseTo(311.13, 2)
+  })
+
+  test('F#4 (F-BASIC octave 2) = 369.99 Hz', () => {
+    expect(calculateNoteFrequency('F', 2, true)).toBeCloseTo(369.99, 2)
+  })
+
+  test('G#4 (F-BASIC octave 2) = 415.30 Hz', () => {
+    expect(calculateNoteFrequency('G', 2, true)).toBeCloseTo(415.3, 2)
+  })
+
+  test('A#4 (F-BASIC octave 2) = 466.16 Hz', () => {
+    expect(calculateNoteFrequency('A', 2, true)).toBeCloseTo(466.16, 2)
+  })
+
+  test('sharp is exactly one semitone above natural', () => {
+    const naturalC = calculateNoteFrequency('C', 2, false)
+    const sharpC = calculateNoteFrequency('C', 2, true)
+    const ratio = sharpC / naturalC
+    // One semitone = 2^(1/12) ≈ 1.05946
+    expect(ratio).toBeCloseTo(Math.pow(2, 1 / 12), 4)
+  })
+})
+
+// ============================================================================
+// Octave boundaries
+// ============================================================================
+
+describe('calculateNoteFrequency - octave boundaries', () => {
+  test('F-BASIC octave 0 (standard octave 2) - low C = 65.41 Hz', () => {
+    // midiNote = (0+2)*12 + 0 + 12 = 36
+    expect(calculateNoteFrequency('C', 0, false)).toBeCloseTo(65.41, 2)
+  })
+
+  test('F-BASIC octave 0 - A = 110 Hz', () => {
+    // midiNote = (0+2)*12 + 9 + 12 = 45
+    expect(calculateNoteFrequency('A', 0, false)).toBeCloseTo(110.0, 2)
+  })
+
+  test('F-BASIC octave 5 (standard octave 7) - C = 2093.00 Hz', () => {
+    // midiNote = (5+2)*12 + 0 + 12 = 96
+    expect(calculateNoteFrequency('C', 5, false)).toBeCloseTo(2093.0, 0)
+  })
+
+  test('F-BASIC octave 5 - A = 3520.00 Hz', () => {
+    // midiNote = (5+2)*12 + 9 + 12 = 105
+    // 440 * 2^((105-69)/12) = 440 * 2^3 = 3520
+    expect(calculateNoteFrequency('A', 5, false)).toBeCloseTo(3520.0, 0)
+  })
+
+  test('octave doubles frequency for same note', () => {
+    const cOctave2 = calculateNoteFrequency('C', 2, false)
+    const cOctave3 = calculateNoteFrequency('C', 3, false)
+    expect(cOctave3 / cOctave2).toBeCloseTo(2, 4)
+  })
+})
+
+// ============================================================================
+// Error handling
+// ============================================================================
+
+describe('calculateNoteFrequency - invalid note name', () => {
+  test('throws for note H', () => {
+    expect(() => calculateNoteFrequency('H', 2, false)).toThrow('Invalid note name: H')
+  })
+
+  test('throws for note Z', () => {
+    expect(() => calculateNoteFrequency('Z', 2, false)).toThrow('Invalid note name: Z')
+  })
+
+  test('throws for empty string note', () => {
+    expect(() => calculateNoteFrequency('', 2, false)).toThrow('Invalid note name: ')
+  })
+
+  test('throws for lowercase c', () => {
+    expect(() => calculateNoteFrequency('c', 2, false)).toThrow('Invalid note name: c')
+  })
+
+  test('throws for number as note', () => {
+    expect(() => calculateNoteFrequency('3', 2, false)).toThrow('Invalid note name: 3')
+  })
+})


### PR DESCRIPTION
## Summary
- Add 104 unit tests for `validateMusicString()` covering valid strings, invalid characters, tempo/octave/duty/envelope/volume boundaries, sharp notes, rests, natural notes, channel separators, and complex multi-channel strings
- Add 36 unit tests for `calculateNoteFrequency()` covering NOTE_SEMITONES mapping, reference frequencies (A4=440Hz, C4=261.63Hz), all natural notes, sharp variants, octave boundaries, and error handling
- All 140 new tests pass, zero regressions

## Test plan
- [x] `pnpm test:run test/sound/` — 247/247 pass
- [x] `pnpm type-check` — clean
- [x] `pnpm exec eslint test/sound/musicValidation.test.ts test/sound/noteFrequency.test.ts` — clean

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)