### PR TITLE
feat: resolve #893 - REPL integration, command history, RUN/CLS support

### DIFF
--- a/src/features/ide/components/ReplInput.vue
+++ b/src/features/ide/components/ReplInput.vue
@@ -5,6 +5,7 @@ import { nextTick, ref, useTemplateRef, watch } from 'vue'
  * ReplInput component - Single-line text input for REPL mode.
  * Hidden by default; appears when active prop is true.
  * Auto-focuses when activated, submits on Enter key.
+ * Supports command history navigation via Up/Down arrow keys.
  */
 defineOptions({
   name: 'ReplInput',
@@ -14,19 +15,28 @@ const props = withDefaults(
   defineProps<{
     active: boolean
     disabled: boolean
+    commandHistory: string[]
+    historyIndex: number
   }>(),
   {
     active: false,
     disabled: false,
+    commandHistory: () => [],
+    historyIndex: -1,
   },
 )
 
 const emit = defineEmits<{
   execute: [statement: string]
+  navigateHistory: [index: number]
 }>()
 
 const inputValue = ref('')
 const inputRef = useTemplateRef<HTMLInputElement>('inputRef')
+
+// Track whether user is actively navigating history
+// (to avoid clobbering input while they type)
+const isNavigatingHistory = ref(false)
 
 watch(
   () => props.active,
@@ -38,15 +48,77 @@ watch(
   },
 )
 
+// When history index changes externally (e.g., from composable), update input
+watch(
+  () => props.historyIndex,
+  (newIndex) => {
+    if (newIndex < 0 || !isNavigatingHistory.value) return
+    const command = props.commandHistory[newIndex]
+    if (command !== undefined) {
+      inputValue.value = command
+    }
+  },
+)
+
 function onKeyDown(event: KeyboardEvent) {
-  if (event.key !== 'Enter') return
   if (props.disabled) return
 
-  const trimmed = inputValue.value.trim()
-  if (!trimmed) return
+  if (event.key === 'Enter') {
+    isNavigatingHistory.value = false
+    const trimmed = inputValue.value.trim()
+    if (!trimmed) return
 
-  emit('execute', trimmed)
-  inputValue.value = ''
+    emit('execute', trimmed)
+    inputValue.value = ''
+    return
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    handleHistoryUp()
+    return
+  }
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    handleHistoryDown()
+    return
+  }
+
+  // Any other key resets history navigation
+  isNavigatingHistory.value = false
+}
+
+function handleHistoryUp(): void {
+  const history = props.commandHistory
+  if (history.length === 0) return
+
+  let newIndex: number
+  if (!isNavigatingHistory.value) {
+    // Starting fresh navigation: go to last entry
+    newIndex = history.length - 1
+    isNavigatingHistory.value = true
+  } else {
+    // Already navigating: go one step back
+    newIndex = Math.max(0, props.historyIndex - 1)
+  }
+
+  emit('navigateHistory', newIndex)
+}
+
+function handleHistoryDown(): void {
+  if (!isNavigatingHistory.value) return
+
+  const history = props.commandHistory
+  if (props.historyIndex >= history.length - 1) {
+    // At the end: clear input and stop navigating
+    inputValue.value = ''
+    isNavigatingHistory.value = false
+    return
+  }
+
+  const newIndex = props.historyIndex + 1
+  emit('navigateHistory', newIndex)
 }
 </script>
 

--- a/src/features/ide/components/ScreenTab.vue
+++ b/src/features/ide/components/ScreenTab.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useReplContext } from '@/features/ide/composables/useReplMode'
 import { provideScreenDebug } from '@/features/ide/composables/useScreenDebug'
 import { useScreenFilter } from '@/features/ide/composables/useScreenFilter'
 import { provideScreenZoom } from '@/features/ide/composables/useScreenZoom'
