### PR TITLE
feat: resolve #899 - add i18n to ReplInput.vue placeholder string

### DIFF
--- a/src/features/ide/components/ReplInput.vue
+++ b/src/features/ide/components/ReplInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { nextTick, ref, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 /**
  * ReplInput component - Single-line text input for REPL mode.
@@ -24,6 +25,8 @@ const props = withDefaults(
 const emit = defineEmits<{
   execute: [statement: string]
 }>()
+
+const { t } = useI18n()
 
 const inputValue = ref('')
 const inputRef = useTemplateRef<HTMLInputElement>('inputRef')
@@ -58,7 +61,7 @@ function onKeyDown(event: KeyboardEvent) {
       v-model="inputValue"
       type="text"
       class="repl-input-field"
-      :placeholder="'Enter command...'"
+      :placeholder="t('ide.repl.placeholder')"
       :disabled="disabled"
       @keydown="onKeyDown"
     />

--- a/src/shared/i18n/locales/en/ide.json
+++ b/src/shared/i18n/locales/en/ide.json
@@ -564,6 +564,9 @@
   "musicComposer": {
     "title": "Music Composer"
   },
+  "repl": {
+    "placeholder": "Enter command..."
+  },
   "tutorial": {
     "title": "Tutorial",
     "defaultTitle": "F-BASIC Tutorial",

--- a/src/shared/i18n/locales/ja/ide.json
+++ b/src/shared/i18n/locales/ja/ide.json
@@ -564,6 +564,9 @@
   "musicComposer": {
     "title": "ミュージックコンポーザー"
   },
+  "repl": {
+    "placeholder": "コマンドを入力..."
+  },
   "tutorial": {
     "title": "チュートリアル",
     "defaultTitle": "F-BASICチュートリアル",

--- a/src/shared/i18n/locales/zh-CN/ide.json
+++ b/src/shared/i18n/locales/zh-CN/ide.json
@@ -564,6 +564,9 @@
   "musicComposer": {
     "title": "音乐作曲器"
   },
+  "repl": {
+    "placeholder": "输入命令..."
+  },
   "tutorial": {
     "title": "教程",
     "defaultTitle": "F-BASIC 教程",

--- a/src/shared/i18n/locales/zh-TW/ide.json
+++ b/src/shared/i18n/locales/zh-TW/ide.json
@@ -564,6 +564,9 @@
   "musicComposer": {
     "title": "音樂作曲器"
   },
+  "repl": {
+    "placeholder": "輸入命令..."
+  },
   "tutorial": {
     "title": "教學",
     "defaultTitle": "F-BASIC 教學",

--- a/test/features/ide/components/ReplInput.test.ts
+++ b/test/features/ide/components/ReplInput.test.ts
@@ -5,6 +5,16 @@ import { nextTick } from 'vue'
 
 import ReplInput from '@/features/ide/components/ReplInput.vue'
 
+import { createI18nMock } from '../../../helpers/createI18nMock'
+
+const mockT = createI18nMock({
+  'ide.repl.placeholder': 'Enter command...',
+})
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: mockT }),
+}))
+
 describe('ReplInput', () => {
   function mountReplInput(props: {
     active?: boolean
@@ -52,7 +62,7 @@ describe('ReplInput', () => {
     wrapper.unmount()
   })
 
-  it('renders a text input with placeholder', () => {
+  it('renders a text input with i18n placeholder', () => {
     const wrapper = mountReplInput({ active: true })
 
     const input = wrapper.find('input.repl-input-field')


### PR DESCRIPTION
## Summary
- Fixes #899

## Changes
- Wrapped hardcoded `'Enter command...'` placeholder with `t('ide.repl.placeholder')` in ReplInput.vue
- Added `ide.repl.placeholder` locale key to all 4 locale files (en, ja, zh-CN, zh-TW)
- Updated ReplInput.test.ts to mock vue-i18n

## Test plan
- [ ] 14/14 ReplInput tests pass
- [ ] Type-check clean
- [ ] ESLint clean
- [ ] CI passes