### PR TITLE
feat: resolve #892 - REPL input component below CRT screen

### DIFF
--- a/src/features/ide/components/ReplInput.vue
+++ b/src/features/ide/components/ReplInput.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { nextTick, ref, useTemplateRef, watch } from 'vue'
+
+/**
+ * ReplInput component - Single-line text input for REPL mode.
+ * Hidden by default; appears when active prop is true.
+ * Auto-focuses when activated, submits on Enter key.
+ */
+defineOptions({
+  name: 'ReplInput',
+})
+
+const props = withDefaults(
+  defineProps<{
+    active: boolean
+    disabled: boolean
+  }>(),
+  {
+    active: false,
+    disabled: false,
+  },
+)
+
+const emit = defineEmits<{
+  execute: [statement: string]
+}>()
+
+const inputValue = ref('')
+const inputRef = useTemplateRef<HTMLInputElement>('inputRef')
+
+watch(
+  () => props.active,
+  async (isActive) => {
+    if (isActive) {
+      await nextTick()
+      inputRef.value?.focus()
+    }
+  },
+)
+
+function onKeyDown(event: KeyboardEvent) {
+  if (event.key !== 'Enter') return
+  if (props.disabled) return
+
+  const trimmed = inputValue.value.trim()
+  if (!trimmed) return
+
+  emit('execute', trimmed)
+  inputValue.value = ''
+}
+</script>
+
+<template>
+  <div v-if="active" class="repl-input-container">
+    <span class="repl-input-prompt">&gt;</span>
+    <input
+      ref="inputRef"
+      v-model="inputValue"
+      type="text"
+      class="repl-input-field"
+      :placeholder="'Enter command...'"
+      :disabled="disabled"
+      @keydown="onKeyDown"
+    />
+  </div>
+</template>
+
+<style scoped>
+.repl-input-container {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 0.75rem;
+  border-top: 1px solid var(--game-surface-border);
+  background: var(--game-surface-bg-gradient);
+  flex-shrink: 0;
+}
+
+.repl-input-prompt {
+  font-family: monospace;
+  font-size: 0.875rem;
+  color: var(--game-surface-border);
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.repl-input-field {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: monospace;
+  font-size: 0.875rem;
+  color: inherit;
+  padding: 0.125rem 0;
+  min-width: 0;
+}
+
+.repl-input-field::placeholder {
+  color: var(--game-surface-border);
+  opacity: 0.6;
+}
+</style>

--- a/src/features/ide/components/ScreenTab.vue
+++ b/src/features/ide/components/ScreenTab.vue
@@ -8,6 +8,7 @@ import { provideScreenZoom } from '@/features/ide/composables/useScreenZoom'
 import { GameButton, GameButtonGroup, GameIcon, GameTabPane } from '@/shared/components/ui'
 
 import ErrorPanel from './ErrorPanel.vue'
+import ReplInput from './ReplInput.vue'
 import Screen from './Screen.vue'
 
 /**
@@ -98,6 +99,9 @@ const isReducedMotion = computed(() => prefersReducedMotion.value)
 
     <div class="tab-content">
       <Screen />
+    </div>
+    <div class="repl-input-wrapper">
+      <ReplInput :active="false" :disabled="false" @execute="() => {}" />
     </div>
     <div class="tab-content-footer">
       <ErrorPanel :errors="errors" />

--- a/test/features/ide/components/ReplInput.test.ts
+++ b/test/features/ide/components/ReplInput.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import ReplInput from '@/features/ide/components/ReplInput.vue'
+
+describe('ReplInput', () => {
+  function mountReplInput(props: {
+    active?: boolean
+    disabled?: boolean
+  } = {}) {
+    return mount(ReplInput, {
+      props: {
+        active: props.active ?? false,
+        disabled: props.disabled ?? false,
+      },
+      attachTo: document.body,
+    })
+  }
+
+  it('is hidden when active is false (default)', () => {
+    const wrapper = mountReplInput()
+
+    const container = wrapper.find('.repl-input-container')
+    expect(container.exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('is hidden when active prop is explicitly false', () => {
+    const wrapper = mountReplInput({ active: false })
+
+    const container = wrapper.find('.repl-input-container')
+    expect(container.exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('is visible when active prop is true', () => {
+    const wrapper = mountReplInput({ active: true })
+
+    const container = wrapper.find('.repl-input-container')
+    expect(container.exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders the ">" prompt prefix', () => {
+    const wrapper = mountReplInput({ active: true })
+
+    const prompt = wrapper.find('.repl-input-prompt')
+    expect(prompt.exists()).toBe(true)
+    expect(prompt.text()).toEqual('>')
+    wrapper.unmount()
+  })
+
+  it('renders a text input with placeholder', () => {
+    const wrapper = mountReplInput({ active: true })
+
+    const input = wrapper.find('input.repl-input-field')
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('placeholder')).toEqual('Enter command...')
+    wrapper.unmount()
+  })
+
+  it('input is not disabled by default', () => {
+    const wrapper = mountReplInput({ active: true })
+
+    const input = wrapper.find('input.repl-input-field')
+    expect(input.attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('input is disabled when disabled prop is true', () => {
+    const wrapper = mountReplInput({ active: true, disabled: true })
+
+    const input = wrapper.find('input.repl-input-field')
+    expect(input.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('emits execute with trimmed value on Enter key', async () => {
+    const wrapper = mountReplInput({ active: true })
+
+    const input = wrapper.find('input.repl-input-field')
+    await input.setValue('PRINT "Hello"')
+    await input.trigger('keydown', { key: 'Enter' })
+
+    const emitted = wrapper.emitted('execute')
+    expect(emitted).toHaveLength(1)
+    expect(emitted![0]).toEqual(['PRINT "Hello"'])
+    wrapper.unmount()
+  })
+
+  it('clears input after emitting execute on Enter', async () => {
+    const wrapper = mountReplInput({ active: true })
+
+    const input = wrapper.find('input.repl-input-field')
+    await input.setValue('PRINT "Hello"')
+    await input.trigger('keydown', { key: 'Enter' })
+
+    expect((input.element as HTMLInputElement).value).toEqual('')
+    wrapper.unmount()
+  })
+
+  it('does not emit execute on non-Enter keys', async () => {
+    const wrapper = mountReplInput({ active: true })
+
+    const input = wrapper.find('input.repl-input-field')
+    await input.setValue('PRINT "Hello"')
+    await input.trigger('keydown', { key: 'a' })
+    await input.trigger('keydown', { key: 'Escape' })
+
+    expect(wrapper.emitted('execute')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('does not emit execute when input is empty on Enter', async () => {
+    const wrapper = mountReplInput({ active: true })
+
+    const input = wrapper.find('input.repl-input-field')
+    await input.trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.emitted('execute')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('trims whitespace before emitting execute', async () => {
+    const wrapper = mountReplInput({ active: true })
+
+    const input = wrapper.find('input.repl-input-field')
+    await input.setValue('  PRINT "Hello"  ')
+    await input.trigger('keydown', { key: 'Enter' })
+
+    const emitted = wrapper.emitted('execute')
+    expect(emitted).toHaveLength(1)
+    expect(emitted![0]).toEqual(['PRINT "Hello"'])
+    wrapper.unmount()
+  })
+
+  it('auto-focuses input when active becomes true', async () => {
+    const focusSpy = vi.spyOn(HTMLInputElement.prototype, 'focus')
+
+    const wrapper = mountReplInput({ active: false })
+
+    await wrapper.setProps({ active: true })
+    await nextTick()
+
+    const input = wrapper.find('input.repl-input-field')
+    expect(input.exists()).toBe(true)
+    expect(focusSpy).toHaveBeenCalled()
+
+    focusSpy.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('does not emit execute when disabled', async () => {
+    const wrapper = mountReplInput({ active: true, disabled: true })
+
+    const input = wrapper.find('input.repl-input-field')
+    await input.setValue('PRINT "Hello"')
+    await input.trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.emitted('execute')).toBeUndefined()
+    wrapper.unmount()
+  })
+})

--- a/test/features/ide/components/ScreenTab.test.ts
+++ b/test/features/ide/components/ScreenTab.test.ts
@@ -163,4 +163,44 @@ describe('ScreenTab', () => {
     expect(mockToggleFilter).not.toHaveBeenCalled()
     wrapper.unmount()
   })
+
+  it('renders ReplInput between tab-content and tab-content-footer', () => {
+    const wrapper = mountScreenTab()
+
+    const tabContent = wrapper.find('.tab-content')
+    const replInput = wrapper.findComponent({ name: 'ReplInput' })
+    const footer = wrapper.find('.tab-content-footer')
+
+    expect(tabContent.exists()).toBe(true)
+    expect(replInput.exists()).toBe(true)
+    expect(footer.exists()).toBe(true)
+
+    // Verify DOM order: tab-content before ReplInput before footer
+    const children = wrapper.element.children
+    let foundTabContent = false
+    let foundReplInput = false
+    for (let i = 0; i < children.length; i++) {
+      const el = children[i] as HTMLElement
+      if (el.classList.contains('tab-content')) foundTabContent = true
+      if (foundTabContent && !foundReplInput && el.classList.contains('repl-input-wrapper')) {
+        foundReplInput = true
+      }
+      if (foundReplInput && el.classList.contains('tab-content-footer')) {
+        // Correct order found
+        expect(true).toBe(true)
+        return
+      }
+    }
+    // Should not reach here
+    expect.fail('ReplInput not found between tab-content and tab-content-footer')
+    wrapper.unmount()
+  })
+
+  it('passes active=false to ReplInput by default', () => {
+    const wrapper = mountScreenTab()
+
+    const replInput = wrapper.findComponent({ name: 'ReplInput' })
+    expect(replInput.props('active')).toBe(false)
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes #892 — Part of REPL mode (#889)

## Changes
- **ReplInput.vue** (NEW): Text input component with `active`/`disabled` props, `>` prefix, auto-focus on activation, Enter-to-submit, monospace styling
- **ScreenTab.vue**: Import and place `ReplInput` between screen content and error panel (`active=false` hardcoded — state wiring in #893)

## Test plan
- [x] 14 new ReplInput tests (visibility, prompt, submit, clear, auto-focus, disabled guard, trim, empty rejection)
- [x] 2 new ScreenTab tests (ReplInput placement, default active=false)
- [x] 32/32 component tests pass
- [x] Type-check clean, ESLint clean

Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)