@@ -14,6 +15,7 @@ import Screen from './Screen.vue'
 /**
  * ScreenTab component - Displays the screen buffer in a tab pane format with zoom controls.
  * Screen data comes from useScreenContext (provided by IdePage); Screen component injects it.
+ * REPL state comes from useReplContext (provided by useBasicIdeEnhanced).
  */
 defineOptions({
   name: 'ScreenTab',
@@ -38,6 +40,15 @@ const { showGrid, toggleGrid } = provideScreenDebug()
 const { filterEnabled, prefersReducedMotion, toggleFilter } =
   useScreenFilter()
 
+// REPL context (provided by useBasicIdeEnhanced in IdePage)
+const {
+  replActive,
+  commandHistory,
+  historyIndex,
+  navigateHistory,
+  executeReplCommand,
+} = useReplContext()
+
 // Zoom level options
 const zoomLevels: Array<{ value: 1 | 2 | 3 | 4; label: string }> = [
   { value: 1, label: '×1' },
@@ -46,11 +57,12 @@ const zoomLevels: Array<{ value: 1 | 2 | 3 | 4; label: string }> = [
   { value: 4, label: '×4' },
 ]
 
-// Computed property for template binding (Vue templates auto-unwrap refs, but this helps TypeScript)
+// Computed properties for template binding (Vue templates auto-unwrap refs, but this helps TypeScript)
 const currentZoomLevel = computed(() => zoomLevel.value)
 const isGridShown = computed(() => showGrid.value)
 const isFilterEnabled = computed(() => filterEnabled.value)
 const isReducedMotion = computed(() => prefersReducedMotion.value)
+const isReplDisabled = computed(() => !replActive.value)
 </script>
 
 <template>
@@ -101,7 +113,14 @@ const isReducedMotion = computed(() => prefersReducedMotion.value)
       <Screen />
     </div>
     <div class="repl-input-wrapper">
-      <ReplInput :active="false" :disabled="false" @execute="() => {}" />
+      <ReplInput
+        :active="replActive"
+        :disabled="isReplDisabled"
+        :command-history="commandHistory"
+        :history-index="historyIndex"
+        @execute="executeReplCommand"
+        @navigate-history="navigateHistory"
+      />
     </div>
     <div class="tab-content-footer">
       <ErrorPanel :errors="errors" />

--- a/src/features/ide/composables/useBasicIdeEnhanced.ts
+++ b/src/features/ide/composables/useBasicIdeEnhanced.ts
@@ -29,6 +29,8 @@ import { useBasicIdeState } from './useBasicIdeState'
 import { useBasicIdeWorkerIntegration } from './useBasicIdeWorkerIntegration'
 import { useKeyboardInput } from './useKeyboardInput'
 import { useProgramStore } from './useProgramStore'
+import { provideReplContext, useReplMode } from './useReplMode'
+import { createReplWorkerAdapter } from './useReplWorkerAdapter'
 
 /**
  * Enhanced composable: reactive state and methods for IDE (AST-based parser, worker, screen).
@@ -41,6 +43,32 @@ export function useBasicIde() {
   const execution = useBasicIdeExecution(state, worker, editor.parseCode, {
     clearSharedDisplay: () => screen.clearDisplayToSharedBuffer(),
     clearWorkerDisplay: () => worker.sendClearDisplay(),
+  })
+
+  // REPL mode: create adapter from worker, track readiness via isRunning
+  const { adapter: replAdapter, markReplReady } =
+    createReplWorkerAdapter(worker.webWorkerManager)
+  const replMode = useReplMode(replAdapter)
+
+  // Mark REPL ready when program finishes running, not ready when it starts
+  watch(
+    state.isRunning,
+    (running, wasRunning) => {
+      if (wasRunning && !running) {
+        markReplReady()
+        replMode.activateRepl()
+      } else if (!wasRunning && running) {
+        replMode.deactivateRepl()
+      }
+    },
+  )
+
+  provideReplContext({
+    replActive: replMode.replActive,
+    commandHistory: replMode.commandHistory,
+    historyIndex: replMode.historyIndex,
+    navigateHistory: replMode.navigateHistory,
+    executeReplCommand: replMode.executeReplCommand,
   })
 
   // Keyboard input for INKEY$ function

--- a/src/features/ide/composables/useReplMode.ts
+++ b/src/features/ide/composables/useReplMode.ts
@@ -1,0 +1,188 @@
+/**
+ * useReplMode composable
+ *
+ * Orchestrates REPL state management: activation lifecycle, command execution,
+ * special command handling (RUN/CLS), and command history.
+ */
+
+import { computed, type ComputedRef, inject, type InjectionKey, provide, ref } from 'vue'
+
+import type { ExecutionResult } from '@/core/types/execution-types'
+
+/**
+ * Adapter interface for worker REPL operations.
+ * Abstracts the underlying WebWorkerManager so the composable is testable.
+ */
+export interface ReplWorkerAdapter {
+  replExecute(statement: string): Promise<ExecutionResult>
+  replRun(): Promise<ExecutionResult>
+  replClear(): Promise<void>
+  isReplReady(): boolean
+}
+
+export interface ReplModeState {
+  /** Whether REPL mode is currently active and accepting input. */
+  replActive: ComputedRef<boolean>
+  /** Past executed commands (deduplicated consecutive). */
+  commandHistory: ReturnType<typeof ref<string[]>>
+  /** Current navigation position in command history (-1 = no selection). */
+  historyIndex: ReturnType<typeof ref<number>>
+
+  /** Activate REPL (after program ends). Only activates if worker is ready. */
+  activateRepl: () => void
+  /** Deactivate REPL (when program starts running). */
+  deactivateRepl: () => void
+  /** Execute a REPL command. Handles RUN/CLS interception and history. */
+  executeReplCommand: (statement: string) => Promise<void>
+  /** Navigate to a specific history index. Returns the command or undefined. */
+  navigateHistory: (index: number) => string | undefined
+  /** Re-run the stored program. */
+  handleRun: () => Promise<void>
+  /** Clear the screen. */
+  handleCls: () => Promise<void>
+}
+
+/**
+ * Create REPL mode state and actions.
+ *
+ * @param adapter - Worker adapter for REPL operations
+ */
+export function useReplMode(adapter: ReplWorkerAdapter): ReplModeState {
+  const replActive = ref(false)
+  const commandHistory = ref<string[]>([])
+  const historyIndex = ref(-1)
+
+  function activateRepl(): void {
+    replActive.value = adapter.isReplReady()
+  }
+
+  function deactivateRepl(): void {
+    replActive.value = false
+  }
+
+  function addToHistory(command: string): void {
+    const trimmed = command.trim()
+    if (!trimmed) return
+
+    // Deduplicate consecutive identical commands
+    if (commandHistory.value.length > 0 && commandHistory.value[commandHistory.value.length - 1] === trimmed) {
+      return
+    }
+
+    commandHistory.value = [...commandHistory.value, trimmed]
+    // Reset navigation to end of history
+    historyIndex.value = commandHistory.value.length - 1
+  }
+
+  function navigateHistory(index: number): string | undefined {
+    if (index < 0 || index >= commandHistory.value.length) {
+      return undefined
+    }
+    historyIndex.value = index
+    return commandHistory.value[index]
+  }
+
+  async function executeReplCommand(statement: string): Promise<void> {
+    const trimmed = statement.trim()
+    if (!trimmed) return
+
+    // Must be active to execute
+    if (!replActive.value) return
+
+    const upperCommand = trimmed.toUpperCase()
+
+    if (upperCommand === 'RUN') {
+      addToHistory(trimmed)
+      deactivateRepl()
+      try {
+        await adapter.replRun()
+      } catch {
+        // Error display is handled by message handlers; REPL reactivates regardless
+      } finally {
+        activateRepl()
+      }
+      return
+    }
+
+    if (upperCommand === 'CLS') {
+      addToHistory(trimmed)
+      await adapter.replClear()
+      return
+    }
+
+    // Regular statement execution
+    addToHistory(trimmed)
+    try {
+      await adapter.replExecute(trimmed)
+    } catch {
+      // Error display is handled by message handlers; REPL reactivates regardless
+    } finally {
+      // Ensure REPL stays active even on error
+      activateRepl()
+    }
+  }
+
+  async function handleRun(): Promise<void> {
+    addToHistory('RUN')
+    deactivateRepl()
+    try {
+      await adapter.replRun()
+    } catch {
+      // Error display is handled by message handlers; REPL reactivates regardless
+    } finally {
+      activateRepl()
+    }
+  }
+
+  async function handleCls(): Promise<void> {
+    addToHistory('CLS')
+    await adapter.replClear()
+  }
+
+  return {
+    replActive: computed(() => replActive.value),
+    commandHistory,
+    historyIndex,
+    activateRepl,
+    deactivateRepl,
+    executeReplCommand,
+    navigateHistory,
+    handleRun,
+    handleCls,
+  }
+}
+
+// --- Provide / Inject ---
+
+/**
+ * REPL context provided by IdePage (via useBasicIdeEnhanced) and consumed by ScreenTab.
+ */
+export interface ReplContextValue {
+  replActive: ComputedRef<boolean>
+  commandHistory: ReturnType<typeof ref<string[]>>
+  historyIndex: ReturnType<typeof ref<number>>
+  navigateHistory: (index: number) => string | undefined
+  executeReplCommand: (statement: string) => Promise<void>
+}
+
+export const ReplContextKey: InjectionKey<ReplContextValue> = Symbol('ide-repl-context')
+
+/**
+ * Provide REPL context. Call from useBasicIdeEnhanced (which runs in IdePage setup).
+ */
+export function provideReplContext(value: ReplContextValue): void {
+  provide(ReplContextKey, value)
+}
+
+/**
+ * Inject REPL context. Use in ScreenTab and ReplInput.
+ */
+export function useReplContext(): ReplContextValue {
+  const ctx = inject(ReplContextKey)
+  if (!ctx) {
+    throw new Error(
+      'useReplContext() must be used within a component tree that calls provideReplContext (e.g. IdePage)'
+    )
+  }
+  return ctx
+}

--- a/src/features/ide/composables/useReplWorkerAdapter.ts
+++ b/src/features/ide/composables/useReplWorkerAdapter.ts
@@ -1,0 +1,81 @@
+/**
+ * Factory for creating a ReplWorkerAdapter from the existing composable-layer
+ * WebWorkerManager (plain object) and execution state.
+ */
+
+import { ref } from 'vue'
+
+import type { ExecutionResult } from '@/core/types/execution-types'
+import type { ReplExecuteMessage, ReplRunMessage } from '@/core/types/worker-messages'
+import { logComposable } from '@/shared/logger'
+
+import type { WebWorkerManager } from './useBasicIdeWebWorkerUtils'
+import { sendMessageToWorker } from './useBasicIdeWebWorkerUtils'
+import type { ReplWorkerAdapter } from './useReplMode'
+
+/**
+ * Create a ReplWorkerAdapter that uses the composable-layer WebWorkerManager
+ * and tracks REPL readiness based on execution lifecycle.
+ *
+ * @param webWorkerManager - Plain WebWorkerManager object from useBasicIdeWorkerIntegration
+ * @returns Adapter + `markReplReady()` callback to call after program execution completes
+ */
+export function createReplWorkerAdapter(webWorkerManager: WebWorkerManager): {
+  adapter: ReplWorkerAdapter
+  markReplReady: () => void
+  markReplNotReady: () => void
+} {
+  const replReady = ref(false)
+
+  const adapter: ReplWorkerAdapter = {
+    replExecute(statement: string): Promise<ExecutionResult> {
+      const message: ReplExecuteMessage = {
+        type: 'REPL_EXECUTE',
+        id: `repl-exec-${Date.now()}`,
+        timestamp: Date.now(),
+        data: { statement },
+      }
+      logComposable.debug('[ReplWorkerAdapter] Sending REPL_EXECUTE:', statement)
+      return sendMessageToWorker(message, webWorkerManager)
+    },
+
+    replRun(): Promise<ExecutionResult> {
+      const message: ReplRunMessage = {
+        type: 'REPL_RUN',
+        id: `repl-run-${Date.now()}`,
+        timestamp: Date.now(),
+        data: {},
+      }
+      logComposable.debug('[ReplWorkerAdapter] Sending REPL_RUN')
+      return sendMessageToWorker(message, webWorkerManager)
+    },
+
+    async replClear(): Promise<void> {
+      if (!webWorkerManager.worker) {
+        logComposable.warn('[ReplWorkerAdapter] Cannot CLS: worker not initialized')
+        return
+      }
+      webWorkerManager.worker.postMessage({
+        type: 'REPL_CLEAR',
+        id: `repl-clear-${Date.now()}`,
+        timestamp: Date.now(),
+        data: {},
+      })
+      logComposable.debug('[ReplWorkerAdapter] Sent REPL_CLEAR')
+    },
+
+    isReplReady(): boolean {
+      return replReady.value
+    },
+  }
+
+  function markReplReady(): void {
+    replReady.value = true
+  }
+
+  function markReplNotReady(): void {
+    replReady.value = false
+  }
+
+  return { adapter, markReplReady, markReplNotReady }
+}

--- a/test/features/ide/components/ReplInput.test.ts
+++ b/test/features/ide/components/ReplInput.test.ts
@@ -9,11 +9,15 @@ describe('ReplInput', () => {
   function mountReplInput(props: {
     active?: boolean
     disabled?: boolean
+    commandHistory?: string[]
+    historyIndex?: number
   } = {}) {
     return mount(ReplInput, {
       props: {
         active: props.active ?? false,
         disabled: props.disabled ?? false,
+        commandHistory: props.commandHistory ?? [],
+        historyIndex: props.historyIndex ?? -1,
       },
       attachTo: document.body,
     })
@@ -161,5 +165,201 @@ describe('ReplInput', () => {
 
     expect(wrapper.emitted('execute')).toBeUndefined()
     wrapper.unmount()
+  })
+
+  describe('command history navigation', () => {
+    it('emits navigateHistory with last index on first ArrowUp', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        commandHistory: ['PRINT "A"', 'PRINT "B"', 'PRINT "C"'],
+        historyIndex: -1,
+      })
+
+      const input = wrapper.find('input.repl-input-field')
+      await input.trigger('keydown', { key: 'ArrowUp' })
+
+      const emitted = wrapper.emitted('navigateHistory')
+      expect(emitted).toHaveLength(1)
+      expect(emitted![0]).toEqual([2]) // Last index
+      wrapper.unmount()
+    })
+
+    it('emits navigateHistory with previous index on subsequent ArrowUp', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        commandHistory: ['PRINT "A"', 'PRINT "B"', 'PRINT "C"'],
+        historyIndex: 1,
+      })
+
+      const input = wrapper.find('input.repl-input-field')
+      // First ArrowUp enters navigation mode, goes to last entry (index 2)
+      await input.trigger('keydown', { key: 'ArrowUp' })
+      // Simulate parent updating historyIndex to 2
+      await wrapper.setProps({ historyIndex: 2 })
+      // Second ArrowUp goes back one step to index 1
+      await input.trigger('keydown', { key: 'ArrowUp' })
+
+      const emitted = wrapper.emitted('navigateHistory')
+      expect(emitted).toHaveLength(2)
+      expect(emitted![0]).toEqual([2]) // First ArrowUp: go to last
+      expect(emitted![1]).toEqual([1]) // Second ArrowUp: go back
+      wrapper.unmount()
+    })
+
+    it('does not go below index 0 on ArrowUp', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        commandHistory: ['PRINT "A"'],
+        historyIndex: -1,
+      })
+
+      const input = wrapper.find('input.repl-input-field')
+      // First ArrowUp enters navigation, goes to index 0
+      await input.trigger('keydown', { key: 'ArrowUp' })
+      await wrapper.setProps({ historyIndex: 0 })
+
+      // Second ArrowUp should stay at 0
+      await input.trigger('keydown', { key: 'ArrowUp' })
+
+      const emitted = wrapper.emitted('navigateHistory')
+      expect(emitted).toHaveLength(2)
+      expect(emitted![0]).toEqual([0]) // First: go to last (only entry)
+      expect(emitted![1]).toEqual([0]) // Second: clamped to 0
+      wrapper.unmount()
+    })
+
+    it('does nothing on ArrowUp when history is empty', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        commandHistory: [],
+        historyIndex: -1,
+      })
+
+      const input = wrapper.find('input.repl-input-field')
+      await input.trigger('keydown', { key: 'ArrowUp' })
+
+      expect(wrapper.emitted('navigateHistory')).toBeUndefined()
+      wrapper.unmount()
+    })
+
+    it('emits navigateHistory with next index on ArrowDown when navigating', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        commandHistory: ['PRINT "A"', 'PRINT "B"', 'PRINT "C"'],
+        historyIndex: -1,
+      })
+
+      const input = wrapper.find('input.repl-input-field')
+      // First ArrowUp enters navigation mode, goes to last (index 2)
+      await input.trigger('keydown', { key: 'ArrowUp' })
+      await wrapper.setProps({ historyIndex: 2 })
+
+      // Second ArrowUp goes to index 1
+      await input.trigger('keydown', { key: 'ArrowUp' })
+      await wrapper.setProps({ historyIndex: 1 })
+
+      // ArrowDown goes back to index 2
+      await input.trigger('keydown', { key: 'ArrowDown' })
+
+      const emitted = wrapper.emitted('navigateHistory')
+      expect(emitted).toHaveLength(3)
+      expect(emitted![0]).toEqual([2]) // First ArrowUp: go to last
+      expect(emitted![1]).toEqual([1]) // Second ArrowUp: go back
+      expect(emitted![2]).toEqual([2]) // ArrowDown: go forward
+      wrapper.unmount()
+    })
+
+    it('clears input on ArrowDown when at end of history', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        commandHistory: ['PRINT "A"', 'PRINT "B"'],
+        historyIndex: -1,
+      })
+
+      const input = wrapper.find('input.repl-input-field')
+      // ArrowUp to enter navigation mode, go to last entry (index 1)
+      await input.trigger('keydown', { key: 'ArrowUp' })
+      await wrapper.setProps({ historyIndex: 1 })
+
+      // ArrowDown at end of history should clear input
+      await input.trigger('keydown', { key: 'ArrowDown' })
+
+      // At end of history, should clear input (no emit)
+      expect(wrapper.emitted('navigateHistory')).toHaveLength(1) // Only the ArrowUp
+      expect((input.element as HTMLInputElement).value).toEqual('')
+      wrapper.unmount()
+    })
+
+    it('does nothing on ArrowDown when not navigating history', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        commandHistory: ['PRINT "A"', 'PRINT "B"'],
+        historyIndex: -1,
+      })
+
+      const input = wrapper.find('input.repl-input-field')
+      await input.trigger('keydown', { key: 'ArrowDown' })
+
+      expect(wrapper.emitted('navigateHistory')).toBeUndefined()
+      wrapper.unmount()
+    })
+
+    it('does nothing on ArrowUp when disabled', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        disabled: true,
+        commandHistory: ['PRINT "A"'],
+        historyIndex: -1,
+      })
+
+      const input = wrapper.find('input.repl-input-field')
+      await input.trigger('keydown', { key: 'ArrowUp' })
+
+      expect(wrapper.emitted('navigateHistory')).toBeUndefined()
+      wrapper.unmount()
+    })
+
+    it('updates input value when historyIndex prop changes', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        commandHistory: ['PRINT "A"', 'PRINT "B"'],
+        historyIndex: -1,
+      })
+
+      // First ArrowUp to enter navigation mode and emit navigateHistory(1)
+      const input = wrapper.find('input.repl-input-field')
+      await input.trigger('keydown', { key: 'ArrowUp' })
+
+      // Simulate parent updating historyIndex prop
+      await wrapper.setProps({ historyIndex: 1 })
+      await nextTick()
+
+      expect((input.element as HTMLInputElement).value).toEqual('PRINT "B"')
+      wrapper.unmount()
+    })
+
+    it('resets history navigation when Enter is pressed', async () => {
+      const wrapper = mountReplInput({
+        active: true,
+        commandHistory: ['PRINT "A"', 'PRINT "B"'],
+        historyIndex: -1,
+      })
+
+      const input = wrapper.find('input.repl-input-field')
+      // Navigate up
+      await input.trigger('keydown', { key: 'ArrowUp' })
+      // Execute (resets navigation)
+      await input.setValue('PRINT "C"')
+      await input.trigger('keydown', { key: 'Enter' })
+
+      // Now ArrowUp should start fresh from end of history
+      wrapper.emitted('navigateHistory')!.length = 0 // Clear previous emits
+      await input.trigger('keydown', { key: 'ArrowUp' })
+
+      const emitted = wrapper.emitted('navigateHistory')
+      expect(emitted).toHaveLength(1)
+      expect(emitted![0]).toEqual([1]) // Last index
+      wrapper.unmount()
+    })
   })
 })

--- a/test/features/ide/components/ScreenTab.test.ts
+++ b/test/features/ide/components/ScreenTab.test.ts
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, ref } from 'vue'
-import { defineComponent } from 'vue'
+import { computed, defineComponent, ref } from 'vue'
 
 import ScreenTab from '@/features/ide/components/ScreenTab.vue'
 
@@ -34,6 +33,23 @@ vi.mock('@/features/ide/composables/useScreenFilter', () => ({
     ),
     toggleFilter: mockToggleFilter,
     setFilterEnabled: mockSetFilterEnabled,
+  }),
+}))
+
+// Mock REPL context
+const mockReplActive = ref(false)
+const mockCommandHistory = ref<string[]>([])
+const mockHistoryIndex = ref(-1)
+const mockNavigateHistory = vi.fn()
+const mockExecuteReplCommand = vi.fn()
+
+vi.mock('@/features/ide/composables/useReplMode', () => ({
+  useReplContext: () => ({
+    replActive: computed(() => mockReplActive.value),
+    commandHistory: mockCommandHistory,
+    historyIndex: mockHistoryIndex,
+    navigateHistory: mockNavigateHistory,
+    executeReplCommand: mockExecuteReplCommand,
   }),
 }))
 
@@ -78,6 +94,9 @@ describe('ScreenTab', () => {
     localStorage.clear()
     mockFilterEnabled.value = false
     mockPrefersReducedMotion.value = false
+    mockReplActive.value = false
+    mockCommandHistory.value = []
+    mockHistoryIndex.value = -1
     vi.clearAllMocks()
   })
 
@@ -196,11 +215,70 @@ describe('ScreenTab', () => {
     wrapper.unmount()
   })
 
-  it('passes active=false to ReplInput by default', () => {
+  it('passes active=false to ReplInput when REPL is not active', () => {
+    mockReplActive.value = false
     const wrapper = mountScreenTab()
 
     const replInput = wrapper.findComponent({ name: 'ReplInput' })
     expect(replInput.props('active')).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('passes active=true to ReplInput when REPL is active', () => {
+    mockReplActive.value = true
+    const wrapper = mountScreenTab()
+
+    const replInput = wrapper.findComponent({ name: 'ReplInput' })
+    expect(replInput.props('active')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('passes commandHistory to ReplInput', () => {
+    mockCommandHistory.value = ['PRINT "A"', 'CLS']
+    const wrapper = mountScreenTab()
+
+    const replInput = wrapper.findComponent({ name: 'ReplInput' })
+    expect(replInput.props('commandHistory')).toEqual(['PRINT "A"', 'CLS'])
+    wrapper.unmount()
+  })
+
+  it('passes historyIndex to ReplInput', () => {
+    mockHistoryIndex.value = 1
+    const wrapper = mountScreenTab()
+
+    const replInput = wrapper.findComponent({ name: 'ReplInput' })
+    expect(replInput.props('historyIndex')).toBe(1)
+    wrapper.unmount()
+  })
+
+  it('forwards execute event from ReplInput to executeReplCommand', async () => {
+    const wrapper = mountScreenTab()
+
+    const replInput = wrapper.findComponent({ name: 'ReplInput' })
+    replInput.vm.$emit('execute', 'PRINT "Hello"')
+
+    expect(mockExecuteReplCommand).toHaveBeenCalledOnce()
+    expect(mockExecuteReplCommand).toHaveBeenCalledWith('PRINT "Hello"')
+    wrapper.unmount()
+  })
+
+  it('forwards navigateHistory event from ReplInput to navigateHistory', async () => {
+    const wrapper = mountScreenTab()
+
+    const replInput = wrapper.findComponent({ name: 'ReplInput' })
+    replInput.vm.$emit('navigateHistory', 0)
+
+    expect(mockNavigateHistory).toHaveBeenCalledOnce()
+    expect(mockNavigateHistory).toHaveBeenCalledWith(0)
+    wrapper.unmount()
+  })
+
+  it('disables ReplInput when REPL is not active', () => {
+    mockReplActive.value = false
+    const wrapper = mountScreenTab()
+
+    const replInput = wrapper.findComponent({ name: 'ReplInput' })
+    expect(replInput.props('disabled')).toBe(true)
     wrapper.unmount()
   })
 })

--- a/test/ide/useReplMode.test.ts
+++ b/test/ide/useReplMode.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Unit tests for useReplMode composable.
+ */
+
+import type { Mock } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ExecutionResult } from '@/core/types/execution-types'
+import { type ReplWorkerAdapter,useReplMode } from '@/features/ide/composables/useReplMode'
+
+type MockedReplWorkerAdapter = {
+  [K in keyof ReplWorkerAdapter]: Mock<ReplWorkerAdapter[K]>
+}
+
+function createMockAdapter(): MockedReplWorkerAdapter {
+  return {
+    replExecute: vi.fn(),
+    replRun: vi.fn(),
+    replClear: vi.fn(),
+    isReplReady: vi.fn(),
+  }
+}
+
+function createSuccessfulResult(): ExecutionResult {
+  return {
+    success: true,
+    errors: [],
+    variables: new Map(),
+    executionTime: 1,
+  }
+}
+
+describe('useReplMode', () => {
+  describe('initial state', () => {
+    it('starts with replActive as false', () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(false)
+
+      const { replActive } = useReplMode(adapter)
+
+      expect(replActive.value).toBe(false)
+    })
+
+    it('starts with empty command history', () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(false)
+
+      const { commandHistory } = useReplMode(adapter)
+
+      expect(commandHistory.value).toEqual([])
+    })
+
+    it('starts with historyIndex at -1', () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(false)
+
+      const { historyIndex } = useReplMode(adapter)
+
+      expect(historyIndex.value).toBe(-1)
+    })
+  })
+
+  describe('activateRepl / deactivateRepl', () => {
+    it('activateRepl sets replActive to true when worker is ready', () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+
+      const { replActive, activateRepl } = useReplMode(adapter)
+
+      activateRepl()
+      expect(replActive.value).toBe(true)
+    })
+
+    it('activateRepl sets replActive to false when worker is not ready', () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(false)
+
+      const { replActive, activateRepl } = useReplMode(adapter)
+
+      activateRepl()
+      expect(replActive.value).toBe(false)
+    })
+
+    it('deactivateRepl sets replActive to false', () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+
+      const { replActive, activateRepl, deactivateRepl } = useReplMode(adapter)
+
+      activateRepl()
+      expect(replActive.value).toBe(true)
+
+      deactivateRepl()
+      expect(replActive.value).toBe(false)
+    })
+  })
+
+  describe('executeReplCommand', () => {
+    it('ignores empty strings', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+
+      const { activateRepl, executeReplCommand } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('')
+      await executeReplCommand('   ')
+
+      expect(adapter.replExecute).not.toHaveBeenCalled()
+      expect(adapter.replRun).not.toHaveBeenCalled()
+      expect(adapter.replClear).not.toHaveBeenCalled()
+    })
+
+    it('does not add empty/whitespace commands to history', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+
+      const { activateRepl, executeReplCommand, commandHistory } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('')
+      await executeReplCommand('   ')
+
+      expect(commandHistory.value).toEqual([])
+    })
+
+    it('intercepts RUN command and calls adapter.replRun', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replRun.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, executeReplCommand } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('RUN')
+
+      expect(adapter.replRun).toHaveBeenCalledOnce()
+      expect(adapter.replExecute).not.toHaveBeenCalled()
+    })
+
+    it('deactivates REPL during RUN and reactivates after completion', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replRun.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, executeReplCommand, replActive } = useReplMode(adapter)
+      activateRepl()
+
+      const runPromise = executeReplCommand('RUN')
+
+      // During execution, REPL should be deactivated
+      expect(replActive.value).toBe(false)
+
+      await runPromise
+
+      // After completion, REPL should be reactivated
+      expect(replActive.value).toBe(true)
+    })
+
+    it('intercepts CLS command (case-insensitive) and calls adapter.replClear', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replClear.mockResolvedValue(undefined)
+
+      const { activateRepl, executeReplCommand } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('CLS')
+
+      expect(adapter.replClear).toHaveBeenCalledOnce()
+      expect(adapter.replExecute).not.toHaveBeenCalled()
+    })
+
+    it('keeps REPL active during CLS', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replClear.mockResolvedValue(undefined)
+
+      const { activateRepl, executeReplCommand, replActive } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('CLS')
+
+      expect(replActive.value).toBe(true)
+    })
+
+    it('sends non-special commands to adapter.replExecute', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replExecute.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, executeReplCommand } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('PRINT "Hello"')
+
+      expect(adapter.replExecute).toHaveBeenCalledOnce()
+      expect(adapter.replExecute).toHaveBeenCalledWith('PRINT "Hello"')
+    })
+
+    it('adds executed commands to history', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replExecute.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, executeReplCommand, commandHistory } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('PRINT "Hello"')
+      await executeReplCommand('CLS')
+      await executeReplCommand('RUN')
+
+      expect(commandHistory.value).toEqual([
+        'PRINT "Hello"',
+        'CLS',
+        'RUN',
+      ])
+    })
+
+    it('deduplicates consecutive identical commands', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replExecute.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, executeReplCommand, commandHistory } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('PRINT "A"')
+      await executeReplCommand('PRINT "A"')
+      await executeReplCommand('PRINT "A"')
+
+      expect(commandHistory.value).toEqual(['PRINT "A"'])
+    })
+
+    it('allows non-consecutive duplicates', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replExecute.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, executeReplCommand, commandHistory } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('PRINT "A"')
+      await executeReplCommand('PRINT "B"')
+      await executeReplCommand('PRINT "A"')
+
+      expect(commandHistory.value).toEqual([
+        'PRINT "A"',
+        'PRINT "B"',
+        'PRINT "A"',
+      ])
+    })
+
+    it('adds REM comments to history silently', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replExecute.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, executeReplCommand, commandHistory } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('REM this is a comment')
+
+      expect(adapter.replExecute).toHaveBeenCalledOnce()
+      expect(commandHistory.value).toEqual(['REM this is a comment'])
+    })
+
+    it('does nothing when REPL is not active', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+
+      const { executeReplCommand } = useReplMode(adapter)
+
+      await executeReplCommand('PRINT "Hello"')
+
+      expect(adapter.replExecute).not.toHaveBeenCalled()
+    })
+
+    it('reactivates REPL after successful statement execution', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replExecute.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, executeReplCommand, replActive } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('PRINT "Hello"')
+
+      expect(replActive.value).toBe(true)
+    })
+
+    it('reactivates REPL after execution error', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replExecute.mockRejectedValue(new Error('syntax error'))
+
+      const { activateRepl, executeReplCommand, replActive } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('INVALID')
+
+      expect(replActive.value).toBe(true)
+    })
+
+    it('adds command to history even if execution fails', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replExecute.mockRejectedValue(new Error('syntax error'))
+
+      const { activateRepl, executeReplCommand, commandHistory } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('INVALID')
+
+      expect(commandHistory.value).toEqual(['INVALID'])
+    })
+
+    it('reactivates REPL after RUN error', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replRun.mockRejectedValue(new Error('division by zero'))
+
+      const { activateRepl, executeReplCommand, replActive } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('RUN')
+
+      expect(replActive.value).toBe(true)
+    })
+  })
+
+  describe('command history navigation', () => {
+    it('navigateHistory returns the correct command for index 0', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replExecute.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, executeReplCommand, navigateHistory } = useReplMode(adapter)
+      activateRepl()
+
+      await executeReplCommand('PRINT "First"')
+      await executeReplCommand('PRINT "Second"')
+
+      expect(navigateHistory(0)).toBe('PRINT "First"')
+      expect(navigateHistory(1)).toBe('PRINT "Second"')
+    })
+
+    it('navigateHistory returns undefined for out-of-range index', () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+
+      const { navigateHistory } = useReplMode(adapter)
+
+      expect(navigateHistory(-1)).toBeUndefined()
+      expect(navigateHistory(0)).toBeUndefined()
+      expect(navigateHistory(999)).toBeUndefined()
+    })
+
+    it('navigateHistory returns undefined when history is empty', () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+
+      const { navigateHistory } = useReplMode(adapter)
+
+      expect(navigateHistory(0)).toBeUndefined()
+    })
+  })
+
+  describe('handleRun', () => {
+    it('calls adapter.replRun', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replRun.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, handleRun } = useReplMode(adapter)
+      activateRepl()
+
+      await handleRun()
+
+      expect(adapter.replRun).toHaveBeenCalledOnce()
+    })
+
+    it('adds RUN to command history', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replRun.mockResolvedValue(createSuccessfulResult())
+
+      const { activateRepl, handleRun, commandHistory } = useReplMode(adapter)
+      activateRepl()
+
+      await handleRun()
+
+      expect(commandHistory.value).toEqual(['RUN'])
+    })
+  })
+
+  describe('handleCls', () => {
+    it('calls adapter.replClear', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replClear.mockResolvedValue(undefined)
+
+      const { activateRepl, handleCls } = useReplMode(adapter)
+      activateRepl()
+
+      await handleCls()
+
+      expect(adapter.replClear).toHaveBeenCalledOnce()
+    })
+
+    it('adds CLS to command history', async () => {
+      const adapter = createMockAdapter()
+      adapter.isReplReady.mockReturnValue(true)
+      adapter.replClear.mockResolvedValue(undefined)
+
+      const { activateRepl, handleCls, commandHistory } = useReplMode(adapter)
+      activateRepl()
+
+      await handleCls()
+
+      expect(commandHistory.value).toEqual(['CLS'])
+    })
+  })
+})

--- a/test/ide/useReplWorkerAdapter.test.ts
+++ b/test/ide/useReplWorkerAdapter.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for useReplWorkerAdapter composable.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ExecutionResult } from '@/core/types/execution-types'
+
+import type { MockWorkerLike } from '../helpers/mockWorker'
+import { createMockWorkerClass } from '../helpers/mockWorker'
+
+// Mock logger to suppress debug output
+vi.mock('@/shared/logger', () => ({
+  logComposable: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+import type { WebWorkerManager } from '@/features/ide/composables/useBasicIdeWebWorkerUtils'
+import { createReplWorkerAdapter } from '@/features/ide/composables/useReplWorkerAdapter'
+
+describe('createReplWorkerAdapter', () => {
+  let worker: MockWorkerLike
+  let webWorkerManager: WebWorkerManager
+  let savedWorker: typeof globalThis.Worker | undefined
+
+  function createWebWorkerManager(workerInstance: MockWorkerLike): WebWorkerManager {
+    return {
+      // eslint-disable-next-line no-restricted-syntax
+      worker: workerInstance as unknown as Worker,
+      messageId: 0,
+      pendingMessages: new Map(),
+    }
+  }
+
+  function installMockWorker(): MockWorkerLike {
+    const mockClass = createMockWorkerClass()
+     
+    const instance = new mockClass()
+    worker = instance
+    webWorkerManager = createWebWorkerManager(instance)
+    return instance
+  }
+
+  beforeEach(() => {
+    savedWorker = globalThis.Worker
+    installMockWorker()
+  })
+
+  afterEach(() => {
+    if (savedWorker !== undefined) {
+      globalThis.Worker = savedWorker
+    }
+  })
+
+  it('isReplReady returns false initially', () => {
+    const { adapter } = createReplWorkerAdapter(webWorkerManager)
+
+    expect(adapter.isReplReady()).toBe(false)
+  })
+
+  it('isReplReady returns true after markReplReady', () => {
+    const { adapter, markReplReady } = createReplWorkerAdapter(webWorkerManager)
+
+    markReplReady()
+
+    expect(adapter.isReplReady()).toBe(true)
+  })
+
+  it('isReplReady returns false after markReplNotReady', () => {
+    const { adapter, markReplReady, markReplNotReady } = createReplWorkerAdapter(webWorkerManager)
+
+    markReplReady()
+    markReplNotReady()
+
+    expect(adapter.isReplReady()).toBe(false)
+  })
+
+  it('replExecute posts REPL_EXECUTE message', () => {
+    const { adapter } = createReplWorkerAdapter(webWorkerManager)
+
+    void adapter.replExecute('PRINT "Hello"')
+
+    expect(worker.postedMessages.length).toBe(1)
+    const msg = worker.postedMessages[0] as { type: string; data: { statement: string } }
+    expect(msg.type).toBe('REPL_EXECUTE')
+    expect(msg.data.statement).toBe('PRINT "Hello"')
+  })
+
+  it('replExecute uses sendMessageToWorker which tracks pending messages', () => {
+    const { adapter } = createReplWorkerAdapter(webWorkerManager)
+
+    const promise = adapter.replExecute('PRINT "Hello"')
+
+    // The promise is tracked in pendingMessages
+    expect(webWorkerManager.pendingMessages.size).toBe(1)
+    // Don't wait for it - it will timeout eventually, but we just want to verify the message was sent
+    void promise
+  })
+
+  it('replRun posts REPL_RUN message', () => {
+    const { adapter } = createReplWorkerAdapter(webWorkerManager)
+
+    void adapter.replRun()
+
+    expect(worker.postedMessages.length).toBe(1)
+    const msg = worker.postedMessages[0] as { type: string }
+    expect(msg.type).toBe('REPL_RUN')
+  })
+
+  it('replClear posts REPL_CLEAR message', async () => {
+    const { adapter } = createReplWorkerAdapter(webWorkerManager)
+
+    await adapter.replClear()
+
+    expect(worker.postedMessages.length).toBe(1)
+    const msg = worker.postedMessages[0] as { type: string }
+    expect(msg.type).toBe('REPL_CLEAR')
+  })
+
+  it('replClear does nothing when worker is null', async () => {
+    webWorkerManager.worker = null
+    const { adapter } = createReplWorkerAdapter(webWorkerManager)
+
+    await adapter.replClear()
+
+    expect(worker.postedMessages.length).toBe(0)
+  })
+
+  it('replExecute resolves when RESULT message is received', async () => {
+    const { adapter } = createReplWorkerAdapter(webWorkerManager)
+
+    const promise = adapter.replExecute('PRINT "Hello"')
+
+    // Simulate RESULT response from worker
+    const msg = worker.postedMessages[0] as { id: string }
+    const resultData: ExecutionResult = {
+      success: true,
+      errors: [],
+      variables: new Map(),
+      executionTime: 5,
+    }
+    // Manually resolve the pending message (simulating what handleWorkerMessage does)
+    const pending = webWorkerManager.pendingMessages.get(msg.id)
+    expect(pending).toBeDefined()
+    pending!.resolve(resultData)
+
+    const result = await promise
+    expect(result.success).toBe(true)
+  })
+
+  it('replExecute rejects when ERROR message is received', async () => {
+    const { adapter } = createReplWorkerAdapter(webWorkerManager)
+
+    const promise = adapter.replExecute('INVALID')
+
+    // Simulate ERROR response
+    const msg = worker.postedMessages[0] as { id: string }
+    const pending = webWorkerManager.pendingMessages.get(msg.id)
+    expect(pending).toBeDefined()
+    pending!.reject(new Error('syntax error'))
+
+    await expect(promise).rejects.toThrow('syntax error')
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #893 — Part of REPL mode (#889)
- Completes the REPL feature by wiring all building blocks together

## Changes
- **useReplMode.ts** (NEW): Composable for REPL state management — `replActive`, `executeReplCommand()`, `activateRepl()`/`deactivateRepl()`, command history with Up/Down navigation
- **useReplWorkerAdapter.ts** (NEW): Adapter factory bridging composable to `WebWorkerManager` REPL API
- **ReplInput.vue**: Added command history navigation (Up/Down arrows), `navigateHistory` emit
- **ScreenTab.vue**: Inject REPL context via provide/inject, pass to ReplInput
- **useBasicIdeEnhanced.ts**: Create adapter, provide REPL context, watch `isRunning` lifecycle

## Key Features
- **RUN command**: Re-executes stored program via `replRun()`, deactivates REPL during execution
- **CLS command**: Clears screen via `replClear()`, REPL stays active
- **Command history**: Up/Down arrow navigation, deduplication of consecutive commands
- **Error handling**: Parse/runtime errors displayed, REPL stays active on error
- **Lifecycle**: REPL activates after program ends, deactivates when program starts

## Dependencies
- Builds on #890 (PR #894), #891 (PR #895), #892 (PR #896)

## Test plan
- [x] 29 useReplMode tests (state, execute, activate/deactivate, RUN/CLS, history)
- [x] 10 useReplWorkerAdapter tests
- [x] 24 ReplInput tests (including history navigation)
- [x] 14 ScreenTab tests (including REPL context injection)
- [x] 910 IDE tests pass (0 regressions)
- [x] Type-check clean, ESLint clean

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)